### PR TITLE
feature: add coming soon to disabled links

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -80,6 +80,7 @@
   "nav_feedback": "Feedback",
   "nav_docs": "Docs",
   "nav_terms_and_conditions": "Terms and Conditions",
+  "nav_coming_soon": "Coming soon",
   "report_bug": "Report a bug:",
   "request_funds": "{{tokenSymbol}} Faucet",
   "request_btc": "BTC Faucet",

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -195,7 +195,7 @@ const Navigation = ({
                   onSmallScreen ? 'mr-4' : 'mr-3'
                 )}
                 aria-hidden='true' />
-              {t(navigationItem.name)}
+              {t(navigationItem.name)} ({t('nav_coming_soon')})
             </p>
           );
         }


### PR DESCRIPTION
Note: can't be merged into master as that branch doesn't have the disabled navigation commit. PR goes into kintsugi branch.

Adds coming soon to the nav items as per Jay's design. @nud3l after making the changes I saw your comment in Discord. PR's in draft, so here if we want it but can be discarded if not.

<img width="529" alt="Screenshot 2022-01-28 at 08 31 13" src="https://user-images.githubusercontent.com/40243778/151515629-ceb65e77-ead5-491a-8af9-19d8659f81a3.png">
 