### PR TITLE
fix: correct colors in RedeemedChart

### DIFF
--- a/src/pages/Dashboard/sub-pages/RedeemRequests/UpperContent/RedeemedChart/index.tsx
+++ b/src/pages/Dashboard/sub-pages/RedeemRequests/UpperContent/RedeemedChart/index.tsx
@@ -82,8 +82,8 @@ const RedeemedChart = (): JSX.Element => {
     secondChartLineColor = INTERLAY_MULBERRY[500];
   // MEMO: should check dark mode as well
   } else if (process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA) {
-    firstChartLineColor = KINTSUGI_MIDNIGHT[500];
-    secondChartLineColor = KINTSUGI_PRAIRIE_SAND[500];
+    firstChartLineColor = KINTSUGI_MIDNIGHT[200];
+    secondChartLineColor = KINTSUGI_PRAIRIE_SAND[400];
   } else {
     throw new Error('Something went wrong!');
   }


### PR DESCRIPTION
Before:
![Capture-4](https://user-images.githubusercontent.com/84005068/153780758-00d9cd44-a3da-476e-a85e-4741f448fc5f.PNG)
After:
![Capture-3](https://user-images.githubusercontent.com/84005068/153780760-418808b1-b7c2-4cf9-bf39-756166c7ce0e.PNG)

