### PR TITLE
fix: validate vaults before issuing

### DIFF
--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -185,7 +185,7 @@ const IssueForm = (): JSX.Element | null => {
 
         return vaults;
       } catch (error) {
-        // We need to reset here as this function is called while
+        // We need to reset here as this function is called
         // on form submit
         if (submitStatus === STATUSES.PENDING) {
           setSubmitStatus(STATUSES.RESOLVED);

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -185,6 +185,12 @@ const IssueForm = (): JSX.Element | null => {
 
         return vaults;
       } catch (error) {
+        // We need to reset here as this function is called while
+        // on form submit
+        if (submitStatus === STATUSES.PENDING) {
+          setSubmitStatus(STATUSES.RESOLVED);
+        }
+
         setStatus(STATUSES.REJECTED);
         handleError(error);
       }

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -144,18 +144,6 @@ const RedeemForm = (): JSX.Element | null => {
   ]);
 
   React.useEffect(() => {
-    const refetchPremiumRedeemVaults = async () => {
-      const premiumRedeemVaults = await window.bridge.interBtcApi.vaults.getPremiumRedeemVaults();
-
-      setPremiumRedeemVaults(premiumRedeemVaults);
-    };
-
-    if (premiumRedeemSelected) {
-      refetchPremiumRedeemVaults();
-    }
-  }, [premiumRedeemSelected]);
-
-  React.useEffect(() => {
     if (!bridgeLoaded) return;
     if (!handleError) return;
 

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -144,6 +144,18 @@ const RedeemForm = (): JSX.Element | null => {
   ]);
 
   React.useEffect(() => {
+    const refetchPremiumRedeemVaults = async () => {
+      const premiumRedeemVaults = await window.bridge.interBtcApi.vaults.getPremiumRedeemVaults();
+
+      setPremiumRedeemVaults(premiumRedeemVaults);
+    };
+
+    if (premiumRedeemSelected) {
+      refetchPremiumRedeemVaults();
+    }
+  }, [premiumRedeemSelected]);
+
+  React.useEffect(() => {
     if (!bridgeLoaded) return;
     if (!handleError) return;
 


### PR DESCRIPTION
This is a workaround for the issue of stale vault data on submit. This could definitely be improved by refactoring how we fetch data, but this is intended to be a quick fix so I've kept the changes to a minimum to reduce testing overhead and avoid the risk of regressions.

This PR makes the following changes to the issue request:

1. Removes the request for vaults on initial render.
2. Remove the vault capacity check from the onChange field validation.
3. Requests the vaults and validates capacity on submit so that the data is always fresh.
4. If there is no vault with capacity, the error is appended to the form field (as happens now)
    * If this happens the form submission is cancelled.
5. If there is a vault with capacity, the form is submitted. 

In UI terms there are no visual changes. Submission takes slightly longer as we need to wait for the vaults request to complete, but this isn't particularly noticeable as the request was already quite long-running.