### PR TITLE
feature: disabled link component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -438,7 +438,7 @@ const App = (): JSX.Element => {
                 <Redirect
                   exact
                   from={PAGES.HOME}
-                  to={PAGES.BRIDGE} />
+                  to={PAGES.TRANSFER} />
                 <Route path='*'>
                   <NoMatch />
                 </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,24 +77,24 @@ import {
 } from 'common/actions/general.actions';
 import 'react-toastify/dist/ReactToastify.css';
 
-const Bridge = React.lazy(() =>
-  import(/* webpackChunkName: 'bridge' */ 'pages/Bridge')
-);
+// const Bridge = React.lazy(() =>
+//   import(/* webpackChunkName: 'bridge' */ 'pages/Bridge')
+// );
 const Transfer = React.lazy(() =>
   import(/* webpackChunkName: 'transfer' */ 'pages/Transfer')
 );
-const Transactions = React.lazy(() =>
-  import(/* webpackChunkName: 'transactions' */ 'pages/Transactions')
-);
-const Staking = React.lazy(() =>
-  import(/* webpackChunkName: 'staking' */ 'pages/Staking')
-);
-const Dashboard = React.lazy(() =>
-  import(/* webpackChunkName: 'dashboard' */ 'pages/Dashboard')
-);
-const VaultDashboard = React.lazy(() =>
-  import(/* webpackChunkName: 'vault' */ 'pages/Vault')
-);
+// const Transactions = React.lazy(() =>
+//   import(/* webpackChunkName: 'transactions' */ 'pages/Transactions')
+// );
+// const Staking = React.lazy(() =>
+//   import(/* webpackChunkName: 'staking' */ 'pages/Staking')
+// );
+// const Dashboard = React.lazy(() =>
+//   import(/* webpackChunkName: 'dashboard' */ 'pages/Dashboard')
+// );
+// const VaultDashboard = React.lazy(() =>
+//   import(/* webpackChunkName: 'vault' */ 'pages/Vault')
+// );
 const NoMatch = React.lazy(() =>
   import(/* webpackChunkName: 'no-match' */ 'pages/NoMatch')
 );
@@ -105,8 +105,7 @@ const App = (): JSX.Element => {
     address,
     wrappedTokenBalance,
     collateralTokenBalance,
-    governanceTokenBalance,
-    vaultClientLoaded
+    governanceTokenBalance
   } = useSelector((state: StoreType) => state.general);
   const [isLoading, setIsLoading] = React.useState(true);
   const dispatch = useDispatch();
@@ -415,7 +414,7 @@ const App = (): JSX.Element => {
           render={({ location }) => (
             <React.Suspense fallback={<FullLoadingSpinner />}>
               <Switch location={location}>
-                {vaultClientLoaded && (
+                {/* {vaultClientLoaded && (
                   <Route path={PAGES.VAULT}>
                     <VaultDashboard />
                   </Route>
@@ -431,7 +430,7 @@ const App = (): JSX.Element => {
                 </Route>
                 <Route path={PAGES.BRIDGE}>
                   <Bridge />
-                </Route>
+                </Route> */}
                 <Route path={PAGES.TRANSFER}>
                   <Transfer />
                 </Route>

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -81,6 +81,16 @@ interface CustomProps {
 }
 
 // TODO: could be reused
+const textClasses = clsx(
+  'group',
+  'flex',
+  'items-center',
+  'px-2',
+  'py-2',
+  'font-light',
+  'rounded-md'
+);
+
 const textClassesForSelected = clsx(
   { 'text-interlayDenim-700':
     process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
@@ -98,6 +108,12 @@ const textClassesForDisabled = clsx(
   { 'text-gray-500':
     process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
   { 'dark:text-gray-400': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+);
+
+const navigationIconClasses = clsx(
+  'flex-shrink-0',
+  'w-6',
+  'h-6'
 );
 
 const Navigation = ({
@@ -128,23 +144,14 @@ const Navigation = ({
           return (
             <p
               className={clsx(
+                textClasses,
                 textClassesForDisabled,
-                'group',
-                'flex',
-                'items-center',
-                'px-2',
-                'py-2',
-                onSmallScreen ? 'text-base' : 'text-sm',
-                'font-light',
-                'rounded-md'
+                onSmallScreen ? 'text-base' : 'text-sm'
               )}>
               <navigationItem.icon
                 className={clsx(
                   textClassesForDisabled,
-                  onSmallScreen ? 'mr-4' : 'mr-3',
-                  'flex-shrink-0',
-                  'w-6',
-                  'h-6'
+                  navigationIconClasses
                 )}
                 aria-hidden='true' />
               {t(navigationItem.name)}
@@ -180,14 +187,8 @@ const Navigation = ({
                   { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
                   { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
                 ),
-              'group',
-              'flex',
-              'items-center',
-              'px-2',
-              'py-2',
               onSmallScreen ? 'text-base' : 'text-sm',
-              'font-medium',
-              'rounded-md'
+              textClasses
             )}>
             <navigationItem.icon
               className={clsx(
@@ -195,9 +196,7 @@ const Navigation = ({
                   textClassesForSelected :
                   textClassesForUnselected,
                 onSmallScreen ? 'mr-4' : 'mr-3',
-                'flex-shrink-0',
-                'w-6',
-                'h-6'
+                navigationIconClasses
               )}
               aria-hidden='true' />
             {t(navigationItem.name)}

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -1,5 +1,6 @@
 
 import { useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { matchPath } from 'react-router';
 import {
   ClipboardListIcon,
@@ -21,6 +22,7 @@ import {
   POLKADOT
 } from 'utils/constants/relay-chain-names';
 import { PAGES } from 'utils/constants/links';
+import { StoreType } from 'common/types/util.types';
 
 const NAVIGATION_ITEMS = [
   {
@@ -122,6 +124,7 @@ const Navigation = ({
 }: CustomProps & React.ComponentPropsWithRef<'nav'>): JSX.Element => {
   const location = useLocation();
   const { t } = useTranslation();
+  const { vaultClientLoaded } = useSelector((state: StoreType) => state.general);
 
   return (
     <nav
@@ -133,6 +136,11 @@ const Navigation = ({
       )}
       {...rest}>
       {NAVIGATION_ITEMS.map(navigationItem => {
+        // TODO: use suppress flag when available
+        if (navigationItem.link === PAGES.VAULT && !vaultClientLoaded) {
+          return null;
+        }
+
         if (navigationItem.separator) {
           return (
             <Hr2 key={navigationItem.name} />

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -151,7 +151,8 @@ const Navigation = ({
               <navigationItem.icon
                 className={clsx(
                   textClassesForDisabled,
-                  navigationIconClasses
+                  navigationIconClasses,
+                  onSmallScreen ? 'mr-4' : 'mr-3'
                 )}
                 aria-hidden='true' />
               {t(navigationItem.name)}

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -1,10 +1,9 @@
 
 import { useLocation } from 'react-router-dom';
 import { matchPath } from 'react-router';
-import { useSelector } from 'react-redux';
 import {
   ClipboardListIcon,
-  // CashIcon,
+  CashIcon,
   BookOpenIcon,
   RefreshIcon,
   ChartSquareBarIcon,
@@ -22,13 +21,13 @@ import {
   POLKADOT
 } from 'utils/constants/relay-chain-names';
 import { PAGES } from 'utils/constants/links';
-import { StoreType } from 'common/types/util.types';
 
 const NAVIGATION_ITEMS = [
   {
     name: 'nav_bridge',
     link: PAGES.BRIDGE,
-    icon: RefreshIcon
+    icon: RefreshIcon,
+    disabled: true
   },
   {
     name: 'nav_transfer',
@@ -38,23 +37,26 @@ const NAVIGATION_ITEMS = [
   {
     name: 'nav_transactions',
     link: PAGES.TRANSACTIONS,
-    icon: ClipboardListIcon
+    icon: ClipboardListIcon,
+    disabled: true
   },
-  // TODO: blocked for now
-  // {
-  //   name: 'nav_staking',
-  //   link: PAGES.STAKING,
-  //   icon: CashIcon
-  // },
+  {
+    name: 'nav_staking',
+    link: PAGES.STAKING,
+    icon: CashIcon,
+    disabled: true
+  },
   {
     name: 'nav_dashboard',
     link: PAGES.DASHBOARD,
-    icon: ChartSquareBarIcon
+    icon: ChartSquareBarIcon,
+    disabled: true
   },
   {
     name: 'nav_vault',
     link: PAGES.VAULT,
-    icon: ChipIcon
+    icon: ChipIcon,
+    disabled: true
   },
   {
     name: 'separator',
@@ -85,10 +87,17 @@ const textClassesForSelected = clsx(
   { 'dark:text-kintsugiMidnight-700':
     process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
 );
+
 const textClassesForUnselected = clsx(
   { 'text-interlayTextPrimaryInLightMode':
     process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
   { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+);
+
+const textClassesForDisabled = clsx(
+  { 'text-gray-500':
+    process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+  { 'dark:text-gray-400': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
 );
 
 const Navigation = ({
@@ -98,7 +107,6 @@ const Navigation = ({
 }: CustomProps & React.ComponentPropsWithRef<'nav'>): JSX.Element => {
   const location = useLocation();
   const { t } = useTranslation();
-  const { vaultClientLoaded } = useSelector((state: StoreType) => state.general);
 
   return (
     <nav
@@ -116,9 +124,32 @@ const Navigation = ({
           );
         }
 
-        // TODO: could disable the vault link rather than hiding
-        if (navigationItem.link === PAGES.VAULT && !vaultClientLoaded) {
-          return null;
+        if (navigationItem.disabled) {
+          return (
+            <p
+              className={clsx(
+                textClassesForDisabled,
+                'group',
+                'flex',
+                'items-center',
+                'px-2',
+                'py-2',
+                onSmallScreen ? 'text-base' : 'text-sm',
+                'font-light',
+                'rounded-md'
+              )}>
+              <navigationItem.icon
+                className={clsx(
+                  textClassesForDisabled,
+                  onSmallScreen ? 'mr-4' : 'mr-3',
+                  'flex-shrink-0',
+                  'w-6',
+                  'h-6'
+                )}
+                aria-hidden='true' />
+              {t(navigationItem.name)}
+            </p>
+          );
         }
 
         const match = matchPath(location.pathname, {

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -142,6 +142,7 @@ const Navigation = ({
         if (navigationItem.disabled) {
           return (
             <p
+              key={navigationItem.name}
               className={clsx(
                 textClasses,
                 textClassesForDisabled,

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -87,7 +87,6 @@ const textClasses = clsx(
   'items-center',
   'px-2',
   'py-2',
-  'font-light',
   'rounded-md'
 );
 
@@ -146,7 +145,8 @@ const Navigation = ({
               className={clsx(
                 textClasses,
                 textClassesForDisabled,
-                onSmallScreen ? 'text-base' : 'text-sm'
+                onSmallScreen ? 'text-base' : 'text-sm',
+                'font-light'
               )}>
               <navigationItem.icon
                 className={clsx(
@@ -189,7 +189,9 @@ const Navigation = ({
                   { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
                 ),
               onSmallScreen ? 'text-base' : 'text-sm',
-              textClasses
+              textClasses,
+              'font-medium'
+
             )}>
             <navigationItem.icon
               className={clsx(


### PR DESCRIPTION
This PR:

1. Adds disabled items to the navigation
    * All features are now in the nav, including vaults and staking. @nud3l let me know if any of these should be suppressed altogether.
2. Disables routes for all features other than transfer
3. Redirects from the home page to the transfer feature.

Note: I wouldn't usually leave commented out code in the codebase, but in this case I I think it make sense given that the routes are going to be reactivated by reverting the code changes exactly. 

Test scenarios:

* Loading the app now redirects to the transfer page
* Hitting disabled feature urls directly returns a 404:
    * '/bridge',
    * '/transfer',
    * '/transactions',
    * '/staking',
    * '/dashboard',
    * '/dashboard/vaults',
    * '/dashboard/parachain',
    * '/dashboard/oracles',
    * '/dashboard/issue-requests',
    * '/dashboard/redeem-requests',
    * '/dashboard/relay',
    * '/vault',

<img width="255" alt="Screenshot 2022-01-25 at 11 06 32" src="https://user-images.githubusercontent.com/40243778/150968377-ce45b612-740c-434c-af71-d65cb37d4783.png">

<img width="262" alt="Screenshot 2022-01-25 at 11 24 15" src="https://user-images.githubusercontent.com/40243778/150968394-06107d5d-f210-40d0-a72f-bda5d4e3afa3.png">