### PR TITLE
fix: correct underline effect of InterlayRouterLink

### DIFF
--- a/src/components/UI/InterlayRouterLink/index.tsx
+++ b/src/components/UI/InterlayRouterLink/index.tsx
@@ -27,7 +27,6 @@ const InterlayRouterLink = ({
         process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
       { 'dark:text-kintsugiSupernova':
         process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-      'hover:underline',
       'space-x-1.5',
       'inline-flex',
       'items-center',

--- a/src/pages/Dashboard/Stats/index.tsx
+++ b/src/pages/Dashboard/Stats/index.tsx
@@ -46,6 +46,7 @@ const StatsRouterLink = ({
     className={clsx(
       'text-sm',
       'font-medium',
+      'hover:underline',
       className
     )}
     to={to}


### PR DESCRIPTION
In the process of transaction non-blocking feature, I found this bug and quickly fixed it.
![Capture-5](https://user-images.githubusercontent.com/84005068/149608831-5ca378c5-32fb-4944-be5b-50b7d37f846e.png)
 