### PR TITLE
fix: getVaultCollateralization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "interbtc-ui",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^1.0.3",
-    "@interlay/interbtc": "1.5.7",
+    "@interlay/interbtc": "1.5.8",
     "@polkadot/api": "6.9.2",
     "@polkadot/extension-dapp": "0.41.2",
     "@polkadot/types": "6.9.2",

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -22,8 +22,7 @@ import {
 } from '@interlay/interbtc-api';
 import {
   MonetaryAmount,
-  Currency,
-  BitcoinAmount
+  Currency
 } from '@interlay/monetary-js';
 
 import ErrorMessage from 'components/ErrorMessage';
@@ -65,7 +64,7 @@ interface Props {
   onClose: () => void;
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
-  lockedBTC: BitcoinAmount;
+  hasLockedBTC: boolean;
 }
 
 const UpdateCollateralModal = ({
@@ -73,7 +72,7 @@ const UpdateCollateralModal = ({
   onClose,
   collateralUpdateStatus,
   vaultAddress,
-  lockedBTC
+  hasLockedBTC
 }: Props): JSX.Element => {
   const {
     bridgeLoaded,
@@ -154,7 +153,7 @@ const UpdateCollateralModal = ({
     ],
     genericFetcher<Big>(),
     {
-      enabled: !!bridgeLoaded && !lockedBTC.eq(BitcoinAmount.zero)
+      enabled: !!bridgeLoaded && !hasLockedBTC
     }
   );
   useErrorHandler(vaultCollateralizationError);
@@ -228,7 +227,7 @@ const UpdateCollateralModal = ({
     const initializing =
       requiredCollateralTokenAmountIdle ||
       requiredCollateralTokenAmountLoading ||
-      (vaultCollateralizationIdle && lockedBTC.gt(BitcoinAmount.zero)) ||
+      (vaultCollateralizationIdle && hasLockedBTC) ||
       vaultCollateralizationLoading;
     const buttonText =
       initializing ?
@@ -255,7 +254,7 @@ const UpdateCollateralModal = ({
       return '-';
     }
 
-    if (lockedBTC.eq(BitcoinAmount.zero)) {
+    if (!hasLockedBTC) {
       return '∞';
     }
 

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -155,7 +155,7 @@ const UpdateCollateralModal = ({
     ],
     genericFetcher<Big>(),
     {
-      enabled: !!bridgeLoaded && hasLockedBTC
+      enabled: bridgeLoaded && hasLockedBTC
     }
   );
   useErrorHandler(vaultCollateralizationError);

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -120,8 +120,6 @@ const UpdateCollateralModal = ({
   );
   useErrorHandler(requiredCollateralTokenAmountError);
 
-  console.log(hasLockedBTC);
-
   const collateralTokenAmount = newMonetaryAmount(strCollateralTokenAmount || '0', COLLATERAL_TOKEN, true);
   let newCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
   let labelText;

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -22,7 +22,8 @@ import {
 } from '@interlay/interbtc-api';
 import {
   MonetaryAmount,
-  Currency
+  Currency,
+  BitcoinAmount
 } from '@interlay/monetary-js';
 
 import ErrorMessage from 'components/ErrorMessage';
@@ -64,13 +65,15 @@ interface Props {
   onClose: () => void;
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
+  lockedBTC: BitcoinAmount;
 }
 
 const UpdateCollateralModal = ({
   open,
   onClose,
   collateralUpdateStatus,
-  vaultAddress
+  vaultAddress,
+  lockedBTC
 }: Props): JSX.Element => {
   const {
     bridgeLoaded,
@@ -151,7 +154,7 @@ const UpdateCollateralModal = ({
     ],
     genericFetcher<Big>(),
     {
-      enabled: !!bridgeLoaded
+      enabled: !!bridgeLoaded && lockedBTC.gt(BitcoinAmount.zero)
     }
   );
   useErrorHandler(vaultCollateralizationError);
@@ -224,7 +227,7 @@ const UpdateCollateralModal = ({
     const initializing =
       requiredCollateralTokenAmountIdle ||
       requiredCollateralTokenAmountLoading ||
-      vaultCollateralizationIdle ||
+      (vaultCollateralizationIdle && lockedBTC.gt(BitcoinAmount.zero)) ||
       vaultCollateralizationLoading;
     const buttonText =
       initializing ?
@@ -246,12 +249,12 @@ const UpdateCollateralModal = ({
   };
 
   const renderNewCollateralizationLabel = () => {
-    if (vaultCollateralizationIdle || vaultCollateralizationLoading) {
+    if ((vaultCollateralizationIdle && lockedBTC.gt(BitcoinAmount.zero)) || vaultCollateralizationLoading) {
       // TODO: should use skeleton loaders
       return '-';
     }
 
-    if (vaultCollateralization === undefined) {
+    if (vaultCollateralization === undefined || lockedBTC.gt(BitcoinAmount.zero)) {
       return '∞';
     }
 

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -154,7 +154,7 @@ const UpdateCollateralModal = ({
     ],
     genericFetcher<Big>(),
     {
-      enabled: !!bridgeLoaded && lockedBTC.gt(BitcoinAmount.zero)
+      enabled: !!bridgeLoaded && !lockedBTC.eq(BitcoinAmount.zero)
     }
   );
   useErrorHandler(vaultCollateralizationError);
@@ -249,17 +249,17 @@ const UpdateCollateralModal = ({
   };
 
   const renderNewCollateralizationLabel = () => {
-    if ((vaultCollateralizationIdle && lockedBTC.gt(BitcoinAmount.zero)) || vaultCollateralizationLoading) {
+    if (vaultCollateralizationLoading) {
       // TODO: should use skeleton loaders
       return '-';
     }
 
-    if (vaultCollateralization === undefined || lockedBTC.gt(BitcoinAmount.zero)) {
+    if (vaultCollateralizationIdle && lockedBTC.eq(BitcoinAmount.zero)) {
       return '∞';
     }
 
     // The vault API returns collateralization as a regular number rather than a percentage
-    const strVaultCollateralizationPercentage = vaultCollateralization.mul(100).toString();
+    const strVaultCollateralizationPercentage = vaultCollateralization?.mul(100).toString();
     if (Number(strVaultCollateralizationPercentage) > 1000) {
       return 'more than 1000%';
     } else {

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -254,7 +254,7 @@ const UpdateCollateralModal = ({
       return '-';
     }
 
-    if (vaultCollateralizationIdle && lockedBTC.eq(BitcoinAmount.zero)) {
+    if (lockedBTC.eq(BitcoinAmount.zero)) {
       return '∞';
     }
 

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -177,11 +177,12 @@ const UpdateCollateralModal = ({
       dispatch(updateCollateralAction(balanceLockedDOT));
 
       if (vaultCollateralization === undefined) {
-        throw new Error('Something went wrong!');
+        dispatch(updateCollateralizationAction('∞'));
+      } else {
+        // The vault API returns collateralization as a regular number rather than a percentage
+        const strVaultCollateralizationPercentage = vaultCollateralization.mul(100).toString();
+        dispatch(updateCollateralizationAction(strVaultCollateralizationPercentage));
       }
-      // The vault API returns collateralization as a regular number rather than a percentage
-      const strVaultCollateralizationPercentage = vaultCollateralization.mul(100).toString();
-      dispatch(updateCollateralizationAction(strVaultCollateralizationPercentage));
 
       toast.success(t('vault.successfully_updated_collateral'));
       setSubmitStatus(STATUSES.RESOLVED);

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -120,6 +120,8 @@ const UpdateCollateralModal = ({
   );
   useErrorHandler(requiredCollateralTokenAmountError);
 
+  console.log(hasLockedBTC);
+
   const collateralTokenAmount = newMonetaryAmount(strCollateralTokenAmount || '0', COLLATERAL_TOKEN, true);
   let newCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
   let labelText;
@@ -153,7 +155,7 @@ const UpdateCollateralModal = ({
     ],
     genericFetcher<Big>(),
     {
-      enabled: !!bridgeLoaded && !hasLockedBTC
+      enabled: !!bridgeLoaded && hasLockedBTC
     }
   );
   useErrorHandler(vaultCollateralizationError);

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -17,7 +17,8 @@ import clsx from 'clsx';
 import {
   roundTwoDecimals,
   newMonetaryAmount,
-  CollateralUnit
+  CollateralUnit,
+  tickerToCurrencyIdLiteral
 } from '@interlay/interbtc-api';
 import {
   MonetaryAmount,
@@ -145,6 +146,7 @@ const UpdateCollateralModal = ({
       'vaults',
       'getVaultCollateralization',
       vaultId,
+      tickerToCurrencyIdLiteral(COLLATERAL_TOKEN.ticker),
       newCollateralTokenAmount
     ],
     genericFetcher<Big>(),

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -187,7 +187,7 @@ const Vault = (): JSX.Element => {
   const VAULT_ITEMS = [
     {
       title: t('collateralization'),
-      value: `${safeRoundTwoDecimals(collateralization?.toString(), '∞')}%`
+      value: collateralization === '∞' ? '∞' : `${safeRoundTwoDecimals(collateralization?.toString(), '∞')}%`
     },
     {
       title: t('vault.fees_earned_interbtc', {

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -32,7 +32,7 @@ import BoldParagraph from 'components/BoldParagraph';
 import
 InterlayDenimOrKintsugiMidnightContainedButton
   from 'components/buttons/InterlayDenimOrKintsugiMidnightContainedButton';
-import InterlayCaliforniaContainedButton from 'components/buttons/InterlayCaliforniaContainedButton';
+// import InterlayCaliforniaContainedButton from 'components/buttons/InterlayCaliforniaContainedButton';
 import InterlayDefaultContainedButton from 'components/buttons/InterlayDefaultContainedButton';
 import Panel from 'components/Panel';
 import { ACCOUNT_ID_TYPE_NAME } from 'config/general';
@@ -95,9 +95,9 @@ const Vault = (): JSX.Element => {
   const handleRequestReplacementModalClose = () => {
     setRequestReplacementModalOpen(false);
   };
-  const handleRequestReplacementModalOpen = () => {
-    setRequestReplacementModalOpen(true);
-  };
+  // const handleRequestReplacementModalOpen = () => {
+  //   setRequestReplacementModalOpen(true);
+  // };
 
   React.useEffect(() => {
     (async () => {
@@ -287,12 +287,12 @@ const Vault = (): JSX.Element => {
               onClick={handleWithdrawCollateralModalOpen}>
               {t('vault.withdraw_collateral')}
             </InterlayDefaultContainedButton>
-            {lockedBTC.gt(BitcoinAmount.zero) && (
+            {/* {lockedBTC.gt(BitcoinAmount.zero) && (
               <InterlayCaliforniaContainedButton
                 onClick={handleRequestReplacementModalOpen}>
                 {t('vault.replace_vault')}
               </InterlayCaliforniaContainedButton>
-            )}
+            )} */}
           </div>
         )}
         <VaultIssueRequestsTable

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -315,7 +315,7 @@ const Vault = (): JSX.Element => {
           onClose={handleUpdateCollateralModalClose}
           collateralUpdateStatus={collateralUpdateStatus}
           vaultAddress={selectedVaultAddress}
-          hasLockedBTC={lockedBTC.eq(BitcoinAmount.zero)} />
+          hasLockedBTC={lockedBTC.gt(BitcoinAmount.zero)} />
       )}
       <RequestReplacementModal
         onClose={handleRequestReplacementModalClose}

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -187,8 +187,7 @@ const Vault = (): JSX.Element => {
   const VAULT_ITEMS = [
     {
       title: t('collateralization'),
-      value: collateralization ===
-        '∞' ?
+      value: collateralization === '∞' ?
         collateralization :
         `${safeRoundTwoDecimals(collateralization?.toString(), '∞')}%`
     },

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -311,7 +311,8 @@ const Vault = (): JSX.Element => {
           }
           onClose={handleUpdateCollateralModalClose}
           collateralUpdateStatus={collateralUpdateStatus}
-          vaultAddress={selectedVaultAddress} />
+          vaultAddress={selectedVaultAddress}
+          lockedBTC={lockedBTC} />
       )}
       <RequestReplacementModal
         onClose={handleRequestReplacementModalClose}

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -187,7 +187,10 @@ const Vault = (): JSX.Element => {
   const VAULT_ITEMS = [
     {
       title: t('collateralization'),
-      value: collateralization === '∞' ? '∞' : `${safeRoundTwoDecimals(collateralization?.toString(), '∞')}%`
+      value: collateralization ===
+        '∞' ?
+        collateralization :
+        `${safeRoundTwoDecimals(collateralization?.toString(), '∞')}%`
     },
     {
       title: t('vault.fees_earned_interbtc', {
@@ -312,7 +315,7 @@ const Vault = (): JSX.Element => {
           onClose={handleUpdateCollateralModalClose}
           collateralUpdateStatus={collateralUpdateStatus}
           vaultAddress={selectedVaultAddress}
-          lockedBTC={lockedBTC} />
+          hasLockedBTC={lockedBTC.eq(BitcoinAmount.zero)} />
       )}
       <RequestReplacementModal
         onClose={handleRequestReplacementModalClose}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,10 +1585,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@1.5.18":
-  version "1.5.18"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-1.5.18.tgz#be431e725e4e599231839995ae2287c10bbea060"
-  integrity sha512-IAl+fldII2NDc9PRvT5vl7g3vvfsckwsR79PPMKTscENB8YHxIxbTmijddpnrd2Y1b7ZrYB8yzw7UQUMUx3bxg==
+"@interlay/interbtc-api@1.5.19":
+  version "1.5.19"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-1.5.19.tgz#5c369233e3a0ad779c651412e6fc973f27d1bd2b"
+  integrity sha512-sDucSznNrkiVEEbPBWBjCBeYs4WMP+VX+0T3CUyOu3KAzz3ac5QO8FrRXo+rr7uTtUG48NjZz8JvVMdfXDH+Dw==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "1.5.10"
@@ -1620,12 +1620,12 @@
   resolved "https://registry.yarnpkg.com/@interlay/interbtc-types/-/interbtc-types-1.5.10.tgz#8ff123e7886df06776e090deacca5c1b84ecf315"
   integrity sha512-7pUzNKmNeHi74uJl9WBoYzwyKh8+X18wZz9MVDvx58SgkDiEjUpyeafjhcmVhJptaB+OwPJ1V76RDbJRxr0T4w==
 
-"@interlay/interbtc@1.5.7":
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc/-/interbtc-1.5.7.tgz#8ec810d87e33a7241c71a9a185c89e8bb279ff17"
-  integrity sha512-wU4AmbJvfUuFMtdLgWc61q1qMEp5jRNGG56snmemOevAzyGpb+CcCTJQ3DC7FZkkwEfr+O6TT+CjA6jlOqxAiA==
+"@interlay/interbtc@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc/-/interbtc-1.5.8.tgz#cfc4c16be7185f13528f49da101597143a3a78c9"
+  integrity sha512-zscQxxX9gEvle1xnHMME88+mw1jcwvmtlltsjbrJu7xwvV/ARvggOo4zjPGRYVoYFUbK30Oj0DllK7TuGMlhsQ==
   dependencies:
-    "@interlay/interbtc-api" "1.5.18"
+    "@interlay/interbtc-api" "1.5.19"
     "@interlay/interbtc-index-client" "1.6.0"
     "@interlay/interbtc-types" "1.3.0"
     "@interlay/monetary-js" "0.5.3"


### PR DESCRIPTION
Vault collateralisation is working now - users can deposit and withdraw. This has been tested against an account with lockedBTC, and an account with no lockedBTC.

This PR blocks the API call if a user has no lockedBTC. Hitting the API in that case will cause an error to be returned (correctly - the calculation won't work against a value of zero) so it makes sense to set collateralisation to ∞ in the client as this will always be the correct value for an account with no locked BTC.

This is a quick fix to get the release out - we should rethink the logic when implementing the updated vault dashboard. The original logic assumed that `undefined` was not a valid value for collateralisation. This PR patches that, but ideally we need to refactor properly on the assumption that undefined is valid.

Note: this PR also disables vault replacement. This has been commented out rather than removed as it's going to be fixed and released imminently.