### PR TITLE
feature: nominal transfer fee

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,8 @@ import {
   APP_NAME,
   WRAPPED_TOKEN,
   COLLATERAL_TOKEN,
-  GOVERNANCE_TOKEN
+  GOVERNANCE_TOKEN,
+  NOMINAL_TRANSFER_FEE
 } from 'config/relay-chains';
 import { PAGES } from 'utils/constants/links';
 import { CLASS_NAMES } from 'utils/constants/styles';
@@ -361,7 +362,8 @@ const App = (): JSX.Element => {
                 dispatch(updateGovernanceTokenBalanceAction(balance.free));
               }
               if (!balance.transferable.eq(governanceTokenTransferableBalance)) {
-                dispatch(updateGovernanceTokenTransferableBalanceAction(balance.transferable));
+                const adjustedTransferableBalance = balance.transferable.sub(NOMINAL_TRANSFER_FEE);
+                dispatch(updateGovernanceTokenTransferableBalanceAction(adjustedTransferableBalance));
               }
             }
           );

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -22,7 +22,6 @@ import {
   GovernanceToken,
   GOVERNANCE_TOKEN,
   GOVERNANCE_TOKEN_SYMBOL,
-  NOMINAL_TRANSFER_FEE,
   GovernanceTokenLogoIcon
 } from 'config/relay-chains';
 import { displayMonetaryAmount } from 'common/utils/utils';
@@ -116,7 +115,7 @@ const Tokens = ({
         token: GOVERNANCE_TOKEN,
         type: TokenType.GOVERNANCE,
         balance: displayMonetaryAmount(governanceTokenBalance),
-        transferableBalance: displayMonetaryAmount(governanceTokenTransferableBalance.sub(NOMINAL_TRANSFER_FEE)),
+        transferableBalance: displayMonetaryAmount(governanceTokenTransferableBalance),
         icon: <GovernanceTokenLogoIcon
           height={variant === SELECT_VARIANTS.formField ? 46 : 26} />,
         symbol: GOVERNANCE_TOKEN_SYMBOL

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -22,6 +22,7 @@ import {
   GovernanceToken,
   GOVERNANCE_TOKEN,
   GOVERNANCE_TOKEN_SYMBOL,
+  NOMINAL_TRANSFER_FEE,
   GovernanceTokenLogoIcon
 } from 'config/relay-chains';
 import { displayMonetaryAmount } from 'common/utils/utils';
@@ -115,7 +116,7 @@ const Tokens = ({
         token: GOVERNANCE_TOKEN,
         type: TokenType.GOVERNANCE,
         balance: displayMonetaryAmount(governanceTokenBalance),
-        transferableBalance: displayMonetaryAmount(governanceTokenTransferableBalance),
+        transferableBalance: displayMonetaryAmount(governanceTokenTransferableBalance.sub(NOMINAL_TRANSFER_FEE)),
         icon: <GovernanceTokenLogoIcon
           height={variant === SELECT_VARIANTS.formField ? 46 : 26} />,
         symbol: GOVERNANCE_TOKEN_SYMBOL

--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -1,3 +1,5 @@
+
+import { newMonetaryAmount } from '@interlay/interbtc-api';
 import {
   Currency,
   BitcoinUnit,
@@ -8,7 +10,8 @@ import {
   InterBtc, // on Polkadot
   Polkadot, // on Polkadot
   InterBtcAmount, // on Polkadot
-  Interlay // On Polkadot
+  Interlay, // On Polkadot
+  MonetaryAmount
 } from '@interlay/monetary-js';
 import {
   CollateralUnit,
@@ -46,6 +49,8 @@ let WRAPPED_TOKEN_SYMBOL: string;
 let WRAPPED_TOKEN: WrappedToken;
 let COLLATERAL_TOKEN: CollateralToken;
 let GOVERNANCE_TOKEN: GovernanceToken;
+// TODO: This should be removed when transfer fees implemented in lib
+let NOMINAL_TRANSFER_FEE: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
 let PRICES_URL: string;
 let RELAY_CHAIN_NAME: string;
 let BRIDGE_PARACHAIN_NAME: string;
@@ -95,6 +100,7 @@ case POLKADOT: {
   WRAPPED_TOKEN_SYMBOL = 'interBTC';
   COLLATERAL_TOKEN_SYMBOL = 'DOT';
   GOVERNANCE_TOKEN_SYMBOL = 'INTR';
+  NOMINAL_TRANSFER_FEE = newMonetaryAmount('0.00001', GOVERNANCE_TOKEN, true);
   RELAY_CHAIN_NAME = 'polkadot';
   BRIDGE_PARACHAIN_NAME = 'interlay';
   // eslint-disable-next-line max-len
@@ -120,6 +126,7 @@ case KUSAMA: {
   WRAPPED_TOKEN_SYMBOL = 'kBTC';
   COLLATERAL_TOKEN_SYMBOL = 'KSM';
   GOVERNANCE_TOKEN_SYMBOL = 'KINT';
+  NOMINAL_TRANSFER_FEE = newMonetaryAmount('0.00001', GOVERNANCE_TOKEN, true);
   RELAY_CHAIN_NAME = 'kusama';
   BRIDGE_PARACHAIN_NAME = 'kintsugi';
   // eslint-disable-next-line max-len
@@ -156,6 +163,7 @@ export {
   WRAPPED_TOKEN_SYMBOL,
   COLLATERAL_TOKEN_SYMBOL,
   GOVERNANCE_TOKEN_SYMBOL,
+  NOMINAL_TRANSFER_FEE,
   RELAY_CHAIN_NAME,
   BRIDGE_PARACHAIN_NAME,
   PRICES_URL,


### PR DESCRIPTION
This PR does two things:

1. Adds a nominal transfer fee to the chain config
2. Subtracts the fee from the transferable governance token balance.

Because we validate against the transferable balance, this means there is no need for an additional validation step as the transferable balance now takes into account the nominal transfer fee, for example:

* transferable balance from the lib = 10.00005
* nominal transfer fee = 0.00001
* transferable balance in UI = 10.00004

@nud3l the reason this is in draft is that I want to check you're happy with the transfer fee effectively being hidden from the user. We're not flagging that we're deducting a nominal amount from the transferable balance, we're just handling it behind the scenes (e.g. a transferable balance of 0 as displayed to the user is 0.00001 as returned from the lib).

I think this is ok because the aim with this ticket is to prevent the transaction failing rather than displaying the nominal transfer fee which wouldn't necessarily match the real transfer fee in any case.
