### PR TITLE
chore: bump interbtc-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@craco/craco": "^6.1.1",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^1.0.3",
-    "@interlay/interbtc": "1.1.0",
+    "@interlay/interbtc": "1.1.1",
     "@interlay/monetary-js": "0.4.0",
     "@polkadot/api": "5.3.2",
     "@polkadot/extension-dapp": "0.38.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,10 +1609,10 @@
   resolved "https://registry.yarnpkg.com/@interlay/interbtc-types/-/interbtc-types-0.12.5.tgz#d78f62700aa6330454b8ee80bfe0b2fb76fc29a2"
   integrity sha512-6SfMnYHzp9ROFBGVKoNwSPZDjJ6hBZqiz2mfxjNRBQQfx2SUq9xbFg8gS0yudACYXWmF4zs3ceH5v/13e9tmtw==
 
-"@interlay/interbtc@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc/-/interbtc-1.1.0.tgz#3b33c16750b8ee8a354f2f84335ef4c48c95853f"
-  integrity sha512-m7nU4kaIbP29H/uCgWHpBoPtJQt1MKnIWpOZ9am8JMX+H9XY+0z6jViyZ07C7zh8nnAwsyWTcG1lizA1ym4mvQ==
+"@interlay/interbtc@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc/-/interbtc-1.1.1.tgz#0cf2b809f1c2100fbad659ec96aa85d048528069"
+  integrity sha512-gfzrZSq+n3l4Ccc13MVQdrHxu5ZiiMbgTFKN0i7OcezkbMv3kRDVVQfrvAnclREdJ3aGcAWjvKOurWRgAQQemQ==
   dependencies:
     "@interlay/interbtc-api" "1.0.0"
     "@interlay/interbtc-index-client" "1.0.0"


### PR DESCRIPTION
fixes an interbtc-index bug with oracles with KSM