### PR TITLE
fix: refetch replace requests to update table without a refresh

### DIFF
--- a/src/pages/Vault/ReplaceTable/index.tsx
+++ b/src/pages/Vault/ReplaceTable/index.tsx
@@ -74,7 +74,8 @@ const ReplaceTable = ({
     ],
     genericFetcher<Map<H256, ReplaceRequestExt>>(),
     {
-      enabled: !!bridgeLoaded
+      enabled: !!bridgeLoaded,
+      refetchInterval: 10000
     }
   );
   useErrorHandler(replaceRequestsError);


### PR DESCRIPTION
This adds a refetch interval to the query config to show replace requests without refreshing