### PR TITLE
feat: try a simplier approach

### DIFF
--- a/src/components/NumberInput/NumberInput.stories.tsx
+++ b/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,0 +1,25 @@
+
+import {
+  Story,
+  Meta
+} from '@storybook/react';
+
+import NumberInput, { Props } from './';
+
+const Template: Story<Props> = args => <NumberInput {...args} />;
+
+const Default = Template.bind({});
+Default.args = {
+  id: 'id',
+  name: 'name',
+  placeholder: 'placeholder'
+};
+
+export {
+  Default
+};
+
+export default {
+  title: 'NumberInput',
+  component: NumberInput
+} as Meta;

--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -3,41 +3,18 @@ import * as React from 'react';
 import InterlayInput, { Props as InterlayInputProps } from 'components/UI/InterlayInput';
 
 type Ref = HTMLInputElement;
-const NumberInput = React.forwardRef<Ref, InterlayInputProps>((props, ref): JSX.Element => {
-  // `onWheel` prop can't be used with `preventDefault` because
-  // React implements passive event listeners.
-  const disableChangeOnWheel = (event: MouseEvent) => {
-    event.preventDefault();
-  };
-
-  const inputParent = React.useRef<HTMLDivElement | null>(null);
-
-  React.useEffect(() => {
-    if (!inputParent || !inputParent.current) return;
-
-    const currentInputParent = inputParent.current;
-
-    currentInputParent.addEventListener('wheel', (event: MouseEvent) =>
-      disableChangeOnWheel(event), { passive: false });
-
-    return () => {
-      currentInputParent.removeEventListener('wheel', (event: MouseEvent) =>
-        disableChangeOnWheel(event));
-    };
-  });
-  return (
-    <div ref={inputParent}>
-      <InterlayInput
-        ref={ref}
-        type='number'
-        step='any'
-        pattern='[-+]?[0-9]*[.,]?[0-9]+'
-        placeholder='0.00'
-        spellCheck='false'
-        {...props} />
-    </div>
-  );
-});
+const NumberInput = React.forwardRef<Ref, InterlayInputProps>((props, ref): JSX.Element => (
+  <InterlayInput
+    ref={ref}
+    type='number'
+    step='any'
+    pattern='[-+]?[0-9]*[.,]?[0-9]+'
+    placeholder='0.00'
+    spellCheck='false'
+    // MEMO: inspired by https://stackoverflow.com/questions/63224459/disable-scrolling-on-input-type-number-in-react
+    onWheel={event => event.currentTarget.blur()}
+    {...props} />
+));
 NumberInput.displayName = 'NumberInput';
 
 export type Props = InterlayInputProps;


### PR DESCRIPTION
@tomjeatt 
Could you please review this approach? The approach was inspired by https://stackoverflow.com/questions/63224459/disable-scrolling-on-input-type-number-in-react.

I also added a story for this `NumerInput` component so that we can test it out independently of the main app.