### PR TITLE
fix: staking division by 0; fix: indexer dependency; refactor: show KINT to be claimed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@craco/craco": "^6.1.1",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^1.0.3",
-    "@interlay/interbtc-api": "../api",
+    "@interlay/interbtc-api": "1.7.0",
     "@polkadot/api": "7.7.1",
     "@polkadot/extension-dapp": "0.42.7",
     "@polkadot/types": "7.7.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@craco/craco": "^6.1.1",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^1.0.3",
-    "@interlay/interbtc": "1.6.2",
+    "@interlay/interbtc-api": "../api",
     "@polkadot/api": "7.7.1",
     "@polkadot/extension-dapp": "0.42.7",
     "@polkadot/types": "7.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
 } from '@polkadot/extension-dapp';
 import { Keyring } from '@polkadot/api';
 import {
+  createInterBtcApi,
   tickerToCurrencyIdLiteral,
   SecurityStatusCode,
   FaucetClient,
@@ -29,7 +30,6 @@ import {
   CollateralUnit,
   GovernanceUnit
 } from '@interlay/interbtc-api';
-import { createInterbtc } from '@interlay/interbtc';
 import { BitcoinUnit } from '@interlay/monetary-js';
 
 import InterlayHelmet from 'parts/InterlayHelmet';
@@ -113,10 +113,9 @@ const App = (): JSX.Element => {
   // Load the main bridge API - connection to the bridge
   const loadPolkaBTC = React.useCallback(async (): Promise<void> => {
     try {
-      window.bridge = await createInterbtc(
+      window.bridge = await createInterBtcApi(
         constants.PARACHAIN_URL,
-        constants.BITCOIN_NETWORK,
-        constants.STATS_URL
+        constants.BITCOIN_NETWORK
       );
       dispatch(isPolkaBtcLoaded(true));
       setIsLoading(false);
@@ -138,7 +137,7 @@ const App = (): JSX.Element => {
   // Load the connection to the faucet - only for testnet purposes
   const loadFaucet = React.useCallback(async (): Promise<void> => {
     try {
-      window.faucet = new FaucetClient(window.bridge.interBtcApi.api, constants.FAUCET_URL);
+      window.faucet = new FaucetClient(window.bridge.api, constants.FAUCET_URL);
       dispatch(isFaucetLoaded(true));
     } catch (error) {
       console.log('[loadFaucet] error.message => ', error.message);
@@ -149,13 +148,13 @@ const App = (): JSX.Element => {
     if (!bridgeLoaded) return;
     if (!address) return;
 
-    const id = window.bridge.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, address);
+    const id = window.bridge.api.createType(ACCOUNT_ID_TYPE_NAME, address);
 
     // Maybe load the vault client - only if the current address is also registered as a vault
     (async () => {
       try {
         dispatch(isVaultClientLoaded(false));
-        const vault = await window.bridge.interBtcApi.vaults.get(
+        const vault = await window.bridge.vaults.get(
           id,
           tickerToCurrencyIdLiteral(COLLATERAL_TOKEN.ticker)
         );
@@ -185,12 +184,12 @@ const App = (): JSX.Element => {
           bitcoinHeight,
           state
         ] = await Promise.all([
-          window.bridge.interBtcApi.tokens.total(WRAPPED_TOKEN),
-          window.bridge.interBtcApi.tokens.total(COLLATERAL_TOKEN),
-          window.bridge.interBtcApi.tokens.total(GOVERNANCE_TOKEN),
-          window.bridge.interBtcApi.btcRelay.getLatestBlockHeight(),
-          window.bridge.interBtcApi.electrsAPI.getLatestBlockHeight(),
-          window.bridge.interBtcApi.system.getStatusCode()
+          window.bridge.tokens.total(WRAPPED_TOKEN),
+          window.bridge.tokens.total(COLLATERAL_TOKEN),
+          window.bridge.tokens.total(GOVERNANCE_TOKEN),
+          window.bridge.btcRelay.getLatestBlockHeight(),
+          window.bridge.electrsAPI.getLatestBlockHeight(),
+          window.bridge.system.getStatusCode()
         ]);
 
         const parachainStatus = (state: SecurityStatusCode) => {
@@ -233,7 +232,7 @@ const App = (): JSX.Element => {
       if (constants.DEFAULT_ACCOUNT_SEED) {
         const keyring = new Keyring({ type: 'sr25519', ss58Format: constants.SS58_FORMAT });
         const defaultAccountKeyring = keyring.addFromUri(constants.DEFAULT_ACCOUNT_SEED as string);
-        window.bridge.interBtcApi.setAccount(defaultAccountKeyring);
+        window.bridge.setAccount(defaultAccountKeyring);
         dispatch(changeAddressAction(defaultAccountKeyring.address));
       }
     };
@@ -259,7 +258,7 @@ const App = (): JSX.Element => {
 
         const { signer } = await web3FromAddress(newAddress);
         // TODO: could store the active address just in one place (either in `window` object or in redux)
-        window.bridge.interBtcApi.setAccount(newAddress, signer);
+        window.bridge.setAccount(newAddress, signer);
         dispatch(changeAddressAction(newAddress));
       } catch (error) {
         // TODO: should add error handling
@@ -313,7 +312,7 @@ const App = (): JSX.Element => {
     (async () => {
       try {
         unsubscribeFromCollateral =
-          await window.bridge.interBtcApi.tokens.subscribeToBalance(
+          await window.bridge.tokens.subscribeToBalance(
             COLLATERAL_TOKEN,
             address,
             (_: string, balance: ChainBalance<CollateralUnit>) => {
@@ -333,7 +332,7 @@ const App = (): JSX.Element => {
     (async () => {
       try {
         unsubscribeFromWrapped =
-          await window.bridge.interBtcApi.tokens.subscribeToBalance(
+          await window.bridge.tokens.subscribeToBalance(
             WRAPPED_TOKEN,
             address,
             (_: string, balance: ChainBalance<BitcoinUnit>) => {
@@ -353,7 +352,7 @@ const App = (): JSX.Element => {
     (async () => {
       try {
         unsubscribeFromGovernance =
-          await window.bridge.interBtcApi.tokens.subscribeToBalance(
+          await window.bridge.tokens.subscribeToBalance(
             GOVERNANCE_TOKEN,
             address,
             (_: string, balance: ChainBalance<GovernanceUnit>) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,7 +111,7 @@ const App = (): JSX.Element => {
   const store: StoreState = useStore();
 
   // Load the main bridge API - connection to the bridge
-  const loadPolkaBTC = React.useCallback(async (): Promise<void> => {
+  const loadInterBtc = React.useCallback(async (): Promise<void> => {
     try {
       window.bridge = await createInterBtcApi(
         constants.PARACHAIN_URL,
@@ -121,13 +121,13 @@ const App = (): JSX.Element => {
       setIsLoading(false);
     } catch (error) {
       toast.warn('Unable to connect to the BTC-Parachain.');
-      console.log('[loadPolkaBTC] error.message => ', error.message);
+      console.log('[loadInterBtc] error.message => ', error.message);
     }
 
     try {
       startFetchingLiveData(dispatch, store);
     } catch (error) {
-      console.log('[loadPolkaBTC] error.message => ', error.message);
+      console.log('[loadInterBtc] error.message => ', error.message);
     }
   }, [
     dispatch,
@@ -281,7 +281,7 @@ const App = (): JSX.Element => {
         setTimeout(() => {
           if (isLoading) setIsLoading(false);
         }, 3000);
-        await loadPolkaBTC();
+        await loadInterBtc();
         // Only load faucet on testnet
         if (process.env.REACT_APP_BITCOIN_NETWORK !== 'mainnet') {
           await loadFaucet();
@@ -292,7 +292,7 @@ const App = (): JSX.Element => {
     })();
     startFetchingLiveData(dispatch, store);
   }, [
-    loadPolkaBTC,
+    loadInterBtc,
     loadFaucet,
     isLoading,
     bridgeLoaded,

--- a/src/common/live-data/block-height-watcher.ts
+++ b/src/common/live-data/block-height-watcher.ts
@@ -8,8 +8,8 @@ export default async function fetchBtcRelayAndBitcoinHeight(dispatch: Dispatch, 
   if (!bridgeLoaded) return;
 
   try {
-    const latestBtcRelayHeight = Number(await window.bridge.interBtcApi.btcRelay.getLatestBlockHeight());
-    const latestBitcoinHeight = await window.bridge.interBtcApi.electrsAPI.getLatestBlockHeight();
+    const latestBtcRelayHeight = Number(await window.bridge.btcRelay.getLatestBlockHeight());
+    const latestBitcoinHeight = await window.bridge.electrsAPI.getLatestBlockHeight();
 
     // update store only if there is a difference between the latest heights and current heights
     if (btcRelayHeight !== latestBtcRelayHeight || bitcoinHeight !== latestBitcoinHeight) {

--- a/src/common/live-data/totals-watcher.ts
+++ b/src/common/live-data/totals-watcher.ts
@@ -22,8 +22,8 @@ export default async function fetchTotals(dispatch: Dispatch, store: StoreState)
       latestTotalWrappedTokenAmount,
       latestTotalLockedCollateralTokenAmount
     ] = await Promise.all([
-      window.bridge.interBtcApi.tokens.total(WRAPPED_TOKEN),
-      window.bridge.interBtcApi.tokens.total(COLLATERAL_TOKEN)
+      window.bridge.tokens.total(WRAPPED_TOKEN),
+      window.bridge.tokens.total(COLLATERAL_TOKEN)
     ]);
 
     // update store only if there is a difference between the latest totals and current totals

--- a/src/pages/Bridge/BurnForm/index.tsx
+++ b/src/pages/Bridge/BurnForm/index.tsx
@@ -112,7 +112,7 @@ const BurnForm = (): JSX.Element | null => {
     (async () => {
       try {
         setStatus(STATUSES.PENDING);
-        const theBurnRate = await window.bridge.interBtcApi.redeem.getBurnExchangeRate(COLLATERAL_TOKEN);
+        const theBurnRate = await window.bridge.redeem.getBurnExchangeRate(COLLATERAL_TOKEN);
         setBurnRate(theBurnRate);
         setStatus(STATUSES.RESOLVED);
       } catch (error) {
@@ -146,7 +146,7 @@ const BurnForm = (): JSX.Element | null => {
     const onSubmit = async (data: BurnFormData) => {
       try {
         setSubmitStatus(STATUSES.PENDING);
-        await window.bridge.interBtcApi.redeem.burn(
+        await window.bridge.redeem.burn(
           BitcoinAmount.from.BTC(data[WRAPPED_TOKEN_AMOUNT]),
           COLLATERAL_TOKEN as CollateralCurrency
         );

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -113,8 +113,8 @@ const IssueForm = (): JSX.Element | null => {
   const [status, setStatus] = React.useState(STATUSES.IDLE);
   // Additional info: bridge fee, security deposit, amount BTC
   // Current fee model specification taken from: https://interlay.gitlab.io/polkabtc-spec/spec/fee.html
-  const [feeRate, setFeeRate] = React.useState(0.005); // Set default to 0.5%
-  const [depositRate, setDepositRate] = React.useState(0.00005); // Set default to 0.005%
+  const [feeRate, setFeeRate] = React.useState(new Big(0.005)); // Set default to 0.5%
+  const [depositRate, setDepositRate] = React.useState(new Big(0.00005)); // Set default to 0.005%
   const [btcToGovernanceTokenRate, setBTCToGovernanceTokenRate] = React.useState(
     new ExchangeRate<
       Bitcoin,
@@ -148,13 +148,13 @@ const IssueForm = (): JSX.Element | null => {
         ] = await Promise.all([
           // Loading this data is not strictly required as long as the constantly set values did
           // not change. However, you will not see the correct value for the security deposit.
-          window.bridge.interBtcIndex.getIssueFee(),
-          window.bridge.interBtcIndex.getIssueGriefingCollateral(),
-          window.bridge.interBtcIndex.getIssuePeriod(),
-          window.bridge.interBtcIndex.getDustValue(),
-          window.bridge.interBtcApi.oracle.getExchangeRate(GOVERNANCE_TOKEN),
+          window.bridge.fee.getIssueFee(),
+          window.bridge.fee.getIssueGriefingCollateralRate(),
+          window.bridge.issue.getIssuePeriod(),
+          window.bridge.issue.getDustValue(),
+          window.bridge.oracle.getExchangeRate(GOVERNANCE_TOKEN),
           // This data (the vaults) is strictly required to request issue
-          window.bridge.interBtcApi.vaults.getVaultsWithIssuableTokens()
+          window.bridge.vaults.getVaultsWithIssuableTokens()
         ]);
         setStatus(STATUSES.RESOLVED);
 
@@ -252,7 +252,7 @@ const IssueForm = (): JSX.Element | null => {
       try {
         const wrappedTokenAmount = BitcoinAmount.from.BTC(data[BTC_AMOUNT]);
         setSubmitStatus(STATUSES.PENDING);
-        const result = await window.bridge.interBtcApi.issue.request(wrappedTokenAmount);
+        const result = await window.bridge.issue.request(wrappedTokenAmount);
         // TODO: handle issue aggregation
         const issueRequest = result[0];
         handleSubmittedRequestModalOpen(issueRequest);

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -158,12 +158,12 @@ const RedeemForm = (): JSX.Element | null => {
           redeemFeeRateResult,
           currentInclusionFeeResult
         ] = await Promise.allSettled([
-          window.bridge.interBtcApi.redeem.getDustValue(),
-          window.bridge.interBtcApi.vaults.getPremiumRedeemVaults(),
-          window.bridge.interBtcIndex.getPremiumRedeemFee(),
-          window.bridge.interBtcApi.oracle.getExchangeRate(COLLATERAL_TOKEN),
-          window.bridge.interBtcApi.redeem.getFeeRate(),
-          window.bridge.interBtcApi.redeem.getCurrentInclusionFee()
+          window.bridge.redeem.getDustValue(),
+          window.bridge.vaults.getPremiumRedeemVaults(),
+          window.bridge.redeem.getPremiumRedeemFeeRate(),
+          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN),
+          window.bridge.redeem.getFeeRate(),
+          window.bridge.redeem.getCurrentInclusionFee()
         ]);
 
         if (dustValueResult.status === 'rejected') {
@@ -256,7 +256,7 @@ const RedeemForm = (): JSX.Element | null => {
             return;
           }
         } else {
-          const vaults = await window.bridge.interBtcApi.vaults.getVaultsWithRedeemableTokens();
+          const vaults = await window.bridge.vaults.getVaultsWithRedeemableTokens();
           vaultId = getRandomVaultIdWithCapacity(Array.from(vaults || new Map()), wrappedTokenAmount);
         }
 
@@ -264,7 +264,7 @@ const RedeemForm = (): JSX.Element | null => {
         const relevantVaults = new Map<InterbtcPrimitivesVaultId, BitcoinAmount>();
         // FIXME: a bit of a dirty workaround with the capacity
         relevantVaults.set(vaultId, wrappedTokenAmount.mul(2));
-        const result = await window.bridge.interBtcApi.redeem.request(
+        const result = await window.bridge.redeem.request(
           wrappedTokenAmount,
           data[BTC_ADDRESS],
           vaultId

--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -81,7 +81,7 @@ const Bridge = (): JSX.Element | null => {
     if (!bridgeLoaded) return;
     (async () => {
       try {
-        const maxBurnableTokens = await window.bridge.interBtcApi.redeem.getMaxBurnableTokens(
+        const maxBurnableTokens = await window.bridge.redeem.getMaxBurnableTokens(
           COLLATERAL_TOKEN as CollateralCurrency
         );
         setBurnable(maxBurnableTokens.gt(BitcoinAmount.zero));

--- a/src/pages/Dashboard/cards/CollateralizationCard/index.tsx
+++ b/src/pages/Dashboard/cards/CollateralizationCard/index.tsx
@@ -55,7 +55,6 @@ const CollateralizationCard = ({ hasLinks }: Props): JSX.Element => {
   } = useQuery<Big, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getSystemCollateralization'
     ],
@@ -74,7 +73,6 @@ const CollateralizationCard = ({ hasLinks }: Props): JSX.Element => {
   } = useQuery<BitcoinAmount, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getTotalIssuableAmount'
     ],
@@ -93,7 +91,6 @@ const CollateralizationCard = ({ hasLinks }: Props): JSX.Element => {
   } = useQuery<Big, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getSecureCollateralThreshold',
       COLLATERAL_TOKEN

--- a/src/pages/Dashboard/cards/OracleStatusCard/index.tsx
+++ b/src/pages/Dashboard/cards/OracleStatusCard/index.tsx
@@ -46,7 +46,6 @@ const OracleStatusCard = ({ hasLinks }: Props): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'oracle',
       'getOnlineTimeout'
     ],

--- a/src/pages/Dashboard/sub-pages/BTCRelay/BlockstreamCard/index.tsx
+++ b/src/pages/Dashboard/sub-pages/BTCRelay/BlockstreamCard/index.tsx
@@ -39,7 +39,6 @@ const BlockstreamCard = (): JSX.Element => {
   } = useQuery<string, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'electrsAPI',
       'getLatestBlock'
     ],

--- a/src/pages/Dashboard/sub-pages/IssueRequests/IssueRequestsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/IssueRequests/IssueRequestsTable/index.tsx
@@ -194,8 +194,8 @@ const IssueRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {
@@ -212,8 +212,8 @@ const IssueRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'latestParachainActiveBlock'
+      'system',
+      'getCurrentActiveBlockNumber'
     ],
     genericFetcher<number>(),
     {
@@ -230,8 +230,8 @@ const IssueRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getParachainConfirmations'
+      'btcRelay',
+      'getStableParachainConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Dashboard/sub-pages/Oracles/OraclesTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Oracles/OraclesTable/index.tsx
@@ -55,7 +55,6 @@ const OracleTable = (): JSX.Element => {
   } = useQuery<Map<string, string>, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'oracle',
       'getSourcesById'
     ],
@@ -74,7 +73,6 @@ const OracleTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'oracle',
       'getOnlineTimeout'
     ],

--- a/src/pages/Dashboard/sub-pages/RedeemRequests/RedeemRequestsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/RedeemRequests/RedeemRequestsTable/index.tsx
@@ -190,8 +190,8 @@ const RedeemRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {
@@ -208,8 +208,8 @@ const RedeemRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'latestParachainActiveBlock'
+      'system',
+      'getCurrentActiveBlockNumber'
     ],
     genericFetcher<number>(),
     {
@@ -226,8 +226,8 @@ const RedeemRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getParachainConfirmations'
+      'btcRelay',
+      'getStableParachainConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
@@ -122,7 +122,6 @@ const VaultsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'system',
       'getCurrentActiveBlockNumber'
     ],
@@ -141,7 +140,6 @@ const VaultsTable = (): JSX.Element => {
   } = useQuery<Big, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getSecureCollateralThreshold',
       COLLATERAL_TOKEN
@@ -161,7 +159,6 @@ const VaultsTable = (): JSX.Element => {
   } = useQuery<Big, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getLiquidationCollateralThreshold',
       COLLATERAL_TOKEN
@@ -189,7 +186,6 @@ const VaultsTable = (): JSX.Element => {
   >(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'oracle',
       'getExchangeRate',
       COLLATERAL_TOKEN
@@ -216,7 +212,6 @@ const VaultsTable = (): JSX.Element => {
   } = useQuery<Array<VaultExt<BitcoinUnit>>, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'list'
     ],

--- a/src/pages/Staking/ClaimRewardsButton/index.tsx
+++ b/src/pages/Staking/ClaimRewardsButton/index.tsx
@@ -12,11 +12,17 @@ import InterlayDenimOrKintsugiMidnightContainedButton, {
 } from 'components/buttons/InterlayDenimOrKintsugiMidnightContainedButton';
 import { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
 import { StoreType } from 'common/types/util.types';
+import { GOVERNANCE_TOKEN_SYMBOL } from 'config/relay-chains';
+
+interface CustomProps {
+  rewardsToClaim: string;
+}
 
 const ClaimRewardsButton = ({
   className,
+  rewardsToClaim,
   ...rest
-}: InterlayDenimOrKintsugiMidnightContainedButtonProps): JSX.Element => {
+}: CustomProps & InterlayDenimOrKintsugiMidnightContainedButtonProps): JSX.Element => {
   const { address } = useSelector((state: StoreType) => state.general);
 
   const queryClient = useQueryClient();
@@ -31,6 +37,12 @@ const ClaimRewardsButton = ({
           GENERIC_FETCHER,
           'escrow',
           'getRewardEstimate',
+          address
+        ]);
+        queryClient.invalidateQueries([
+          GENERIC_FETCHER,
+          'escrow',
+          'getRewards',
           address
         ]);
       }
@@ -55,7 +67,7 @@ const ClaimRewardsButton = ({
         onClick={handleClaimRewards}
         pending={claimRewardsMutation.isLoading}
         {...rest}>
-        Claim Rewards
+        Claim {rewardsToClaim} {GOVERNANCE_TOKEN_SYMBOL} Rewards
       </InterlayDenimOrKintsugiMidnightContainedButton>
       {claimRewardsMutation.isError && (
         <ErrorModal

--- a/src/pages/Staking/ClaimRewardsButton/index.tsx
+++ b/src/pages/Staking/ClaimRewardsButton/index.tsx
@@ -23,13 +23,12 @@ const ClaimRewardsButton = ({
 
   const claimRewardsMutation = useMutation<void, Error, void>(
     () => {
-      return window.bridge.interBtcApi.escrow.withdrawRewards();
+      return window.bridge.escrow.withdrawRewards();
     },
     {
       onSuccess: () => {
         queryClient.invalidateQueries([
           GENERIC_FETCHER,
-          'interBtcApi',
           'escrow',
           'getRewardEstimate',
           address

--- a/src/pages/Staking/WithdrawButton/index.tsx
+++ b/src/pages/Staking/WithdrawButton/index.tsx
@@ -47,13 +47,12 @@ const WithdrawButton = ({
 
   const withdrawMutation = useMutation<void, Error, void>(
     () => {
-      return window.bridge.interBtcApi.escrow.withdraw();
+      return window.bridge.escrow.withdraw();
     },
     {
       onSuccess: () => {
         queryClient.invalidateQueries([
           GENERIC_FETCHER,
-          'interBtcApi',
           'escrow',
           'getStakedBalance',
           address

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -136,7 +136,6 @@ const Staking = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'system',
       'getCurrentBlockNumber'
     ],
@@ -156,7 +155,6 @@ const Staking = (): JSX.Element => {
   } = useQuery<MonetaryAmount<Currency<VoteUnit>, VoteUnit>, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'escrow',
       'votingBalance',
       address
@@ -178,7 +176,6 @@ const Staking = (): JSX.Element => {
   } = useQuery<RewardAmountAndAPY, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'escrow',
       'getRewardEstimate',
       address
@@ -200,7 +197,6 @@ const Staking = (): JSX.Element => {
   } = useQuery<RewardAmountAndAPY, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'escrow',
       'getRewardEstimate',
       address,
@@ -222,7 +218,6 @@ const Staking = (): JSX.Element => {
   } = useQuery<StakedAmountAndEndBlock, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'escrow',
       'getStakedBalance',
       address
@@ -241,7 +236,7 @@ const Staking = (): JSX.Element => {
       }
       const unlockHeight = currentBlockNumber + convertWeeksToBlockNumbers(variables.time);
 
-      return window.bridge.interBtcApi.escrow.createLock(variables.amount, unlockHeight);
+      return window.bridge.escrow.createLock(variables.amount, unlockHeight);
     },
     {
       onSuccess: () => {
@@ -270,29 +265,29 @@ const Staking = (): JSX.Element => {
           const unlockHeight = stakedAmountAndEndBlock.endBlock + convertWeeksToBlockNumbers(variables.time);
 
           const txs = [
-            window.bridge.interBtcApi.api.tx.escrow.increaseAmount(
+            window.bridge.api.tx.escrow.increaseAmount(
               variables.amount.toString(variables.amount.currency.rawBase)
             ),
-            window.bridge.interBtcApi.api.tx.escrow.increaseUnlockHeight(unlockHeight)
+            window.bridge.api.tx.escrow.increaseUnlockHeight(unlockHeight)
           ];
-          const batch = window.bridge.interBtcApi.api.tx.utility.batchAll(txs);
+          const batch = window.bridge.api.tx.utility.batchAll(txs);
           await DefaultTransactionAPI.sendLogged(
-            window.bridge.interBtcApi.api,
-            window.bridge.interBtcApi.account as AddressOrPair,
+            window.bridge.api,
+            window.bridge.account as AddressOrPair,
             batch
           );
         } else if ( // Only increase amount
           variables.time === 0 &&
           variables.amount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
         ) {
-          return await window.bridge.interBtcApi.escrow.increaseAmount(variables.amount);
+          return await window.bridge.escrow.increaseAmount(variables.amount);
         } else if ( // Only extend lock time
           variables.time > 0 &&
           variables.amount.eq(ZERO_GOVERNANCE_TOKEN_AMOUNT)
         ) {
           const unlockHeight = stakedAmountAndEndBlock.endBlock + convertWeeksToBlockNumbers(variables.time);
 
-          return await window.bridge.interBtcApi.escrow.increaseUnlockHeight(unlockHeight);
+          return await window.bridge.escrow.increaseUnlockHeight(unlockHeight);
         } else {
           throw new Error('Something went wrong!');
         }

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/IssueRequestStatusUI/ConfirmedIssueRequest/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/IssueRequestStatusUI/ConfirmedIssueRequest/index.tsx
@@ -49,7 +49,7 @@ const ConfirmedIssueRequest = ({
       if (!variables.btcTxId) {
         throw new Error('Bitcoin transaction ID not identified yet.');
       }
-      return window.bridge.interBtcApi.issue.execute('0x' + variables.id, variables.backingPayment.btcTxId);
+      return window.bridge.issue.execute('0x' + variables.id, variables.backingPayment.btcTxId);
     },
     {
       onSuccess: (_, variables) => {

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/IssueRequestStatusUI/ReceivedIssueRequest/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/IssueRequestStatusUI/ReceivedIssueRequest/index.tsx
@@ -63,7 +63,6 @@ const ReceivedIssueRequest = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'btcRelay',
       'getStableParachainConfirmations'
     ],
@@ -82,7 +81,6 @@ const ReceivedIssueRequest = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'system',
       'getCurrentActiveBlockNumber'
     ],

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/IssueRequestStatusUI/ReceivedIssueRequest/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/IssueRequestStatusUI/ReceivedIssueRequest/index.tsx
@@ -45,8 +45,8 @@ const ReceivedIssueRequest = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Transactions/IssueRequestsTable/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/index.tsx
@@ -80,8 +80,8 @@ const IssueRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {
@@ -98,8 +98,8 @@ const IssueRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'latestParachainActiveBlock'
+      'system',
+      'getCurrentActiveBlockNumber'
     ],
     genericFetcher<number>(),
     {
@@ -116,8 +116,8 @@ const IssueRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getParachainConfirmations'
+      'btcRelay',
+      'getStableParachainConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/DefaultRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/DefaultRedeemRequest/index.tsx
@@ -37,8 +37,8 @@ const DefaultRedeemRequest = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/DefaultRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/DefaultRedeemRequest/index.tsx
@@ -55,7 +55,6 @@ const DefaultRedeemRequest = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'btcRelay',
       'getStableParachainConfirmations'
     ],
@@ -74,7 +73,6 @@ const DefaultRedeemRequest = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'system',
       'getCurrentActiveBlockNumber'
     ],

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/PendingWithBtcTxNotFoundRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/PendingWithBtcTxNotFoundRedeemRequest/index.tsx
@@ -36,7 +36,7 @@ const PendingWithBtcTxNotFoundRedeemRequest = ({
     // TODO: should add loading UX
     (async () => {
       try {
-        const redeemPeriod = await window.bridge.interBtcApi.redeem.getRedeemPeriod();
+        const redeemPeriod = await window.bridge.redeem.getRedeemPeriod();
         const requestTimestamp = Math.floor(new Date(request.request.timestamp).getTime() / 1000);
         const theInitialLeftSeconds = requestTimestamp + (redeemPeriod * BLOCK_TIME) - Math.floor(Date.now() / 1000);
         setInitialLeftSeconds(theInitialLeftSeconds);

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/ReimbursedRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/ReimbursedRedeemRequest/index.tsx
@@ -64,8 +64,8 @@ const ReimbursedRedeemRequest = ({
           punishmentFee,
           btcDotRate
         ] = await Promise.all([
-          window.bridge.interBtcApi.vaults.getPunishmentFee(),
-          window.bridge.interBtcApi.oracle.getExchangeRate(COLLATERAL_TOKEN)
+          window.bridge.vaults.getPunishmentFee(),
+          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN)
         ]);
 
         const burnedBTCAmount = request.request.requestedAmountBacking.add(request.bridgeFee);

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/RetriedRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/RetriedRedeemRequest/index.tsx
@@ -57,8 +57,8 @@ const RetriedRedeemRequest = ({
           punishmentFee,
           btcDotRate
         ] = await Promise.all([
-          window.bridge.interBtcApi.vaults.getPunishmentFee(),
-          window.bridge.interBtcApi.oracle.getExchangeRate(COLLATERAL_TOKEN)
+          window.bridge.vaults.getPunishmentFee(),
+          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN)
         ]);
 
         const btcAmount = request.request.requestedAmountBacking;

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/ReimburseStatusUI/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/ReimburseStatusUI/index.tsx
@@ -76,8 +76,8 @@ const ReimburseStatusUI = ({
           punishment,
           btcDotRate
         ] = await Promise.all([
-          window.bridge.interBtcApi.vaults.getPunishmentFee(),
-          window.bridge.interBtcApi.oracle.getExchangeRate(COLLATERAL_TOKEN)
+          window.bridge.vaults.getPunishmentFee(),
+          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN)
         ]);
         const wrappedTokenAmount = request ? request.request.requestedAmountBacking : BitcoinAmount.zero;
         setCollateralTokenAmount(btcDotRate.toCounter(wrappedTokenAmount));
@@ -96,7 +96,7 @@ const ReimburseStatusUI = ({
   // TODO: should type properly (`Relay`)
   const retryMutation = useMutation<void, Error, any>(
     (variables: any) => {
-      return window.bridge.interBtcApi.redeem.cancel(variables.id, false);
+      return window.bridge.redeem.cancel(variables.id, false);
     },
     {
       onSuccess: () => {
@@ -115,7 +115,7 @@ const ReimburseStatusUI = ({
   // TODO: should type properly (`Relay`)
   const reimburseMutation = useMutation<void, Error, any>(
     (variables: any) => {
-      return window.bridge.interBtcApi.redeem.cancel(variables.id, true);
+      return window.bridge.redeem.cancel(variables.id, true);
     },
     {
       onSuccess: () => {

--- a/src/pages/Transactions/RedeemRequestsTable/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/index.tsx
@@ -74,8 +74,8 @@ const RedeemRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {
@@ -92,8 +92,8 @@ const RedeemRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'latestParachainActiveBlock'
+      'system',
+      'getCurrentActiveBlockNumber'
     ],
     genericFetcher<number>(),
     {
@@ -110,8 +110,8 @@ const RedeemRequestsTable = (): JSX.Element => {
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getParachainConfirmations'
+      'btcRelay',
+      'getStableParachainConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Transfer/TransferForm/index.tsx
+++ b/src/pages/Transfer/TransferForm/index.tsx
@@ -70,7 +70,7 @@ const TransferForm = (): JSX.Element => {
     try {
       setSubmitStatus(STATUSES.PENDING);
 
-      await window.bridge.interBtcApi.tokens.transfer(
+      await window.bridge.tokens.transfer(
         data[RECIPIENT_ADDRESS],
         newMonetaryAmount(data[TRANSFER_AMOUNT], activeToken.token as Currency<CurrencyUnit>, true)
       );

--- a/src/pages/Vault/ReplaceTable/index.tsx
+++ b/src/pages/Vault/ReplaceTable/index.tsx
@@ -58,7 +58,7 @@ const ReplaceTable = ({
   const { t } = useTranslation();
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
-  const vaultId = window.bridge?.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, vaultAddress);
+  const vaultId = window.bridge?.api.createType(ACCOUNT_ID_TYPE_NAME, vaultAddress);
   const {
     isIdle: replaceRequestsIdle,
     isLoading: replaceRequestsLoading,
@@ -67,7 +67,6 @@ const ReplaceTable = ({
   } = useQuery<Map<H256, ReplaceRequestExt>, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'replace',
       'mapReplaceRequests',
       vaultId

--- a/src/pages/Vault/RequestReplacementModal/index.tsx
+++ b/src/pages/Vault/RequestReplacementModal/index.tsx
@@ -58,18 +58,16 @@ const RequestReplacementModal = ({
       if (BitcoinAmount.from.BTC(data[AMOUNT]).to.Satoshi() === undefined) {
         throw new Error('Amount to convert is less than 1 satoshi.');
       }
-      const dustValue = await window.bridge.interBtcApi.redeem.getDustValue();
+      const dustValue = await window.bridge.redeem.getDustValue();
       const amountPolkaBtc = BitcoinAmount.from.BTC(data[AMOUNT]);
       if (amountPolkaBtc.lte(dustValue)) {
         throw new Error(`Please enter an amount greater than Bitcoin dust (${displayMonetaryAmount(dustValue)} BTC)`);
       }
-      await window.bridge.interBtcApi.replace.request(amountPolkaBtc, COLLATERAL_TOKEN as CollateralCurrency);
+      await window.bridge.replace.request(amountPolkaBtc, COLLATERAL_TOKEN as CollateralCurrency);
 
-      const vaultId = window.bridge.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, vaultAddress);
+      const vaultId = window.bridge.api.createType(ACCOUNT_ID_TYPE_NAME, vaultAddress);
       queryClient.invalidateQueries([
         GENERIC_FETCHER,
-        'interBtcApi',
-        'replace',
         'mapReplaceRequests',
         vaultId
       ]);

--- a/src/pages/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vault/UpdateCollateralModal/index.tsx
@@ -97,7 +97,7 @@ const UpdateCollateralModal = ({
   const [submitStatus, setSubmitStatus] = React.useState(STATUSES.IDLE);
   const handleError = useErrorHandler();
 
-  const vaultId = window.bridge.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, vaultAddress);
+  const vaultId = window.bridge.api.createType(ACCOUNT_ID_TYPE_NAME, vaultAddress);
 
   const {
     isIdle: requiredCollateralTokenAmountIdle,
@@ -107,7 +107,6 @@ const UpdateCollateralModal = ({
   } = useQuery<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getRequiredCollateralForVault',
       vaultId,
@@ -144,7 +143,6 @@ const UpdateCollateralModal = ({
   } = useQuery<Big, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcApi',
       'vaults',
       'getVaultCollateralization',
       vaultId,
@@ -165,14 +163,14 @@ const UpdateCollateralModal = ({
       setSubmitStatus(STATUSES.PENDING);
       const collateralTokenAmount = newMonetaryAmount(data[COLLATERAL_TOKEN_AMOUNT], COLLATERAL_TOKEN, true);
       if (collateralUpdateStatus === CollateralUpdateStatus.Deposit) {
-        await window.bridge.interBtcApi.vaults.depositCollateral(collateralTokenAmount);
+        await window.bridge.vaults.depositCollateral(collateralTokenAmount);
       } else if (collateralUpdateStatus === CollateralUpdateStatus.Withdraw) {
-        await window.bridge.interBtcApi.vaults.withdrawCollateral(collateralTokenAmount);
+        await window.bridge.vaults.withdrawCollateral(collateralTokenAmount);
       } else {
         throw new Error('Something went wrong!');
       }
 
-      const balanceLockedDOT = (await window.bridge.interBtcApi.tokens.balance(COLLATERAL_TOKEN, vaultId)).reserved;
+      const balanceLockedDOT = (await window.bridge.tokens.balance(COLLATERAL_TOKEN, vaultId)).reserved;
       dispatch(updateCollateralAction(balanceLockedDOT));
 
       if (vaultCollateralization === undefined) {

--- a/src/pages/Vault/VaultIssueRequestsTable/index.tsx
+++ b/src/pages/Vault/VaultIssueRequestsTable/index.tsx
@@ -66,8 +66,8 @@ const VaultIssueRequestsTable = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {
@@ -84,8 +84,8 @@ const VaultIssueRequestsTable = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'latestParachainActiveBlock'
+      'system',
+      'getCurrentActiveBlockNumber'
     ],
     genericFetcher<number>(),
     {
@@ -102,8 +102,8 @@ const VaultIssueRequestsTable = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getParachainConfirmations'
+      'btcRelay',
+      'getStableParachainConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Vault/VaultRedeemRequestsTable/index.tsx
+++ b/src/pages/Vault/VaultRedeemRequestsTable/index.tsx
@@ -66,8 +66,8 @@ const VaultRedeemRequestsTable = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getBtcConfirmations'
+      'btcRelay',
+      'getStableBitcoinConfirmations'
     ],
     genericFetcher<number>(),
     {
@@ -84,8 +84,8 @@ const VaultRedeemRequestsTable = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'latestParachainActiveBlock'
+      'system',
+      'getCurrentActiveBlockNumber'
     ],
     genericFetcher<number>(),
     {
@@ -102,8 +102,8 @@ const VaultRedeemRequestsTable = ({
   } = useQuery<number, Error>(
     [
       GENERIC_FETCHER,
-      'interBtcIndex',
-      'getParachainConfirmations'
+      'btcRelay',
+      'getStableParachainConfirmations'
     ],
     genericFetcher<number>(),
     {

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -99,7 +99,7 @@ const Vault = (): JSX.Element => {
       if (!selectedVaultAddress) return;
 
       try {
-        const vaultId = window.bridge.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, selectedVaultAddress);
+        const vaultId = window.bridge.api.createType(ACCOUNT_ID_TYPE_NAME, selectedVaultAddress);
         const collateralIdLiteral = tickerToCurrencyIdLiteral(COLLATERAL_TOKEN.ticker) as CollateralIdLiteral;
         const wrappedIdLiteral = tickerToCurrencyIdLiteral(WRAPPED_TOKEN.ticker) as WrappedIdLiteral;
         const [
@@ -110,16 +110,16 @@ const Vault = (): JSX.Element => {
           apyScore,
           issuableAmount
         ] = await Promise.allSettled([
-          window.bridge.interBtcApi.vaults.get(vaultId, collateralIdLiteral),
-          window.bridge.interBtcApi.vaults.getWrappedReward(
-            newAccountId(window.bridge.interBtcApi.api, selectedVaultAddress),
+          window.bridge.vaults.get(vaultId, collateralIdLiteral),
+          window.bridge.vaults.getWrappedReward(
+            newAccountId(window.bridge.api, selectedVaultAddress),
             collateralIdLiteral,
             wrappedIdLiteral
           ),
-          window.bridge.interBtcApi.vaults.getIssuedAmount(vaultId, collateralIdLiteral),
-          window.bridge.interBtcApi.vaults.getVaultCollateralization(vaultId, collateralIdLiteral),
-          window.bridge.interBtcApi.vaults.getAPY(vaultId, collateralIdLiteral),
-          window.bridge.interBtcApi.issue.getVaultIssuableAmount(vaultId, collateralIdLiteral)
+          window.bridge.vaults.getIssuedAmount(vaultId, collateralIdLiteral),
+          window.bridge.vaults.getVaultCollateralization(vaultId, collateralIdLiteral),
+          window.bridge.vaults.getAPY(vaultId, collateralIdLiteral),
+          window.bridge.issue.getVaultIssuableAmount(vaultId, collateralIdLiteral)
         ]);
 
         if (vault.status === 'fulfilled') {

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -64,7 +64,7 @@ const AccountModal = ({
     // TODO: should check when the app being initialized (not check everywhere)
     await web3Enable(APP_NAME);
     const { signer } = await web3FromAddress(newAddress);
-    window.bridge.interBtcApi.setAccount(newAddress, signer);
+    window.bridge.setAccount(newAddress, signer);
     dispatch(changeAddressAction(newAddress));
 
     onClose();

--- a/src/parts/Topbar/index.tsx
+++ b/src/parts/Topbar/index.tsx
@@ -55,7 +55,7 @@ const Topbar = (): JSX.Element => {
 
     try {
       const governanceIdLiteral = tickerToCurrencyIdLiteral(GOVERNANCE_TOKEN.ticker) as CollateralIdLiteral;
-      const receiverId = window.bridge.polkadotApi.createType(ACCOUNT_ID_TYPE_NAME, address);
+      const receiverId = window.bridge.api.createType(ACCOUNT_ID_TYPE_NAME, address);
       await window.faucet.fundAccount(receiverId, governanceIdLiteral);
       toast.success('Your account has been funded.');
     } catch (error) {

--- a/src/services/fetchers/generic-fetcher.ts
+++ b/src/services/fetchers/generic-fetcher.ts
@@ -16,24 +16,25 @@ const GENERIC_FETCHER = 'generic-fetcher';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const genericFetcher = <T>() => async ({ queryKey }: any): Promise<T> => {
-  if (queryKey[1] === 'interBtcApi') {
-    const [
-      _key,
-      arg1,
-      arg2,
-      arg3,
-      ...rest
-    ] = queryKey;
-
-    if (_key !== GENERIC_FETCHER) {
-      throw new Error('Invalid key!');
-    }
-
-    // TODO: should type properly
-    return await window.bridge[arg1][arg2][arg3](...rest);
-  }
   if (queryKey[1] === 'interBtcIndex') {
     throw new Error('Unsupported indexer!');
+  }
+  const [
+    _key,
+    arg1,
+    arg2,
+    ...rest
+  ] = queryKey;
+
+  if (_key !== GENERIC_FETCHER) {
+    throw new Error('Invalid key!');
+  }
+
+  try {
+    // TODO: should type properly
+    return await window.bridge[arg1][arg2](...rest);
+  } catch (error) {
+    throw new Error(`Error fetching ${arg1}.${arg2}(). ${error}`);
   }
 };
 

--- a/src/services/fetchers/generic-fetcher.ts
+++ b/src/services/fetchers/generic-fetcher.ts
@@ -34,7 +34,7 @@ const genericFetcher = <T>() => async ({ queryKey }: any): Promise<T> => {
     // TODO: should type properly
     return await window.bridge[arg1][arg2](...rest);
   } catch (error) {
-    throw new Error(`Error fetching ${arg1}.${arg2}(). ${error}`);
+    throw new Error(`Error fetching ${queryKey}}). ${error}`);
   }
 };
 

--- a/src/services/fetchers/generic-fetcher.ts
+++ b/src/services/fetchers/generic-fetcher.ts
@@ -33,21 +33,8 @@ const genericFetcher = <T>() => async ({ queryKey }: any): Promise<T> => {
     return await window.bridge[arg1][arg2][arg3](...rest);
   }
   if (queryKey[1] === 'interBtcIndex') {
-    const [
-      _key,
-      arg1,
-      arg2,
-      ...rest
-    ] = queryKey;
-
-    if (_key !== GENERIC_FETCHER) {
-      throw new Error('Invalid key!');
-    }
-
-    return await window.bridge[arg1][arg2](...rest);
+    throw new Error('Unsupported indexer!');
   }
-
-  throw new Error('Something went wrong!');
 };
 
 export {

--- a/src/services/fetchers/issue-request-fetcher.ts
+++ b/src/services/fetchers/issue-request-fetcher.ts
@@ -61,7 +61,7 @@ const issueFetcher = async ({ queryKey }: any): Promise<Array<any>> => {
   return await Promise.all(issues.map(async issue => {
     issue = decodeIssueValues(issue);
     issue.backingPayment = await getTxDetailsForRequest(
-      window.bridge.interBtcApi.electrsAPI,
+      window.bridge.electrsAPI,
       issue.id,
       issue.vaultBackingAddress,
       stableBtcConfirmations

--- a/src/services/fetchers/oracle-exchange-rates-fetcher.ts
+++ b/src/services/fetchers/oracle-exchange-rates-fetcher.ts
@@ -1,5 +1,5 @@
 import { CurrencyUnit, decodeFixedPointType } from '@interlay/interbtc-api';
-import { OracleStatus } from '@interlay/interbtc/build/oracleTypes';
+import { OracleStatus } from '@interlay/interbtc-api/build/src/types/oracleTypes';
 import {
   Currency,
   ExchangeRate,

--- a/src/services/fetchers/redeem-request-fetcher.ts
+++ b/src/services/fetchers/redeem-request-fetcher.ts
@@ -64,7 +64,7 @@ const redeemFetcher = async ({ queryKey }: any): Promise<Array<any>> => {
   return await Promise.all(redeems.map(async redeem => {
     redeem = decodeRedeemValues(redeem);
     redeem.backingPayment = await getTxDetailsForRequest(
-      window.bridge.interBtcApi.electrsAPI,
+      window.bridge.electrsAPI,
       redeem.id,
       redeem.vaultBackingAddress,
       stableBtcConfirmations,

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,14 +4,13 @@ import {
   createStore
 } from 'redux';
 import { persistStore } from 'redux-persist';
-import { InterBtc } from '@interlay/interbtc';
-import { FaucetClient } from '@interlay/interbtc-api';
+import { InterBtcApi, FaucetClient } from '@interlay/interbtc-api';
 
 import { rootReducer } from './common/reducers/index';
 
 declare global {
   interface Window {
-    bridge: InterBtc;
+    bridge: InterBtcApi;
     faucet: FaucetClient;
     isFetchingActive: boolean;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,10 +158,10 @@
     browserslist "^4.17.5"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.1":
-  version "7.17.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.1.tgz#9699f14a88833a7e055ce57dcd3ffdcd25186b21"
-  integrity sha512-JBdSr/LtyYIno/pNnJ75lBcqc3Z1XXujzPanHqjvvrhOA+DTceTFuJi8XjmWTZh4r3fsdfqaCMN0iZemdkxZHQ==
+"@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.1", "@babel/helper-create-class-features-plugin@^7.17.6":
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz#3778c1ed09a7f3e65e6d6e0f6fbfcc53809d92c9"
+  integrity sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
     "@babel/helper-environment-visitor" "^7.16.7"
@@ -259,9 +259,9 @@
     "@babel/types" "^7.16.7"
 
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz#7665faeb721a01ca5327ddc6bba15a5cb34b6a41"
-  integrity sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz#3c3b03cc6617e33d68ef5a27a67419ac5199ccd0"
+  integrity sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==
   dependencies:
     "@babel/helper-environment-visitor" "^7.16.7"
     "@babel/helper-module-imports" "^7.16.7"
@@ -269,8 +269,8 @@
     "@babel/helper-split-export-declaration" "^7.16.7"
     "@babel/helper-validator-identifier" "^7.16.7"
     "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
 
 "@babel/helper-optimise-call-expression@^7.16.7":
   version "7.16.7"
@@ -407,11 +407,11 @@
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-proposal-class-static-block@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.7.tgz#712357570b612106ef5426d13dc433ce0f200c2a"
-  integrity sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.6.tgz#164e8fd25f0d80fa48c5a4d1438a6629325ad83c"
+  integrity sha512-X/tididvL2zbs7jZCeeRJ8167U/+Ac135AM6jCAx6gYXDUviZV5Ku9UDvWS2NCuWlFjIRXklYhwo6HhAC7ETnA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.16.7"
+    "@babel/helper-create-class-features-plugin" "^7.17.6"
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
@@ -893,9 +893,9 @@
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-react-constant-elements@^7.12.1":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.16.7.tgz#19e9e4c2df2f6c3e6b3aea11778297d81db8df62"
-  integrity sha512-lF+cfsyTgwWkcw715J88JhMYJ5GpysYNLhLP1PkvkhTRN7B3e74R/1KsDxFxhRpSn0UUD3IWM4GvdBR2PEbbQQ==
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.17.6.tgz#6cc273c2f612a6a50cb657e63ee1303e5e68d10a"
+  integrity sha512-OBv9VkyyKtsHZiHLoSfCn+h6yU7YKX8nrs32xUmOa1SRSk+t03FosB6fBZ0Yz4BpD1WV7l73Nsad+2Tz7APpqw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
@@ -1425,9 +1425,9 @@
   integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
 
 "@heroicons/react@^1.0.3":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.5.tgz#2fe4df9d33eb6ce6d5178a0f862e97b61c01e27d"
-  integrity sha512-UDMyLM2KavIu2vlWfMspapw9yii7aoLwzI2Hudx4fyoPwfKfxU8r3cL8dEBXOjcLG0/oOONZzbT14M1HoNtEcg==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"
+  integrity sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -1450,10 +1450,8 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-1.6.1.tgz#31d1fd57204dd946f32a12d262447072b752fb58"
-  integrity sha512-x1tIwB00PCOgbfS/imviekaltcL2LFzf01fLUZKJZFnlLvpbAnthHq4rKoSOsIFKS6mzxtKLu11KJJeZkLzRyw==
+"@interlay/interbtc-api@../api":
+  version "1.7.0"
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "1.5.10"
@@ -1470,30 +1468,10 @@
     sinon "^9.0.3"
     ts-mock-imports "^1.3.0"
 
-"@interlay/interbtc-index-client@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-index-client/-/interbtc-index-client-1.6.0.tgz#2f3fbc3bcc29e76fab773f68f8fe1411a441d26a"
-  integrity sha512-MnyutEkgOvHnse++mul+HNuGCb3GlNPcO0xRXAeC4yTSeyCKihlOC1MfIiymedieVkksnUt19lq3xS60SyKaOw==
-
-"@interlay/interbtc-types@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-types/-/interbtc-types-1.3.0.tgz#c6741a46a98e9696e66d8fc416491c898833e789"
-  integrity sha512-HFWQMsEQSlBO0yAuteWheV0jFHZOioDBnxZltVlmmgcLIPfQkbrKF7iv4viVU26BcKqUbKk8FY5+nCj3xZ0WJg==
-
 "@interlay/interbtc-types@1.5.10":
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/@interlay/interbtc-types/-/interbtc-types-1.5.10.tgz#8ff123e7886df06776e090deacca5c1b84ecf315"
   integrity sha512-7pUzNKmNeHi74uJl9WBoYzwyKh8+X18wZz9MVDvx58SgkDiEjUpyeafjhcmVhJptaB+OwPJ1V76RDbJRxr0T4w==
-
-"@interlay/interbtc@1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc/-/interbtc-1.6.2.tgz#cc098a461a631c2c7b7756610cef589177069000"
-  integrity sha512-GGBnjzr37kFYi+Ak1t6nBkUwJGJ6YM6y7ljYRcIaZDKR0bXt/klGz5bY7xiaTfLAW/uC5Fsi8LrfHYJefNHokw==
-  dependencies:
-    "@interlay/interbtc-api" "1.6.1"
-    "@interlay/interbtc-index-client" "1.6.0"
-    "@interlay/interbtc-types" "1.3.0"
-    "@interlay/monetary-js" "0.5.3"
 
 "@interlay/monetary-js@0.5.3":
   version "0.5.3"
@@ -2092,14 +2070,14 @@
     nock "^13.2.4"
 
 "@polkadot/rpc-provider@^7.5.1":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-7.9.1.tgz#1dd6e64c69a397ad117d2d9c2dbf14a9339b0fc0"
-  integrity sha512-gDcWFxzea5sfjEOCiO3rRRGxWYiUzlcra8PK/aS0H7GU6QnYNi7VXQY4fgM0VZbo1tkrw0+lBlpXrEZcPAP6Qg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-7.11.1.tgz#f0cf70c4fa3b69fb96aafbed07f8d5725db9cca8"
+  integrity sha512-07Mg+r9swMjNISDK8ntDI5gFZU8rtHeoB27/qQwZzcWugogva8rNhaInBikZPKlF7yxM6l2VMaQnOziKUNsnRw==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "7.9.1"
-    "@polkadot/types-support" "7.9.1"
+    "@polkadot/types" "7.11.1"
+    "@polkadot/types-support" "7.11.1"
     "@polkadot/util" "^8.4.1"
     "@polkadot/util-crypto" "^8.4.1"
     "@polkadot/x-fetch" "^8.4.1"
@@ -2108,6 +2086,16 @@
     eventemitter3 "^4.0.7"
     mock-socket "^9.1.2"
     nock "^13.2.4"
+
+"@polkadot/types-augment@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-7.11.1.tgz#2c56779dbd1cff509609db912fcc2575e0983828"
+  integrity sha512-jCnZ/eMkLaqSKl5q4JwBxslhAaJSSNHt04reZRs1i2jlC2UVgiFN1Rr5GJmHYAwDPoFcge/rAm6bckfhXUIdOw==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@polkadot/types" "7.11.1"
+    "@polkadot/types-codec" "7.11.1"
+    "@polkadot/util" "^8.4.1"
 
 "@polkadot/types-augment@7.7.1":
   version "7.7.1"
@@ -2119,14 +2107,12 @@
     "@polkadot/types-codec" "7.7.1"
     "@polkadot/util" "^8.3.3"
 
-"@polkadot/types-augment@7.9.1":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-7.9.1.tgz#a7ba01d89d6a80fa3a403c31c26ecad28e6dbcfa"
-  integrity sha512-2dl7CzgEBgGSjcqNcH2F2ZIlGVkf/mtbvu8ObmVw4z/ojpRLv26MO2TexF6fUMAFi7uNnq4r4yB9NsAxdUv2ZQ==
+"@polkadot/types-codec@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-7.11.1.tgz#4cfcd8ab81f6ba510a984c08eb11861b33acab38"
+  integrity sha512-rDM/FYcnou2Chy+urd7U41lcjM6jWUEUydyP9NuTOSAamCGtH0eKw52GURKTsKTT5r8wJdPMKv/yNxs1i+l5Lw==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@polkadot/types" "7.9.1"
-    "@polkadot/types-codec" "7.9.1"
     "@polkadot/util" "^8.4.1"
 
 "@polkadot/types-codec@7.7.1":
@@ -2137,12 +2123,13 @@
     "@babel/runtime" "^7.17.0"
     "@polkadot/util" "^8.3.3"
 
-"@polkadot/types-codec@7.9.1":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-7.9.1.tgz#b41c090cce86c3416ded572c2d38beec00b69408"
-  integrity sha512-wFSvVrBuk7s8SF1pIs1ftwE0B1TpU2CuWy/AGCh4TG510nbrpCh7DaJQJKfsRXprpbo08ybkocT2p6Snv6SIOA==
+"@polkadot/types-create@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-7.11.1.tgz#878b5bdf278ca9456195980aa91957979a4e9342"
+  integrity sha512-nVYaJC/IDsM4WM9WGjAI7qQ9scPSlBqqzwqLdvXCJeq3trOTt68x39DD0zp0hzJ/7MeXjPToDDWjpAF0B9mWSQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
+    "@polkadot/types-codec" "7.11.1"
     "@polkadot/util" "^8.4.1"
 
 "@polkadot/types-create@7.7.1":
@@ -2153,15 +2140,6 @@
     "@babel/runtime" "^7.17.0"
     "@polkadot/types-codec" "7.7.1"
     "@polkadot/util" "^8.3.3"
-
-"@polkadot/types-create@7.9.1":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-7.9.1.tgz#75575a30a6dc761aee5d4b7bac33d38493349bc2"
-  integrity sha512-/l0EIMrtQFlD7mltwyWv2GuZiOYCHWOSvMMIYSocmhijKIBlJb0Wsn5RIpmUaDojYre01tx5NSwnLH82uTK6mQ==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/types-codec" "7.9.1"
-    "@polkadot/util" "^8.4.1"
 
 "@polkadot/types-known@7.7.1":
   version "7.7.1"
@@ -2175,6 +2153,14 @@
     "@polkadot/types-create" "7.7.1"
     "@polkadot/util" "^8.3.3"
 
+"@polkadot/types-support@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-7.11.1.tgz#509d942c8a9c0670a20b77fc1c98c97b7151b75e"
+  integrity sha512-pJmDUHK7DOO6mjpntxq9Lq0tjvqwc15FrrrNbuENgRiOueRqcAlzv+V80wdzoIBUwINgKphtpzu+rdQIYsVVQg==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@polkadot/util" "^8.4.1"
+
 "@polkadot/types-support@7.7.1":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-7.7.1.tgz#bbd36a00a75c68cb332bd489a229144b0df55cfc"
@@ -2183,13 +2169,19 @@
     "@babel/runtime" "^7.17.0"
     "@polkadot/util" "^8.3.3"
 
-"@polkadot/types-support@7.9.1":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-7.9.1.tgz#e883bec5ac5c1787083a0c8b8bb883f7eff546a0"
-  integrity sha512-WO0xE2P01KqfQ7vJH0DGRYeK/UdIEKakJLdm7Js5zXoWwAtjSJ9Xk66F6TOpqnji5dvYlVcEA0t3a5NgivuzcQ==
+"@polkadot/types@7.11.1", "@polkadot/types@^7.5.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-7.11.1.tgz#aefdd0efa98b43ebf516947a845e12fc5d63e9ae"
+  integrity sha512-jxVrxIbsSfH9xK1Q3vaCfJmbkm0OlvoXz0GxdP5RJ7dQnxlNYWQUXanFkKebbRL8gSEs1wSRVccil/TSH65Nvg==
   dependencies:
     "@babel/runtime" "^7.17.2"
+    "@polkadot/keyring" "^8.4.1"
+    "@polkadot/types-augment" "7.11.1"
+    "@polkadot/types-codec" "7.11.1"
+    "@polkadot/types-create" "7.11.1"
     "@polkadot/util" "^8.4.1"
+    "@polkadot/util-crypto" "^8.4.1"
+    rxjs "^7.5.4"
 
 "@polkadot/types@7.7.1":
   version "7.7.1"
@@ -2204,20 +2196,6 @@
     "@polkadot/util" "^8.3.3"
     "@polkadot/util-crypto" "^8.3.3"
     rxjs "^7.5.2"
-
-"@polkadot/types@7.9.1", "@polkadot/types@^7.5.1":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-7.9.1.tgz#db133d405a25b193b2b14c4ec4dcbc600014568e"
-  integrity sha512-yyBMqPh3pmEWY+G5XWwO8HK6Xh80rrrPiq+BoggPIue8c9ecrXhwRbOyzah7Gk4/Mq2My7nwsDwyhqJfwkUtKw==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types-augment" "7.9.1"
-    "@polkadot/types-codec" "7.9.1"
-    "@polkadot/types-create" "7.9.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    rxjs "^7.5.4"
 
 "@polkadot/util-crypto@8.4.1", "@polkadot/util-crypto@^8.3.3", "@polkadot/util-crypto@^8.4.1":
   version "8.4.1"
@@ -3701,11 +3679,11 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*":
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
-  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
   dependencies:
-    jest-diff "^27.0.0"
+    jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
 "@types/jest@^26.0.15":
@@ -3757,9 +3735,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "17.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.18.tgz#3b4fed5cfb58010e3a2be4b6e74615e4847f1074"
-  integrity sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
 "@types/node@10.12.18":
   version "10.12.18"
@@ -3767,9 +3745,9 @@
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
 "@types/node@^12.0.0":
-  version "12.20.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.46.tgz#7e49dee4c54fd19584e6a9e0da5f3dc2e9136bc7"
-  integrity sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A==
+  version "12.20.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
+  integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
 
 "@types/node@^14.0.10":
   version "14.18.12"
@@ -3858,9 +3836,9 @@
     redux "^4.0.0"
 
 "@types/react-redux@^7.1.20":
-  version "7.1.22"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
-  integrity sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==
+  version "7.1.23"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.23.tgz#3c2bb1bcc698ae69d70735f33c5a8e95f41ac528"
+  integrity sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
@@ -3943,9 +3921,9 @@
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
 
 "@types/testing-library__jest-dom@^5.9.1":
-  version "5.14.2"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz#564fb2b2dc827147e937a75b639a05d17ce18b44"
-  integrity sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==
+  version "5.14.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz#ee6c7ffe9f8595882ee7bda8af33ae7b8789ef17"
+  integrity sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==
   dependencies:
     "@types/jest" "*"
 
@@ -3995,9 +3973,9 @@
     "@types/node" "*"
 
 "@types/yargs-parser@*":
-  version "20.2.1"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
-  integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
 "@types/yargs@^15.0.0":
   version "15.0.14"
@@ -4340,7 +4318,7 @@ acorn@^7.0.0, acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.4, acorn@^8.2.4, acorn@^8.4.1:
+acorn@^8.0.4, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
@@ -5453,12 +5431,12 @@ browserslist@4.14.2:
     node-releases "^1.1.61"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.17.5, browserslist@^4.19.1, browserslist@^4.6.2, browserslist@^4.6.4:
-  version "4.19.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.3.tgz#29b7caad327ecf2859485f696f9604214bedd383"
-  integrity sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.0.tgz#35951e3541078c125d36df76056e94738a52ebe9"
+  integrity sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==
   dependencies:
-    caniuse-lite "^1.0.30001312"
-    electron-to-chromium "^1.4.71"
+    caniuse-lite "^1.0.30001313"
+    electron-to-chromium "^1.4.76"
     escalade "^3.1.1"
     node-releases "^2.0.2"
     picocolors "^1.0.0"
@@ -5712,10 +5690,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001312:
-  version "1.0.30001312"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz#e11eba4b87e24d22697dae05455d5aea28550d5f"
-  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001313:
+  version "1.0.30001313"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz#a380b079db91621e1b7120895874e2fd62ed2e2f"
+  integrity sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -6393,12 +6371,12 @@ core-util-is@~1.0.0:
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cosmiconfig-typescript-loader@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.5.tgz#22373003194a1887bbccbdfd05a13501397109a8"
-  integrity sha512-FL/YR1nb8hyN0bAcP3MBaIoZravfZtVsN/RuPnoo6UVjqIrDxSNIpXHCGgJe0ZWy5yImpyD6jq5wCJ5f1nUv8g==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.6.tgz#6d879cece8063b15ec8a3258f55a8e94893c7cca"
+  integrity sha512-2nEotziYJWtNtoTjKbchj9QrdTT6DBxCvqjNKoDKARw+e2yZmTQCa07uRrykLIZuvSgp69YXLH89UHc0WhdMfQ==
   dependencies:
     cosmiconfig "^7"
-    ts-node "^10.5.0"
+    ts-node "^10.6.0"
 
 cosmiconfig@^5.0.0:
   version "5.2.1"
@@ -6818,14 +6796,14 @@ cssstyle@^2.3.0:
     cssom "~0.3.6"
 
 csstype@^2.5.7:
-  version "2.6.19"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
-  integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
+  version "2.6.20"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.20.tgz#9229c65ea0b260cf4d3d997cb06288e36a8d6dda"
+  integrity sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==
 
 csstype@^3.0.2, csstype@^3.0.6:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
-  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -6897,7 +6875,7 @@ debug@4.3.1:
   dependencies:
     ms "2.1.2"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -7066,9 +7044,9 @@ des.js@^1.0.0:
     minimalistic-assert "^1.0.0"
 
 destroy@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.1.0.tgz#b77ae22e472d85437141319d32ae40b344dff38a"
-  integrity sha512-R5QZrOXxSs0JDUIU/VANvRJlQVMts9C0L76HToQdPdlftfZCE7W6dyH0G4GZ5UW9fRqUOhAoCE2aGekuu+3HjQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.1.1.tgz#38a65ed2f2615ad12bf59c6b5e885512c0cf13dd"
+  integrity sha512-jxwFW+yrVOLdwqIWvowFOM8UPdhZnvOF6mhXQQLXMxBDLtv2JVJlVJPEwkDv9prqscEtGtmnxuuI6pQKStK1vA==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -7207,9 +7185,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dom-accessibility-api@^0.5.6:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz#79d5846c4f90eba3e617d9031e921de9324f84ed"
-  integrity sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
+  integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -7382,10 +7360,10 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.71:
-  version "1.4.71"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz#17056914465da0890ce00351a3b946fd4cd51ff6"
-  integrity sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==
+electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.76:
+  version "1.4.76"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz#a0494baedaf51094b1c172999919becd9975a934"
+  integrity sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7578,20 +7556,20 @@ es-to-primitive@^1.2.1:
     is-symbol "^1.0.2"
 
 es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
+  version "0.10.56"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.56.tgz#fd76bc935212203a83fef35bb58cddde26ae6c3c"
+  integrity sha512-YUhqzoMnIjMW5y8FzaMxsCu0eWCwq32GrlwhOhbQmL5OiZReWFm/KvRiYuvqf3CaG/zZ36Kyb4KfVe674cafCQ==
   dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    next-tick "^1.1.0"
 
 es5-shim@^4.5.13:
   version "4.6.5"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.6.5.tgz#2124bb073b7cede2ed23b122a1fd87bb7b0bb724"
   integrity sha512-vfQ4UAai8szn0sAubCy97xnZ4sJVDD1gt/Grn736hg8D7540wemIb1YPrYZSTqlM2H69EQX1or4HU/tSwRTI3w==
 
-es6-iterator@2.0.3, es6-iterator@~2.0.3:
+es6-iterator@2.0.3, es6-iterator@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
   integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
@@ -7605,7 +7583,7 @@ es6-shim@^0.35.5:
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.6.tgz#d10578301a83af2de58b9eadb7c2c9945f7388a0"
   integrity sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==
 
-es6-symbol@^3.1.1, es6-symbol@~3.1.3:
+es6-symbol@^3.1.1, es6-symbol@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
   integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
@@ -7750,21 +7728,21 @@ eslint-plugin-react-hooks@^4.2.0:
   integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
 
 eslint-plugin-react@^7.21.5:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz#8f3ff450677571a659ce76efc6d80b6a525adbdf"
-  integrity sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz#f4eab757f2756d25d6d4c2a58a9e20b004791f05"
+  integrity sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flatmap "^1.2.5"
     doctrine "^2.1.0"
     estraverse "^5.3.0"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     object.entries "^1.1.5"
     object.fromentries "^2.0.5"
     object.hasown "^1.1.0"
     object.values "^1.1.5"
-    prop-types "^15.7.2"
+    prop-types "^15.8.1"
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
@@ -7956,7 +7934,7 @@ events@^3.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource@^1.0.7:
+eventsource@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.0.tgz#00e8ca7c92109e94b0ddf32dac677d841028cfaf"
   integrity sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==
@@ -8213,7 +8191,7 @@ fault@^1.0.0:
   dependencies:
     format "^0.2.0"
 
-faye-websocket@^0.11.3:
+faye-websocket@^0.11.3, faye-websocket@^0.11.4:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
   integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
@@ -8525,9 +8503,9 @@ fs-extra@^0.30.0:
     rimraf "^2.2.8"
 
 fs-extra@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
-  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.1.tgz#27de43b4320e833f6867cc044bfce29fdf0ef3b8"
+  integrity sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -8973,9 +8951,9 @@ has-glob@^1.0.0:
     is-glob "^3.0.0"
 
 has-symbols@^1.0.1, has-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
-  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -9128,9 +9106,9 @@ highlight.js@^10.1.1, highlight.js@~10.7.0:
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 history@*, history@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.2.0.tgz#7cdd31cf9bac3c5d31f09c231c9928fad0007b7c"
-  integrity sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
   dependencies:
     "@babel/runtime" "^7.7.6"
 
@@ -9333,9 +9311,9 @@ http-errors@~1.6.2:
     statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.5.1:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.5.tgz#d7c30d5d3c90d865b4a2e870181f9d6f22ac7ac5"
-  integrity sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.6.tgz#2e02406ab2df8af8a7abfba62e0da01c62b95afd"
+  integrity sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -10310,7 +10288,7 @@ jest-diff@^26.0.0, jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-diff@^27.0.0:
+jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -10435,6 +10413,16 @@ jest-matcher-utils@^26.6.0, jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-message-util@^26.6.0, jest-message-util@^26.6.2:
   version "26.6.2"
@@ -10797,11 +10785,6 @@ json-stringify-safe@5.0.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
-json3@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
-  integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
 json5@^1.0.1:
   version "1.0.1"
@@ -11348,11 +11331,11 @@ lz-string@^1.4.4:
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 magic-string@^0.25.0, magic-string@^0.25.7:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
-  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
   dependencies:
-    sourcemap-codec "^1.4.4"
+    sourcemap-codec "^1.4.8"
 
 make-dir@^1.3.0:
   version "1.3.0"
@@ -11421,9 +11404,9 @@ markdown-escapes@^1.0.0:
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
 markdown-to-jsx@^7.1.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz#421487df2a66fe4231d94db653a34da033691e62"
-  integrity sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz#a5f22102fb12241c8cea1ca6a4050bb76b23a25d"
+  integrity sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==
 
 match-sorter@^6.0.2:
   version "6.3.1"
@@ -11612,10 +11595,15 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
+mime-db@1.51.0:
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
+"mime-db@>= 1.43.0 < 2":
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.34"
@@ -11689,7 +11677,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -11889,7 +11877,7 @@ nano-time@1.0.0:
   dependencies:
     big-integer "^1.6.16"
 
-nanoid@^3.1.23, nanoid@^3.2.0:
+nanoid@^3.1.23, nanoid@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
@@ -11943,10 +11931,10 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -12327,7 +12315,14 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@^2.3.0, on-finished@~2.3.0:
+on-finished@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
+
+on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -13589,11 +13584,11 @@ postcss@^6.0.9:
     supports-color "^5.4.0"
 
 postcss@^8.1.0, postcss@^8.3.5:
-  version "8.4.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
-  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
+  version "8.4.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.8.tgz#dad963a76e82c081a0657d3a2f3602ce10c2e032"
+  integrity sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==
   dependencies:
-    nanoid "^3.2.0"
+    nanoid "^3.3.1"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -13666,15 +13661,10 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.21.0:
+prismjs@^1.21.0, prismjs@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
-
-prismjs@~1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
-  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -13748,7 +13738,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -14140,9 +14130,9 @@ react-hook-form@^6.8.4:
   integrity sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==
 
 react-i18next@^11.7.4:
-  version "11.15.4"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.15.4.tgz#fe0c792ea93f038548e838cecae3ed4173822937"
-  integrity sha512-jKJNAcVcbPGK+yrTcXhLblgPY16n6NbpZZL3Mk8nswj1v3ayIiUBVDU09SgqnT+DluyQBS97hwSvPU5yVFG0yg==
+  version "11.15.6"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.15.6.tgz#693430fbee5ac7d0774bd88683575d62adb24afb"
+  integrity sha512-OUWcFdNgIA9swVx3JGIreuquglAinpRwB/HYrCprTN+s9BQDt9LSiY7x5DGc2JzVpwqtpoTV7oRUTOxEPNyUPw==
   dependencies:
     "@babel/runtime" "^7.14.5"
     html-escaper "^2.0.2"
@@ -14243,12 +14233,12 @@ react-router-dom@^5.2.0:
     tiny-warning "^1.0.0"
 
 react-router-dom@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.1.tgz#32ec81829152fbb8a7b045bf593a22eadf019bec"
-  integrity sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.2.tgz#f1a2c88365593c76b9612ae80154a13fcb72e442"
+  integrity sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==
   dependencies:
     history "^5.2.0"
-    react-router "6.2.1"
+    react-router "6.2.2"
 
 react-router@5.2.1, react-router@^5.2.0:
   version "5.2.1"
@@ -14266,10 +14256,10 @@ react-router@5.2.1, react-router@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@6.2.1, react-router@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.1.tgz#be2a97a6006ce1d9123c28934e604faef51448a3"
-  integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==
+react-router@6.2.2, react-router@^6.0.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.2.tgz#495e683a0c04461eeb3d705fe445d6cf42f0c249"
+  integrity sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==
   dependencies:
     history "^5.2.0"
 
@@ -14526,13 +14516,13 @@ redux@^4.0.0, redux@^4.0.5:
     "@babel/runtime" "^7.9.2"
 
 refractor@^3.1.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.5.0.tgz#334586f352dda4beaf354099b48c2d18e0819aec"
-  integrity sha512-QwPJd3ferTZ4cSPPjdP5bsYHMytwWYnAN5EEnLtGvkqp/FCCnGsBgxrm9EuIDnjUC3Uc/kETtvVi7fSIVC74Dg==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
   dependencies:
     hastscript "^6.0.0"
     parse-entities "^2.0.0"
-    prismjs "~1.25.0"
+    prismjs "~1.27.0"
 
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"
@@ -15482,16 +15472,15 @@ snapdragon@^0.8.1:
     use "^3.1.0"
 
 sockjs-client@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.5.2.tgz#4bc48c2da9ce4769f19dc723396b50f5c12330a3"
-  integrity sha512-ZzRxPBISQE7RpzlH4tKJMQbHM9pabHluk0WBaxAQ+wm/UieeBVBou0p4wVnSQGN9QmpAZygQ0cDIypWuqOFmFQ==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.6.0.tgz#e0277b8974558edcb557eafc7d3027ef6128d865"
+  integrity sha512-qVHJlyfdHFht3eBFZdKEXKTlb7I4IV41xnVNo8yUKA1UHcPJwgW2SvTq9LhnjjCywSkSK7c/e4nghU0GOoMCRQ==
   dependencies:
-    debug "^3.2.6"
-    eventsource "^1.0.7"
-    faye-websocket "^0.11.3"
+    debug "^3.2.7"
+    eventsource "^1.1.0"
+    faye-websocket "^0.11.4"
     inherits "^2.0.4"
-    json3 "^3.3.3"
-    url-parse "^1.5.3"
+    url-parse "^1.5.10"
 
 sockjs@^0.3.21:
   version "0.3.24"
@@ -15571,7 +15560,7 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
+sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -16236,10 +16225,11 @@ terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.4:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.10.0.tgz#b86390809c0389105eb0a0b62397563096ddafcc"
-  integrity sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.0.tgz#728c6bff05f7d1dcb687d8eace0644802a9dae8a"
+  integrity sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==
   dependencies:
+    acorn "^8.5.0"
     commander "^2.20.0"
     source-map "~0.7.2"
     source-map-support "~0.5.20"
@@ -16474,10 +16464,10 @@ ts-mock-imports@^1.3.0:
   resolved "https://registry.yarnpkg.com/ts-mock-imports/-/ts-mock-imports-1.3.8.tgz#6b26887c651effe947ea91f928338d1899146fb9"
   integrity sha512-A5n0iEg4zh2/qToo54XOa/wT31fAI0B8DHYU4RDcA6HIddZQPRkTsYri3Hl69+OSLjOKWjyP3/vYOIp3SAIZXg==
 
-ts-node@^10.5.0:
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.5.0.tgz#618bef5854c1fbbedf5e31465cbb224a1d524ef9"
-  integrity sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==
+ts-node@^10.6.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
   dependencies:
     "@cspotcode/source-map-support" "0.7.0"
     "@tsconfig/node10" "^1.0.7"
@@ -16510,9 +16500,9 @@ ts-pnp@1.2.0, ts-pnp@^1.1.6:
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 tsconfig-paths@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
-  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz#f3e9b8f6876698581d94470c03c95b3a48c0e3d7"
+  integrity sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
@@ -16658,14 +16648,14 @@ typescript@4.2.2:
   integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 typescript@^4.3.2:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 uglify-js@^3.1.4:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.1.tgz#9403dc6fa5695a6172a91bc983ea39f0f7c9086d"
-  integrity sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.2.tgz#1ed2c976f448063b1f87adb68c741be79959f951"
+  integrity sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -16891,10 +16881,10 @@ url-loader@4.1.1, url-loader@^4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
-url-parse@^1.2.0, url-parse@^1.4.3, url-parse@^1.5.3:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.9.tgz#05ff26484a0b5e4040ac64dcee4177223d74675e"
-  integrity sha512-HpOvhKBvre8wYez+QhHcYiVvVmeF6DVnuSOOPhe3cTum3BnqHhvKaZm8FU5yTiOu/Jut2ZpB2rA/SbBA1JIGlQ==
+url-parse@^1.2.0, url-parse@^1.4.3, url-parse@^1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
@@ -17822,9 +17812,9 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.7:
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^21.0.0:
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
-  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
 yargs@16.2.0, yargs@^16.2.0:
   version "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,8 +1450,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@../api":
+"@interlay/interbtc-api@1.7.0":
   version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-1.7.0.tgz#8c983bc85fb810bb70f7b10779fafd7a025617a1"
+  integrity sha512-fx6Sk+hbg9X36bpwWY6Qyq/7BkxOzwumKYbpqlF9nZpI9bWxwA8rz5ObvaH/iTfYN2ukDpzcOo4waZ2j2tijGQ==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "1.5.10"
@@ -5691,9 +5693,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001313:
-  version "1.0.30001313"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz#a380b079db91621e1b7120895874e2fd62ed2e2f"
-  integrity sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==
+  version "1.0.30001314"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz#65c7f9fb7e4594fca0a333bec1d8939662377596"
+  integrity sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7361,9 +7363,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.76:
-  version "1.4.76"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz#a0494baedaf51094b1c172999919becd9975a934"
-  integrity sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==
+  version "1.4.77"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.77.tgz#c26e454cb8721d4ebdae3e276c57cd32e51c32ed"
+  integrity sha512-fiDxw8mO9Ph1Z0bjX2sFTPpi0J0QkOiwOJF+5Q0J0baNc/F9lLePAvDPlnoxvbUYYMizqrKPeotRRkJ9LtxAew==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
There is a lot going on in this PR, but basically it does these things:
- **Remove interbtc-js dependency and replace with interbtc-api**: We used interbtc-js to bundle the lib with the old indexer. With the removal of the old indexer, we don't need this meta-package anymore. Instead (also for local development), the interbtc-api package can be directly used. 
- **Remove indexer leftovers** However, mid-way of removing the js package I realized a lot of left-overs from the squid merge where we still used the old indexer. I have now removed all the indexer references and added an explicit error on the general-fetcher in case anyone would try to use the old indexer. I've went through the entire UI to issue, redeem, and stake to check that all works as intended. I haven't found a bug, but would be good to verify with users on testnet.
- **Upgrade interbtc-api to include the division by 0 fix** Upgrades the API package to 1.7.0 that includes a couple of fixes for staking, one of those is the division by 0: https://github.com/interlay/interbtc-api/pull/375
- **Harmonized issue and redeem fees to use Big numbers**
- **Adds the getRewardEstimate unlockHeight parameter**: TODO is to add this to the UI. On getRewardEstimate we currently only submit the newly locked amount but not the new unlock height.
- **Adds the KINT to be withdrawn to the claim rewards button in staking**
![image](https://user-images.githubusercontent.com/14966470/157190991-9a1518cb-b470-48cd-b394-7349afdecafe.png)
- **Fixes the loading spinner on the claim rewards button** Awaits now the withdraw rewards calls.
- **Under-the-hood improvements** The lib now awaits only block inclusion and not finalization on must calls which reduces the time for most transactions (except request issue and request redeem) to whenever the next block is minted (ideally every 12 seconds currently 20 seconds on average). This is down from 60 seconds. Also now most lib calls have halved the network time since the finalized block header await is removed.
- **Renames PolkaBTC to InterBTC**