### PR TITLE
activate transfer of KSM, KINT, KBTC on kintsugi

### DIFF
--- a/.env.kintsugi
+++ b/.env.kintsugi
@@ -1,0 +1,5 @@
+REACT_APP_BITCOIN_NETWORK="mainnet"
+REACT_APP_PARACHAIN_URL="wss://api-kusama.interlay.io/parachain"
+REACT_APP_STATS_SERVER_URL="https://api-kusama.interlay.io/stats"
+REACT_APP_HYDRA_URL=https://api-kusama.interlay.io/graphql/graphql
+REACT_APP_RELAY_CHAIN_NAME="kusama"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -231,7 +231,7 @@ const App = (): JSX.Element => {
     bridgeLoaded
   ]);
 
-  // Loads the address for the currently select account and maybe loads the vault and staked relayer dashboards
+  // Loads the address for the currently select account and maybe loads the vault dashboard
   React.useEffect(() => {
     if (!bridgeLoaded) return;
 
@@ -293,6 +293,7 @@ const App = (): JSX.Element => {
         if (process.env.REACT_APP_BITCOIN_NETWORK !== 'mainnet') {
           await loadFaucet();
         }
+
         keyring.loadAll({});
       } catch (error) {
         console.log(error.message);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,6 @@ import {
   web3Enable,
   web3FromAddress
 } from '@polkadot/extension-dapp';
-// import keyring from '@polkadot/ui-keyring';
 import { Keyring } from '@polkadot/api';
 import {
   CollateralCurrency,
@@ -124,9 +123,6 @@ const App = (): JSX.Element => {
       );
       dispatch(isPolkaBtcLoaded(true));
       setIsLoading(false);
-
-      // NOTE: Catch clause variable type annotation must be 'any' or 'unknown'. Use of any here
-      // and throughout is to resolve type errors.
     } catch (error) {
       toast.warn('Unable to connect to the BTC-Parachain.');
       console.log('[loadPolkaBTC] error.message => ', error.message);
@@ -294,8 +290,6 @@ const App = (): JSX.Element => {
         if (process.env.REACT_APP_BITCOIN_NETWORK !== 'mainnet') {
           await loadFaucet();
         }
-
-        // keyring.loadAll({});
       } catch (error) {
         console.log(error.message);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
   web3Enable,
   web3FromAddress
 } from '@polkadot/extension-dapp';
-import keyring from '@polkadot/ui-keyring';
+// import keyring from '@polkadot/ui-keyring';
 import { Keyring } from '@polkadot/api';
 import {
   CollateralCurrency,
@@ -124,6 +124,7 @@ const App = (): JSX.Element => {
       );
       dispatch(isPolkaBtcLoaded(true));
       setIsLoading(false);
+
       // NOTE: Catch clause variable type annotation must be 'any' or 'unknown'. Use of any here
       // and throughout is to resolve type errors.
     } catch (error) {
@@ -237,7 +238,7 @@ const App = (): JSX.Element => {
 
     const trySetDefaultAccount = () => {
       if (constants.DEFAULT_ACCOUNT_SEED) {
-        const keyring = new Keyring({ type: 'sr25519' });
+        const keyring = new Keyring({ type: 'sr25519', ss58Format: constants.SS58_FORMAT });
         const defaultAccountKeyring = keyring.addFromUri(constants.DEFAULT_ACCOUNT_SEED);
         window.bridge.interBtcApi.setAccount(defaultAccountKeyring);
         dispatch(changeAddressAction(defaultAccountKeyring.address));
@@ -254,7 +255,7 @@ const App = (): JSX.Element => {
 
         dispatch(setInstalledExtensionAction(theExtensions.map(extension => extension.name)));
 
-        const accounts = await web3Accounts();
+        const accounts = await web3Accounts({ ss58Format: constants.SS58_FORMAT });
         if (accounts.length === 0) {
           dispatch(changeAddressAction(''));
           return;
@@ -294,7 +295,7 @@ const App = (): JSX.Element => {
           await loadFaucet();
         }
 
-        keyring.loadAll({});
+        // keyring.loadAll({});
       } catch (error) {
         console.log(error.message);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,7 +289,10 @@ const App = (): JSX.Element => {
           if (isLoading) setIsLoading(false);
         }, 3000);
         await loadPolkaBTC();
-        await loadFaucet();
+        // Only load faucet on testnet
+        if (process.env.REACT_APP_BITCOIN_NETWORK !== 'mainnet') {
+          await loadFaucet();
+        }
         keyring.loadAll({});
       } catch (error) {
         console.log(error.message);

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -81,7 +81,7 @@
   "nav_docs": "Docs",
   "nav_terms_and_conditions": "Terms and Conditions",
   "report_bug": "Report a bug:",
-  "request_dot": "{{collateralTokenSymbol}} Faucet",
+  "request_funds": "{{tokenSymbol}} Faucet",
   "request_btc": "BTC Faucet",
   "no_pending_status": "No pending status updates",
   "bridge_fee": "Bridge Fee",

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -41,7 +41,6 @@
   "locked": "Locked: ",
   "request": "Request",
   "no_registered_vaults": "No registered vaults",
-  "no_registered_relayers": "No registered relayers",
   "update": "Update",
   "collateralization": "Collateralization",
   "fees_earned": "Fees earned",
@@ -201,7 +200,6 @@
   "dashboard": {
     "premium_redeem": "Premium Redeem",
     "error_unable_to_compute_collateral": "Unable to compute collateralization rate.",
-    "no-registered": "No registered staked relayers",
     "dashboard": "Dashboard",
     "issues": "Issue Requests",
     "total_locked": "Total locked",
@@ -372,16 +370,6 @@
     "no_feedback": "Don't give feedback",
     "give_feedback": "Give feedback",
     "feedback": "Feedback"
-  },
-  "relayer": {
-    "registration": "Registration",
-    "please_note": "Please note there is a default waiting period before bonding.",
-    "stake": "Stake",
-    "warning_relayer_not_registered": "Local relayer client running, but relayer is not yet registered with the parachain. The client is already submitting blocks, but voting and reporting features are disabled until registered.",
-    "staked_relayer_dashboard": "Relayer Dashboard",
-    "stake_locked": "Stake locked",
-    "deregister": "Deregister",
-    "note_you_can_deregister": "Note: You can only deregister if you are not participating in a vote."
   },
   "vault": {
     "creation_block": "Creation Block",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,55 +1,102 @@
-export const BALANCE_MAX_INTEGER_LENGTH = 13;
+const BALANCE_MAX_INTEGER_LENGTH = 13;
 
-export const BTC_DECIMALS = 8;
+const BTC_DECIMALS = 8;
 
 // regtest btc address validation regex
-export const BTC_REGTEST_REGEX = /\b([2mn][a-km-zA-HJ-NP-Z1-9]{25,34}|bcrt1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\b/;
+const BTC_REGTEST_REGEX = /\b([2mn][a-km-zA-HJ-NP-Z1-9]{25,34}|bcrt1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\b/;
 // testnet btc address validation regex
-export const BTC_TESTNET_REGEX = /\b([2mn][a-km-zA-HJ-NP-Z1-9]{25,34}|tb1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\b/;
+const BTC_TESTNET_REGEX = /\b([2mn][a-km-zA-HJ-NP-Z1-9]{25,34}|tb1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\b/;
 // mainnet btc address validation regex
-export const BTC_MAINNET_REGEX = /\b([13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\b/;
+const BTC_MAINNET_REGEX = /\b([13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\b/;
 // btc transaction validation regex
-export const BTC_TRANSACTION_ID_REGEX = /[a-fA-F0-9]{64}/;
+const BTC_TRANSACTION_ID_REGEX = /[a-fA-F0-9]{64}/;
 
 // regex for validating input strings as numbers
-export const NUMERIC_STRING_REGEX = /^[0-9]+([.][0-9]+)?$/;
+const NUMERIC_STRING_REGEX = /^[0-9]+([.][0-9]+)?$/;
 
-export const BITCOIN_NETWORK = (process.env.REACT_APP_BITCOIN_NETWORK || 'testnet') as
+const BITCOIN_NETWORK = (process.env.REACT_APP_BITCOIN_NETWORK || 'testnet') as
   | 'mainnet'
   | 'testnet'
   | 'regtest';
-export const BITCOIN_REGTEST_URL = process.env.REACT_APP_BITCOIN_REGTEST_URL || 'http://localhost:3002';
+const BITCOIN_REGTEST_URL = process.env.REACT_APP_BITCOIN_REGTEST_URL || 'http://localhost:3002';
 
-export const STORE_NAME = 'pbtc-store-2';
+const STORE_NAME = 'pbtc-store-2';
 
-export const BTC_ADDRESS_REGEX =
+const BTC_ADDRESS_REGEX =
   BITCOIN_NETWORK === 'mainnet' ?
     BTC_MAINNET_REGEX :
     BITCOIN_NETWORK === 'testnet' ?
       BTC_TESTNET_REGEX :
       BTC_REGTEST_REGEX;
 
-export const PARACHAIN_URL = process.env.REACT_APP_PARACHAIN_URL || 'ws://127.0.0.1:9944';
-export const DEFAULT_ACCOUNT_SEED = process.env.REACT_APP_DEFAULT_ACCOUNT_SEED;
-export const FAUCET_URL = process.env.REACT_APP_FAUCET_URL || 'http://localhost:3035';
+const PARACHAIN_URL = process.env.REACT_APP_PARACHAIN_URL || 'ws://127.0.0.1:9944';
+const DEFAULT_ACCOUNT_SEED = process.env.REACT_APP_DEFAULT_ACCOUNT_SEED || '//Alice';
+const FAUCET_URL = process.env.REACT_APP_FAUCET_URL || 'http://localhost:3035';
 
-export const STATS_URL = process.env.REACT_APP_STATS_SERVER_URL || 'http://localhost:3007';
+const STATS_URL = process.env.REACT_APP_STATS_SERVER_URL || 'http://localhost:3007';
 
-export const FEEDBACK_URL = 'https://forms.gle/2eKFnq4j1fkBgejW7';
+const FEEDBACK_URL = 'https://forms.gle/2eKFnq4j1fkBgejW7';
+
+// FIXME: hacky workaround to get the right ss58 prefix. Should be fetched at runtime instead
+// Possible example below:
+//       // Load the basic bridge data without depending on interbtc-api
+//      const api = await ApiPromise.create({ provider: new WsProvider(constants.PARACHAIN_URL) });
+//      // Default ss58 prefix is 42 for generic substrate chains
+//      const rawSs58Format = await (await api.rpc.system.properties()).ss58Format;
+//      const ss58Format = parseInt(rawSs58Format.unwrapOr('42').toString());
+let ss58Format;
+if (BITCOIN_NETWORK === 'mainnet') {
+  // kintsugi
+  if (process.env.REACT_APP_RELAY_CHAIN_NAME === 'kusama') {
+    ss58Format = 2092;
+  // interlay
+  } else {
+    ss58Format = 2032;
+  }
+// generic substrate
+} else {
+  ss58Format = 42;
+}
+const SS58_FORMAT = ss58Format;
 
 // ######################################
 // VAULT
 // ######################################
-export const VAULT_STATUS_ACTIVE = 'Active';
-export const VAULT_STATUS_BANNED = 'Banned until block ';
-export const VAULT_STATUS_THEFT = 'Theft detected';
-export const VAULT_STATUS_LIQUIDATED = 'Liquidated';
-export const VAULT_STATUS_UNDER_COLLATERALIZED = 'Undercollateralized';
-export const VAULT_STATUS_LIQUIDATION = 'Being liquidated';
+const VAULT_STATUS_ACTIVE = 'Active';
+const VAULT_STATUS_BANNED = 'Banned until block ';
+const VAULT_STATUS_THEFT = 'Theft detected';
+const VAULT_STATUS_LIQUIDATED = 'Liquidated';
+const VAULT_STATUS_UNDER_COLLATERALIZED = 'Undercollateralized';
+const VAULT_STATUS_LIQUIDATION = 'Being liquidated';
 
 // ####################################################
 // TODO: make sure the constants below are the same as in the BTC-Parachain
 // Best to fetch from API
 // ####################################################
-export const BTC_RELAY_DELAY_WARNING = 6;
-export const BTC_RELAY_DELAY_CRITICAL = 12;
+const BTC_RELAY_DELAY_WARNING = 6;
+const BTC_RELAY_DELAY_CRITICAL = 12;
+
+export {
+  BALANCE_MAX_INTEGER_LENGTH,
+  BTC_DECIMALS,
+  BTC_ADDRESS_REGEX,
+  BTC_TRANSACTION_ID_REGEX,
+  NUMERIC_STRING_REGEX,
+  BITCOIN_NETWORK,
+  BITCOIN_REGTEST_URL,
+  STORE_NAME,
+  PARACHAIN_URL,
+  DEFAULT_ACCOUNT_SEED,
+  FAUCET_URL,
+  STATS_URL,
+  FEEDBACK_URL,
+  SS58_FORMAT,
+  VAULT_STATUS_ACTIVE,
+  VAULT_STATUS_BANNED,
+  VAULT_STATUS_THEFT,
+  VAULT_STATUS_LIQUIDATED,
+  VAULT_STATUS_UNDER_COLLATERALIZED,
+  VAULT_STATUS_LIQUIDATION,
+  BTC_RELAY_DELAY_WARNING,
+  BTC_RELAY_DELAY_CRITICAL
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,13 +38,6 @@ export const STATS_URL = process.env.REACT_APP_STATS_SERVER_URL || 'http://local
 export const FEEDBACK_URL = 'https://forms.gle/2eKFnq4j1fkBgejW7';
 
 // ######################################
-// STAKED RELAYER
-// ######################################
-export const STAKED_RELAYER_OK = 'Ok';
-export const STAKED_RELAYER_OFFLINE = 'Offline';
-export const STAKED_RELAYER_SLASHED = 'Slashed';
-
-// ######################################
 // VAULT
 // ######################################
 export const VAULT_STATUS_ACTIVE = 'Active';

--- a/src/pages/Transfer/TransferForm/index.tsx
+++ b/src/pages/Transfer/TransferForm/index.tsx
@@ -189,7 +189,7 @@ const TransferForm = (): JSX.Element => {
         </div>
         <SubmitButton
           disabled={
-            parachainStatus !== ParachainStatus.Running
+            parachainStatus === (ParachainStatus.Loading || ParachainStatus.Shutdown)
           }
           pending={submitStatus === STATUSES.PENDING}
           onClick={handleConfirmClick}>

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -33,6 +33,8 @@ import { shortAddress } from 'common/utils/utils';
 import { StoreType } from 'common/types/util.types';
 import { changeAddressAction } from 'common/actions/general.actions';
 import { ReactComponent as PolkadotExtensionLogoIcon } from 'assets/img/polkadot-extension-logo.svg';
+// FIXME: name clash for constants so had to use relative path
+import * as constants from '../../constants';
 
 const POLKADOT_EXTENSION = 'https://polkadot.js.org/extension/';
 
@@ -63,7 +65,7 @@ const AccountModal = ({
 
     (async () => {
       try {
-        const theAccounts = await web3Accounts();
+        const theAccounts = await web3Accounts({ ss58Format: constants.SS58_FORMAT });
         setAccounts(theAccounts);
       } catch (error) {
         // TODO: should add error handling properly

--- a/src/parts/Topbar/index.tsx
+++ b/src/parts/Topbar/index.tsx
@@ -30,6 +30,8 @@ import {
 } from 'config/relay-chains';
 import { showAccountModalAction } from 'common/actions/general.actions';
 import { StoreType } from 'common/types/util.types';
+// FIXME: name clash for constants so had to use relative path
+import * as constants from '../../constants';
 
 // TODO: could create a specific prop
 const SMALL_SIZE_BUTTON_CLASS_NAME = clsx(
@@ -69,7 +71,7 @@ const Topbar = (): JSX.Element => {
 
     (async () => {
       try {
-        const theAccounts = await web3Accounts();
+        const theAccounts = await web3Accounts({ ss58Format: constants.SS58_FORMAT });
         setAccounts(theAccounts);
       } catch (error) {
         // TODO: should add error handling properly

--- a/src/parts/Topbar/index.tsx
+++ b/src/parts/Topbar/index.tsx
@@ -25,8 +25,8 @@ import InterlayDefaultContainedButton from 'components/buttons/InterlayDefaultCo
 import InterlayCaliforniaOutlinedButton from 'components/buttons/InterlayCaliforniaOutlinedButton';
 import { ACCOUNT_ID_TYPE_NAME } from 'config/general';
 import {
-  COLLATERAL_TOKEN,
-  COLLATERAL_TOKEN_SYMBOL
+  GOVERNANCE_TOKEN,
+  GOVERNANCE_TOKEN_SYMBOL
 } from 'config/relay-chains';
 import { showAccountModalAction } from 'common/actions/general.actions';
 import { StoreType } from 'common/types/util.types';
@@ -48,13 +48,13 @@ const Topbar = (): JSX.Element => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
-  const handleRequestDotFromFaucet = async (): Promise<void> => {
+  const handleRequestFromFaucet = async (): Promise<void> => {
     if (!address) return;
 
     try {
-      const collateralIdLiteral = tickerToCurrencyIdLiteral(COLLATERAL_TOKEN.ticker) as CollateralIdLiteral;
+      const governanceIdLiteral = tickerToCurrencyIdLiteral(GOVERNANCE_TOKEN.ticker) as CollateralIdLiteral;
       const receiverId = window.bridge.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, address);
-      await window.faucet.fundAccount(receiverId, collateralIdLiteral);
+      await window.faucet.fundAccount(receiverId, governanceIdLiteral);
       toast.success('Your account has been funded.');
     } catch (error) {
       toast.error(`Funding failed. ${error.message}`);
@@ -78,13 +78,13 @@ const Topbar = (): JSX.Element => {
     })();
   }, [extensions.length]);
 
-  const requestDOT = async () => {
+  const requestFunds = async () => {
     if (!bridgeLoaded) return;
     setIsRequestPending(true);
     try {
-      await handleRequestDotFromFaucet();
+      await handleRequestFromFaucet();
     } catch (error) {
-      console.log('[requestDOT] error.message => ', error.message);
+      console.log('[requestFunds] error.message => ', error.message);
     }
     setIsRequestPending(false);
   };
@@ -128,32 +128,36 @@ const Topbar = (): JSX.Element => {
               </InterlayDefaultContainedButton>
             ) : (
               <>
-                <InterlayLink
-                  className='hover:no-underline'
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  href='https://bitcoinfaucet.uo1.net'>
-                  <InterlayCaliforniaOutlinedButton
-                    className={SMALL_SIZE_BUTTON_CLASS_NAME}
-                    endIcon={
-                      <ExternalLinkIcon
-                        className={clsx(
-                          'w-4',
-                          'h-4',
-                          'ml-1'
-                        )} />
-                    }>
-                    {t('request_btc')}
-                  </InterlayCaliforniaOutlinedButton>
-                </InterlayLink>
-                <InterlayDenimOrKintsugiMidnightOutlinedButton
-                  className={SMALL_SIZE_BUTTON_CLASS_NAME}
-                  pending={isRequestPending}
-                  onClick={requestDOT}>
-                  {t('request_dot', {
-                    collateralTokenSymbol: COLLATERAL_TOKEN_SYMBOL
-                  })}
-                </InterlayDenimOrKintsugiMidnightOutlinedButton>
+                {process.env.REACT_APP_BITCOIN_NETWORK !== 'mainnet' && (
+                  <>
+                    <InterlayLink
+                      className='hover:no-underline'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      href='https://bitcoinfaucet.uo1.net'>
+                      <InterlayCaliforniaOutlinedButton
+                        className={SMALL_SIZE_BUTTON_CLASS_NAME}
+                        endIcon={
+                          <ExternalLinkIcon
+                            className={clsx(
+                              'w-4',
+                              'h-4',
+                              'ml-1'
+                            )} />
+                        }>
+                        {t('request_btc')}
+                      </InterlayCaliforniaOutlinedButton>
+                    </InterlayLink>
+                    <InterlayDenimOrKintsugiMidnightOutlinedButton
+                      className={SMALL_SIZE_BUTTON_CLASS_NAME}
+                      pending={isRequestPending}
+                      onClick={requestFunds}>
+                      {t('request_funds', {
+                        tokenSymbol: GOVERNANCE_TOKEN_SYMBOL
+                      })}
+                    </InterlayDenimOrKintsugiMidnightOutlinedButton>
+                  </>
+                )}
                 <Tokens />
                 <InterlayDefaultContainedButton
                   className={SMALL_SIZE_BUTTON_CLASS_NAME}


### PR DESCRIPTION
This PR adds all the functions to enable transfer on Kintsugi. Successfully tested the current code to transfer KSM and KINT. Successful transactions can be seen here: https://kintsugi.subscan.io/account/5FkGaH4iuUTZaW8PwDM62xN7eZeiaVLBQV4z8Yp6p33jbp5o?tab=transfer

# Detailed changes

- Hotfix to use the correct ss58 prefix. I've left a comment in the code since I've just implemented using a constant. Instead, this should be fetched at runtime. We can do that in a later sprint. As a related comment, @savudani8 is it possible to pass through all the RPC calls, queries, and extrinsics from the parachain instead of redefining them in our lib. For example, I'd like to call `api.rpc.properties()` which is not defined on interbtc-api but we could pass through from the underlying chain since it's implemented by polkadot.
- In the process of adding the constants, I got an error that my project won't compile unless I change the constants export to have the exports at the end. I would not have normally refactored the file for that, but seems like it was necessary.
![image](https://user-images.githubusercontent.com/14966470/151312236-c335e0a2-7dc8-4bfc-8554-022fd32cb662.png)

- Activate transfer when the chain is in active or error state. The error state indicates that we do not allow issue, redeem, register vault, ... (basically all bridge actions). Transfers are possible though and hence, active now also on mainnet. Transfer button was deactivated before the fix.
![image](https://user-images.githubusercontent.com/14966470/151312406-c273404f-fb9d-4dc8-a304-8a81db95d77a.png)

- Add the kintsugi mainnet env variable in case someone wants to deploy the UI locally

- Removes the faucet buttons on mainnet and prevents loading the faucet on testnet in the app initilization.

![image](https://user-images.githubusercontent.com/14966470/151312544-fc1d04f7-e211-4ed5-9b60-ccaa38991494.png)

- Removes some code related to staked relayers. I just stumbled upon that unused code. Makes the PR a bit more complex but I've tested it and since we only release the transfer part, I suggest those changes are fine.

- Updated the Faucet to request KINT instead of KSM. Transaction currency is now KINT and the users should request KINT from the UI faucet instead of KSM to pay for tx fees.
