### PR TITLE
Bugfix/persist account selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-use": "^17.2.3",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "typescript": "4.2.2",
     "use-dark-mode": "^2.3.1",
     "web-vitals": "^1.0.1"

--- a/src/common/reducers/index.ts
+++ b/src/common/reducers/index.ts
@@ -1,12 +1,26 @@
+
 import { combineReducers } from 'redux';
-import { generalReducer as general } from './general.reducer';
+import { persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+
+import { generalReducer } from './general.reducer';
 import { redeemReducer as redeem } from './redeem.reducer';
 import { issueReducer as issue } from './issue.reducer';
 import { vaultReducer as vault } from './vault.reducer';
 
-export const rootReducer = combineReducers({
-  general,
+const generalPersistConfig = {
+  key: 'general',
+  storage: storage,
+  whitelist: ['address']
+};
+
+const rootReducer = combineReducers({
+  general: persistReducer(generalPersistConfig, generalReducer),
   redeem,
   issue,
   vault
 });
+
+export {
+  rootReducer
+};

--- a/src/common/reducers/issue.reducer.ts
+++ b/src/common/reducers/issue.reducer.ts
@@ -5,7 +5,6 @@ import {
 import { IssueState } from '../types/issue.types';
 
 const initialState = {
-  address: '',
   issuePeriod: 86400
 };
 

--- a/src/common/reducers/redeem.reducer.ts
+++ b/src/common/reducers/redeem.reducer.ts
@@ -1,13 +1,11 @@
 
 import {
-  CHANGE_ADDRESS,
   RedeemActions,
   TOGGLE_PREMIUM_REDEEM
 } from '../types/actions.types';
 import { RedeemState } from '../types/redeem.types';
 
 const initialState = {
-  address: '',
   premiumRedeem: false
 };
 
@@ -15,8 +13,6 @@ export const redeemReducer = (state: RedeemState = initialState, action: RedeemA
   switch (action.type) {
   case TOGGLE_PREMIUM_REDEEM:
     return { ...state, premiumRedeem: action.premiumRedeem };
-  case CHANGE_ADDRESS:
-    return { ...state, address: action.address };
   default:
     return state;
   }

--- a/src/common/types/issue.types.ts
+++ b/src/common/types/issue.types.ts
@@ -1,8 +1,4 @@
 
 export interface IssueState {
-  // ray test touch <
-  // TODO: use current account from general state
-  address: string;
-  // ray test touch >
   issuePeriod: number;
 }

--- a/src/common/types/redeem.types.ts
+++ b/src/common/types/redeem.types.ts
@@ -1,7 +1,5 @@
 
 export interface RedeemState {
-  // TODO: use current account from general state
-  address: string;
-  // true if premium redeem is selected
+  // True if premium redeem is selected
   premiumRedeem: boolean;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import {
   QueryClientProvider,
@@ -11,27 +12,33 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { HelmetProvider } from 'react-helmet-async';
 
 import App from './App';
-import { configureStore } from './store';
+import {
+  store,
+  persistor
+} from './store';
 import reportWebVitals from './reportWebVitals';
 import './index.css';
 
-const store = configureStore();
 window.isFetchingActive = false;
 
 const queryClient = new QueryClient();
 
 ReactDOM.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <Router>
-        <QueryClientProvider client={queryClient}>
-          <HelmetProvider>
-            <App />
-          </HelmetProvider>
-          <ReactQueryDevtools initialIsOpen={false} />
-        </QueryClientProvider>
-      </Router>
-    </Provider>
+    <Router>
+      <QueryClientProvider client={queryClient}>
+        <HelmetProvider>
+          <Provider store={store}>
+            <PersistGate
+              loading={null}
+              persistor={persistor}>
+              <App />
+            </PersistGate>
+          </Provider>
+        </HelmetProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </Router>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,10 +1,13 @@
 import { createLogger } from 'redux-logger';
-import { applyMiddleware, createStore } from 'redux';
+import {
+  applyMiddleware,
+  createStore
+} from 'redux';
+import { persistStore } from 'redux-persist';
 import { InterBtc } from '@interlay/interbtc';
 import { FaucetClient } from '@interlay/interbtc-api';
 
 import { rootReducer } from './common/reducers/index';
-import { StoreState } from './common/types/util.types';
 
 declare global {
   interface Window {
@@ -14,9 +17,11 @@ declare global {
   }
 }
 
-export const configureStore = (): StoreState => {
-  const storeLogger = createLogger();
-  const store = createStore(rootReducer, undefined, applyMiddleware(storeLogger));
+const storeLogger = createLogger();
+const store = createStore(rootReducer, undefined, applyMiddleware(storeLogger));
+const persistor = persistStore(store);
 
-  return store;
+export {
+  store,
+  persistor
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14472,18 +14472,7 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet-async@^1.0.7:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.2.2.tgz#38d58d32ebffbc01ba42b5ad9142f85722492389"
-  integrity sha512-XgSQezeCbLfCxdZhDA3T/g27XZKnOYyOkruopTLSJj8RvFZwdXnM4djnfYaiBSDzOidDgTo1jcEozoRu/+P9UQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    invariant "^2.2.4"
-    prop-types "^15.7.2"
-    react-fast-compare "^3.2.0"
-    shallowequal "^1.1.0"
-
-react-helmet-async@^1.2.2:
+react-helmet-async@^1.0.7, react-helmet-async@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.2.2.tgz#38d58d32ebffbc01ba42b5ad9142f85722492389"
   integrity sha512-XgSQezeCbLfCxdZhDA3T/g27XZKnOYyOkruopTLSJj8RvFZwdXnM4djnfYaiBSDzOidDgTo1jcEozoRu/+P9UQ==
@@ -14871,6 +14860,11 @@ redux-logger@^3.0.6:
   integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
   dependencies:
     deep-diff "^0.3.5"
+
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
 redux@^4.0.0, redux@^4.0.5:
   version "4.1.2"


### PR DESCRIPTION
You can try refreshing after selecting different accounts and ensure that the selected account is persisted between times of refreshing.
Here I used `redux-persist` package because:
- This approach should be replaced with substrate-context based mechanism so we need to drop the current approach at all later. So the changes should be modular enough so that we can get rid of it easily.
- Making it persisted manually could be error prone rather than using a proven package.