### PR TITLE
feat: use hydra graphql API for vault registration counts in dashboard

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -47,6 +47,19 @@ function formatDateTimePrecise(date: Date): string {
   return date.toDateString().substring(4) + ' ' + date.toTimeString().substring(0, 8);
 }
 
+function getLastMidnightTimestamps(daysBack: number, startFromTonight = false): Array<number> {
+  const midnights: number[] = [];
+  for (let i = 0; i < daysBack; i++) {
+    const dayBoundary = new Date(Date.now() - (startFromTonight ? i - 1 : i) * 3600 * 24 * 1000);
+    dayBoundary.setMilliseconds(0);
+    dayBoundary.setSeconds(0);
+    dayBoundary.setMinutes(0);
+    dayBoundary.setHours(0);
+    midnights.push(dayBoundary.getTime());
+  }
+  return midnights.reverse();
+}
+
 // TODO: replace these functions with internationalization functions
 // always round USD amounts to two decimals
 function getUsdAmount<C extends CurrencyUnit>(
@@ -142,6 +155,7 @@ export {
   shortTxId,
   formatDateTime,
   formatDateTimePrecise,
+  getLastMidnightTimestamps,
   getUsdAmount,
   displayMonetaryAmount,
   isPositiveNumeric,

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -49,8 +49,8 @@ function formatDateTimePrecise(date: Date): string {
 
 function getLastMidnightTimestamps(daysBack: number, startFromTonight = false): Array<number> {
   const midnights: number[] = [];
-  for (let i = 0; i < daysBack; i++) {
-    const dayBoundary = new Date(Date.now() - (startFromTonight ? i - 1 : i) * 3600 * 24 * 1000);
+  for (let index = 0; index < daysBack; index++) {
+    const dayBoundary = new Date(Date.now() - (startFromTonight ? index - 1 : index) * 3600 * 24 * 1000);
     dayBoundary.setMilliseconds(0);
     dayBoundary.setSeconds(0);
     dayBoundary.setMinutes(0);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const DEFAULT_ACCOUNT_SEED = process.env.REACT_APP_DEFAULT_ACCOUNT_SEED;
 export const FAUCET_URL = process.env.REACT_APP_FAUCET_URL || 'http://localhost:3035';
 
 export const STATS_URL = process.env.REACT_APP_STATS_SERVER_URL || 'http://localhost:3007';
+export const HYDRA_URL = process.env.REACT_APP_HYDRA_URL || 'http://localhost:4000/graphql';
 
 export const FEEDBACK_URL = 'https://forms.gle/2eKFnq4j1fkBgejW7';
 

--- a/src/pages/Dashboard/components/active-vaults.tsx
+++ b/src/pages/Dashboard/components/active-vaults.tsx
@@ -1,17 +1,20 @@
 import { useTranslation } from 'react-i18next';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 import clsx from 'clsx';
+import { useQuery } from 'react-query';
+import { useErrorHandler } from 'react-error-boundary';
 
 import LineChartComponent from './line-chart-component';
 import DashboardCard from 'pages/Dashboard/DashboardCard';
+import EllipsisLoader from 'components/EllipsisLoader';
 import InterlayDenimOutlinedButton from 'components/buttons/InterlayDenimOutlinedButton';
 import InterlayRouterLink from 'components/UI/InterlayRouterLink';
 import { PAGES } from 'utils/constants/links';
-import graphqlFetcher, { GraphqlReturn, GRAPHQL_FETCHER } from 'services/fetchers/graphql-fetcher';
-import { useQuery } from 'react-query';
-import { useErrorHandler } from 'react-error-boundary';
-import EllipsisLoader from 'components/EllipsisLoader';
 import { getLastMidnightTimestamps } from 'common/utils/utils';
+import graphqlFetcher, {
+  GraphqlReturn,
+  GRAPHQL_FETCHER
+} from 'services/fetchers/graphql-fetcher';
 
 interface Props {
   linkButton?: boolean;
@@ -28,7 +31,7 @@ const ActiveVaults = ({ linkButton }: Props): JSX.Element => {
   const {
     isIdle: vaultsIdle,
     isLoading: vaultsLoading,
-    data: vaultsData,
+    data: vaults,
     error: vaultsError
   } = useQuery<GraphqlReturn<Array<VaultRegistration>>, Error>(
     [
@@ -38,8 +41,7 @@ const ActiveVaults = ({ linkButton }: Props): JSX.Element => {
           id
           timestamp
         }
-      }
-      `
+      }`
     ],
     graphqlFetcher<Array<VaultRegistration>>()
   );
@@ -59,11 +61,11 @@ const ActiveVaults = ({ linkButton }: Props): JSX.Element => {
       </div>
     );
   }
-  if (!vaultsData) {
+  if (!vaults) {
     throw new Error('Something went wrong!');
   }
 
-  const vaultRegistrations = vaultsData.data.vaultRegistrations;
+  const vaultRegistrations = vaults.data.vaultRegistrations;
   const graphTimestamps = getLastMidnightTimestamps(5, true);
   const graphData = graphTimestamps.map(
     timestamp => vaultRegistrations.filter(

--- a/src/services/fetchers/graphql-fetcher.ts
+++ b/src/services/fetchers/graphql-fetcher.ts
@@ -1,0 +1,49 @@
+import { HYDRA_URL } from '../../constants';
+
+const GRAPHQL_FETCHER = 'graphql-fetcher';
+
+// interface GraphqlArguments {
+//   queryKey: [
+//     typeof GRAPHQL_FETCHER,
+//     string,
+//     any
+//   ]
+// }
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const graphqlFetcher = <T>() => async ({ queryKey }: any): Promise<GraphqlReturn<T>> => {
+  const [
+    key,
+    query,
+    variables
+  ] = queryKey;
+
+  if (key !== GRAPHQL_FETCHER) {
+    throw new Error('Invalid key!');
+  }
+
+  const response = await fetch(HYDRA_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      query,
+      variables: variables || null
+    })
+  });
+
+  return await response.json();
+};
+
+export {
+  GRAPHQL_FETCHER
+};
+
+export type GraphqlReturn<T> = {
+  data: {
+    [key: string]: T
+  }
+}
+
+export default graphqlFetcher;


### PR DESCRIPTION
This is using an initial query so far, but my next step will be to switch over the entire vault dashboard, and when that is ready I believe all these components will be able to share data from a single query rather than each fetching individually. So some parts of this may end up being temporary, but it still fixes the current bug with the count chart so worth doing first

Devops node: need to point HYDRA_URL variable to the Hydra query node set up by @ns212 .