### PR TITLE
feature: add governance token to relay chain and general state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,8 @@ const App = (): JSX.Element => {
       );
       dispatch(isPolkaBtcLoaded(true));
       setIsLoading(false);
+      // NOTE: Catch clause variable type annotation must be 'any' or 'unknown'. Use of any here
+      // and throughout is to resolve type errors.
     } catch (error: any) {
       toast.warn('Unable to connect to the BTC-Parachain.');
       console.log('[loadPolkaBTC] error.message => ', error.message);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,6 @@ const App = (): JSX.Element => {
         constants.PARACHAIN_URL,
         COLLATERAL_TOKEN as CollateralCurrency,
         WRAPPED_TOKEN,
-        GOVERNANCE_TOKEN as any,
         constants.BITCOIN_NETWORK,
         constants.STATS_URL
       );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -347,7 +347,7 @@ const App = (): JSX.Element => {
 
     (async () => {
       try {
-        unsubscribeFromCollateral =
+        unsubscribeFromGovernance =
           await window.bridge.interBtcApi.tokens.subscribeToBalance(
             GOVERNANCE_TOKEN,
             address,

--- a/src/common/actions/general.actions.ts
+++ b/src/common/actions/general.actions.ts
@@ -85,6 +85,7 @@ export const updateOfPricesAction = (prices: Prices): UpdateOfPrices => ({
 export const initGeneralDataAction = (
   totalWrappedTokenAmount: BitcoinAmount,
   totalLockedCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>,
+  totalGovernanceTokenAmount: MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>,
   btcRelayHeight: number,
   bitcoinHeight: number,
   parachainStatus: ParachainStatus
@@ -94,6 +95,7 @@ export const initGeneralDataAction = (
   bitcoinHeight,
   totalWrappedTokenAmount,
   totalLockedCollateralTokenAmount,
+  totalGovernanceTokenAmount,
   parachainStatus
 });
 

--- a/src/common/actions/general.actions.ts
+++ b/src/common/actions/general.actions.ts
@@ -3,7 +3,10 @@ import {
   MonetaryAmount,
   Currency
 } from '@interlay/monetary-js';
-import { CollateralUnit } from '@interlay/interbtc-api';
+import {
+  CollateralUnit,
+  CurrencyUnit
+} from '@interlay/interbtc-api';
 
 import {
   IS_POLKA_BTC_LOADED,
@@ -12,6 +15,7 @@ import {
   IS_VAULT_CLIENT_LOADED,
   UPDATE_BALANCE_POLKA_BTC,
   UPDATE_COLLATERAL_TOKEN_BALANCE,
+  UPDATE_GOVERNANCE_TOKEN_BALANCE,
   SET_INSTALLED_EXTENSION,
   SHOW_ACCOUNT_MODAL,
   UPDATE_OF_PRICES,
@@ -24,6 +28,7 @@ import {
   IsVaultClientLoaded,
   UpdateBalancePolkaBTC,
   UpdateCollateralTokenBalance,
+  UpdateGovernanceTokenBalance,
   SetInstalledExtension,
   ShowAccountModal,
   IsFaucetLoaded,
@@ -63,6 +68,13 @@ export const updateCollateralTokenBalanceAction = (
 ): UpdateCollateralTokenBalance => ({
   type: UPDATE_COLLATERAL_TOKEN_BALANCE,
   collateralTokenBalance
+});
+
+export const updateGovernanceTokenBalanceAction = (
+  governanceTokenBalance: MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>
+): UpdateGovernanceTokenBalance => ({
+  type: UPDATE_GOVERNANCE_TOKEN_BALANCE,
+  governanceTokenBalance
 });
 
 export const updateOfPricesAction = (prices: Prices): UpdateOfPrices => ({

--- a/src/common/reducers/general.reducer.ts
+++ b/src/common/reducers/general.reducer.ts
@@ -1,13 +1,17 @@
 import { BitcoinAmount } from '@interlay/monetary-js';
 import { newMonetaryAmount } from '@interlay/interbtc-api';
 
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import {
+  COLLATERAL_TOKEN,
+  GOVERNANCE_TOKEN
+} from 'config/relay-chains';
 import {
   IS_POLKA_BTC_LOADED,
   IS_VAULT_CLIENT_LOADED,
   INIT_GENERAL_DATA_ACTION,
   CHANGE_ADDRESS,
   UPDATE_COLLATERAL_TOKEN_BALANCE,
+  UPDATE_GOVERNANCE_TOKEN_BALANCE,
   UPDATE_BALANCE_POLKA_BTC,
   GeneralActions,
   SET_INSTALLED_EXTENSION,
@@ -28,6 +32,7 @@ const initialState = {
   totalLockedCollateralTokenAmount: newMonetaryAmount(0, COLLATERAL_TOKEN),
   wrappedTokenBalance: BitcoinAmount.zero,
   collateralTokenBalance: newMonetaryAmount(0, COLLATERAL_TOKEN),
+  governanceTokenBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
   extensions: [],
   btcRelayHeight: 0,
   bitcoinHeight: 0,
@@ -67,6 +72,8 @@ export const generalReducer = (state: GeneralState = initialState, action: Gener
     return { ...state, vaultClientLoaded: action.isLoaded };
   case UPDATE_COLLATERAL_TOKEN_BALANCE:
     return { ...state, collateralTokenBalance: action.collateralTokenBalance };
+  case UPDATE_GOVERNANCE_TOKEN_BALANCE:
+    return { ...state, governanceTokenBalance: action.governanceTokenBalance };
   case UPDATE_BALANCE_POLKA_BTC:
     return { ...state, wrappedTokenBalance: action.wrappedTokenBalance };
   case SHOW_ACCOUNT_MODAL:

--- a/src/common/types/actions.types.ts
+++ b/src/common/types/actions.types.ts
@@ -72,6 +72,7 @@ export interface InitGeneralDataAction {
   type: typeof INIT_GENERAL_DATA_ACTION;
   totalWrappedTokenAmount: BitcoinAmount;
   totalLockedCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
+  totalGovernanceTokenAmount: MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>;
   btcRelayHeight: number;
   bitcoinHeight: number;
   parachainStatus: ParachainStatus;

--- a/src/common/types/actions.types.ts
+++ b/src/common/types/actions.types.ts
@@ -1,7 +1,8 @@
 import { StoreType, ParachainStatus, Prices } from './util.types';
 import {
   Issue,
-  CollateralUnit
+  CollateralUnit,
+  CurrencyUnit
 } from '@interlay/interbtc-api';
 import {
   BitcoinAmount,
@@ -19,6 +20,7 @@ export const CHANGE_ADDRESS = 'CHANGE_ADDRESS';
 export const INIT_GENERAL_DATA_ACTION = 'INIT_GENERAL_DATA_ACTION';
 export const UPDATE_BALANCE_POLKA_BTC = 'UPDATE_BALANCE_POLKA_BTC';
 export const UPDATE_COLLATERAL_TOKEN_BALANCE = 'UPDATE_COLLATERAL_TOKEN_BALANCE';
+export const UPDATE_GOVERNANCE_TOKEN_BALANCE = 'UPDATE_GOVERNANCE_TOKEN_BALANCE';
 export const SET_INSTALLED_EXTENSION = 'SET_INSTALLED_EXTENSION';
 export const SHOW_ACCOUNT_MODAL = 'SHOW_ACCOUNT_MODAL';
 export const UPDATE_OF_PRICES = 'UPDATE_OF_PRICES';
@@ -85,6 +87,11 @@ export interface UpdateCollateralTokenBalance {
   collateralTokenBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
 }
 
+export interface UpdateGovernanceTokenBalance {
+  type: typeof UPDATE_GOVERNANCE_TOKEN_BALANCE;
+  governanceTokenBalance: MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>;
+}
+
 export interface SetInstalledExtension {
   type: typeof SET_INSTALLED_EXTENSION;
   extensions: string[];
@@ -102,6 +109,7 @@ export type GeneralActions =
   | IsVaultClientLoaded
   | UpdateBalancePolkaBTC
   | UpdateCollateralTokenBalance
+  | UpdateGovernanceTokenBalance
   | SetInstalledExtension
   | ShowAccountModal
   | UpdateOfPrices

--- a/src/common/types/util.types.ts
+++ b/src/common/types/util.types.ts
@@ -10,7 +10,10 @@ import {
   MonetaryAmount,
   Currency
 } from '@interlay/monetary-js';
-import { CollateralUnit } from '@interlay/interbtc-api';
+import {
+  CollateralUnit,
+  CurrencyUnit
+} from '@interlay/interbtc-api';
 
 export interface StatusUpdate {
   id: u256;
@@ -68,6 +71,7 @@ export type GeneralState = {
   totalLockedCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
   wrappedTokenBalance: BitcoinAmount;
   collateralTokenBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
+  governanceTokenBalance: MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>;
   extensions: string[];
   btcRelayHeight: number;
   bitcoinHeight: number;

--- a/src/parts/Topbar/index.tsx
+++ b/src/parts/Topbar/index.tsx
@@ -45,6 +45,7 @@ const Topbar = (): JSX.Element => {
     bridgeLoaded,
     collateralTokenBalance,
     wrappedTokenBalance,
+    governanceTokenBalance,
     showAccountModal
   } = useSelector((state: StoreType) => state.general);
   const dispatch = useDispatch();
@@ -158,7 +159,8 @@ const Topbar = (): JSX.Element => {
                 </InterlayDenimOrKintsugiMidnightOutlinedButton>
                 <Balances
                   collateralTokenBalance={collateralTokenBalance}
-                  wrappedTokenBalance={wrappedTokenBalance} />
+                  wrappedTokenBalance={wrappedTokenBalance}
+                  governanceTokenBalance={governanceTokenBalance} />
                 <InterlayDefaultContainedButton
                   className={SMALL_SIZE_BUTTON_CLASS_NAME}
                   onClick={handleAccountModalOpen}>


### PR DESCRIPTION
Hi @nud3l @savudani8 - scope of this ticket is to add support for the governance token to the relay chain and general state, rather than add it to the features (e.g. currency selector dropdown, and transfer feature). Once this is done, the changes to support at the feature level can be made separately as they'll be quite small.

My biggest concern here is that I've overlooked something. I've been through the code and referenced instances of collateral token, but could you take a look and let me know if this looks right to you?

I could also do with some help testing - I'm not sure how to create an account with governance tokens, so I'm not able to check that the balance is correct.