### PR TITLE
fix: resolve bigint dependency error in production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
   "browserslist": {
     "production": [
       ">0.2%",
+      "not ie <= 99",
+      "not android <= 4.4.4",
       "not dead",
       "not op_mini all"
     ],


### PR DESCRIPTION
The production build for the application was failing due to a BigInt to number conversion issue. This issue is listed here: https://polkadot.js.org/docs/usage/FAQ/#under-my-babel-build-i-have-a-bigint-to-number-conversion-error and was fixed with the approach here: https://github.com/hirosystems/stacks.js/issues/1096#issuecomment-946350299