### PR TITLE
fix: suppress T&Cs link if returned as empty string

### DIFF
--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -47,6 +47,8 @@ const textClassesForUnselected = clsx(
   { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
 );
 
+console.log('TERMS_AND_CONDITIONS_LINK', TERMS_AND_CONDITIONS_LINK);
+
 const Navigation = ({
   onSmallScreen = false,
   className,
@@ -113,6 +115,7 @@ const Navigation = ({
         link: TERMS_AND_CONDITIONS_LINK,
         icon: DocumentTextIcon,
         external: true,
+        hidden: !TERMS_AND_CONDITIONS_LINK,
         rest: {
           target: '_blank',
           rel: 'noopener noreferrer'

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -47,8 +47,6 @@ const textClassesForUnselected = clsx(
   { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
 );
 
-console.log('TERMS_AND_CONDITIONS_LINK', TERMS_AND_CONDITIONS_LINK);
-
 const Navigation = ({
   onSmallScreen = false,
   className,


### PR DESCRIPTION
Hide the T&C link if the link has been set to an empty string (this will suppress it for the testnet release)