### PR TITLE
feat: submit button text depending on user action in staking

### DIFF
--- a/src/common/actions/general.actions.ts
+++ b/src/common/actions/general.actions.ts
@@ -3,11 +3,9 @@ import {
   MonetaryAmount,
   Currency
 } from '@interlay/monetary-js';
-import {
-  CollateralUnit,
-  GovernanceUnit
-} from '@interlay/interbtc-api';
+import { CollateralUnit } from '@interlay/interbtc-api';
 
+import { GovernanceTokenMonetaryAmount } from 'config/relay-chains';
 import {
   IS_POLKA_BTC_LOADED,
   CHANGE_ADDRESS,
@@ -90,14 +88,14 @@ export const updateCollateralTokenTransferableBalanceAction = (
 });
 
 export const updateGovernanceTokenBalanceAction = (
-  governanceTokenBalance: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>
+  governanceTokenBalance: GovernanceTokenMonetaryAmount
 ): UpdateGovernanceTokenBalance => ({
   type: UPDATE_GOVERNANCE_TOKEN_BALANCE,
   governanceTokenBalance
 });
 
 export const updateGovernanceTokenTransferableBalanceAction = (
-  governanceTokenTransferableBalance: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>
+  governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount
 ): UpdateGovernanceTokenTransferableBalance => ({
   type: UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
   governanceTokenTransferableBalance
@@ -111,7 +109,7 @@ export const updateOfPricesAction = (prices: Prices): UpdateOfPrices => ({
 export const initGeneralDataAction = (
   totalWrappedTokenAmount: BitcoinAmount,
   totalLockedCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>,
-  totalGovernanceTokenAmount: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
+  totalGovernanceTokenAmount: GovernanceTokenMonetaryAmount,
   btcRelayHeight: number,
   bitcoinHeight: number,
   parachainStatus: ParachainStatus

--- a/src/common/types/actions.types.ts
+++ b/src/common/types/actions.types.ts
@@ -1,8 +1,7 @@
-import { StoreType, ParachainStatus, Prices } from './util.types';
+
 import {
   Issue,
-  CollateralUnit,
-  GovernanceUnit
+  CollateralUnit
 } from '@interlay/interbtc-api';
 import {
   BitcoinAmount,
@@ -10,8 +9,14 @@ import {
   Currency
 } from '@interlay/monetary-js';
 
-// GENERAL ACTIONS
+import { GovernanceTokenMonetaryAmount } from 'config/relay-chains';
+import {
+  StoreType,
+  ParachainStatus,
+  Prices
+} from './util.types';
 
+// GENERAL ACTIONS
 export const IS_POLKA_BTC_LOADED = 'IS_POLKA_BTC_LOADED';
 export const IS_FAUCET_LOADED = 'IS_FAUCET_LOADED';
 export const IS_VAULT_CLIENT_LOADED = 'IS_VAULT_CLIENT_LOADED';
@@ -75,7 +80,7 @@ export interface InitGeneralDataAction {
   type: typeof INIT_GENERAL_DATA_ACTION;
   totalWrappedTokenAmount: BitcoinAmount;
   totalLockedCollateralTokenAmount: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
-  totalGovernanceTokenAmount: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  totalGovernanceTokenAmount: GovernanceTokenMonetaryAmount;
   btcRelayHeight: number;
   bitcoinHeight: number;
   parachainStatus: ParachainStatus;
@@ -103,12 +108,12 @@ export interface UpdateCollateralTokenTransferableBalance {
 
 export interface UpdateGovernanceTokenBalance {
   type: typeof UPDATE_GOVERNANCE_TOKEN_BALANCE;
-  governanceTokenBalance: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  governanceTokenBalance: GovernanceTokenMonetaryAmount;
 }
 
 export interface UpdateGovernanceTokenTransferableBalance {
   type: typeof UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE;
-  governanceTokenTransferableBalance: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount;
 }
 
 export interface SetInstalledExtension {

--- a/src/common/types/util.types.ts
+++ b/src/common/types/util.types.ts
@@ -1,19 +1,23 @@
 import { Store, CombinedState } from 'redux';
-import { GeneralActions, RedeemActions, IssueActions, VaultActions } from './actions.types';
-import { rootReducer } from '../reducers/index';
 import { u256 } from '@polkadot/types/primitive';
-import { IssueState } from './issue.types';
-import { RedeemState } from './redeem.types';
-import { VaultState } from './vault.types';
 import {
   BitcoinAmount,
   MonetaryAmount,
   Currency
 } from '@interlay/monetary-js';
+import { CollateralUnit } from '@interlay/interbtc-api';
+
+import { GovernanceTokenMonetaryAmount } from 'config/relay-chains';
 import {
-  CollateralUnit,
-  GovernanceUnit
-} from '@interlay/interbtc-api';
+  GeneralActions,
+  RedeemActions,
+  IssueActions,
+  VaultActions
+} from './actions.types';
+import { rootReducer } from '../reducers/index';
+import { IssueState } from './issue.types';
+import { RedeemState } from './redeem.types';
+import { VaultState } from './vault.types';
 
 export interface StatusUpdate {
   id: u256;
@@ -75,8 +79,8 @@ export type GeneralState = {
   wrappedTokenTransferableBalance: BitcoinAmount;
   collateralTokenBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
   collateralTokenTransferableBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
-  governanceTokenBalance: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
-  governanceTokenTransferableBalance: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  governanceTokenBalance: GovernanceTokenMonetaryAmount;
+  governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount;
   extensions: string[];
   btcRelayHeight: number;
   bitcoinHeight: number;

--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -1,6 +1,7 @@
 import {
   Currency,
   BitcoinUnit,
+  MonetaryAmount,
   KBtc, // on Kusama
   Kusama, // on Kusama
   KBtcAmount, // on Kusama
@@ -41,6 +42,8 @@ type WrappedToken = Currency<BitcoinUnit>;
 type CollateralToken = Currency<CollateralUnit>;
 type GovernanceToken = Currency<GovernanceUnit>;
 type VoteGovernanceToken = Currency<VoteUnit>;
+type GovernanceTokenMonetaryAmount = MonetaryAmount<GovernanceToken, GovernanceUnit>;
+type VoteGovernanceTokenMonetaryAmount = MonetaryAmount<VoteGovernanceToken, VoteUnit>;
 
 let APP_NAME: string;
 let TERMS_AND_CONDITIONS_LINK: string;
@@ -98,8 +101,8 @@ case POLKADOT: {
   TERMS_AND_CONDITIONS_LINK = INTERLAY_TERMS_AND_CONDITIONS_LINK;
   WRAPPED_TOKEN = InterBtc;
   COLLATERAL_TOKEN = Polkadot as Currency<CollateralUnit>;
-  GOVERNANCE_TOKEN = Interlay as Currency<GovernanceUnit>;
-  VOTE_GOVERNANCE_TOKEN = Interlay as Currency<VoteUnit>;
+  GOVERNANCE_TOKEN = Interlay as GovernanceToken;
+  VOTE_GOVERNANCE_TOKEN = Interlay as VoteGovernanceToken;
   WRAPPED_TOKEN_SYMBOL = 'interBTC';
   COLLATERAL_TOKEN_SYMBOL = 'DOT';
   GOVERNANCE_TOKEN_SYMBOL = 'INTR';
@@ -129,8 +132,8 @@ case KUSAMA: {
   TERMS_AND_CONDITIONS_LINK = KINTSUGI_TERMS_AND_CONDITIONS_LINK;
   WRAPPED_TOKEN = KBtc;
   COLLATERAL_TOKEN = Kusama as Currency<CollateralUnit>;
-  GOVERNANCE_TOKEN = Kintsugi as Currency<GovernanceUnit>;
-  VOTE_GOVERNANCE_TOKEN = Kintsugi as Currency<VoteUnit>;
+  GOVERNANCE_TOKEN = Kintsugi as GovernanceToken;
+  VOTE_GOVERNANCE_TOKEN = Kintsugi as VoteGovernanceToken;
   WRAPPED_TOKEN_SYMBOL = 'kBTC';
   COLLATERAL_TOKEN_SYMBOL = 'KSM';
   GOVERNANCE_TOKEN_SYMBOL = 'KINT';
@@ -163,7 +166,9 @@ export type {
   CollateralToken,
   WrappedToken,
   GovernanceToken,
-  WrappedTokenAmount
+  WrappedTokenAmount,
+  GovernanceTokenMonetaryAmount,
+  VoteGovernanceTokenMonetaryAmount
 };
 
 export {

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -734,7 +734,21 @@ const Staking = (): JSX.Element => {
   } else {
     if (accountSet) {
       // ray test touch <<
-      submitButtonLabel = votingBalanceGreaterThanZero ? 'Add more stake' : 'Stake';
+      if (votingBalanceGreaterThanZero) {
+        const intLockTime = parseInt(lockTime);
+        if (checkIncreaseLockAmountAndExtendLockTime(intLockTime, monetaryLockingAmount)) {
+          submitButtonLabel = 'Add more stake and extend lock time';
+        } else if (checkOnlyIncreaseLockAmount(intLockTime, monetaryLockingAmount)) {
+          submitButtonLabel = 'Add more stake';
+        } else if (checkOnlyExtendLockTime(intLockTime, monetaryLockingAmount)) {
+          submitButtonLabel = 'Extend lock time';
+        } else {
+          // throw new Error('Something went wrong!');
+          submitButtonLabel = 'Something went wrong!';
+        }
+      } else {
+        submitButtonLabel = 'Stake';
+      }
       // ray test touch >>
     } else {
       submitButtonLabel = t('connect_wallet');

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -71,6 +71,14 @@ const convertBlockNumbersToWeeks = (blockNumbers: number) => {
   return blockNumbers * BLOCK_TIME / ONE_WEEK_SECONDS;
 };
 
+// ray test touch <<
+// https://kentcdodds.com/blog/inversion-of-control
+// const increaseLockAmountOrExtendLockTimeHandler = (
+//   lockAmount: GovernanceTokenMonetaryAmount,
+//   lockTime: number
+// ) => {};
+// ray test touch >>
+
 const ZERO_VOTE_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, VOTE_GOVERNANCE_TOKEN, true);
 const ZERO_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, GOVERNANCE_TOKEN, true);
 

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -734,12 +734,12 @@ const Staking = (): JSX.Element => {
   } else {
     if (accountSet) {
       if (votingBalanceGreaterThanZero) {
-        const intLockTime = parseInt(lockTime);
-        if (checkIncreaseLockAmountAndExtendLockTime(intLockTime, monetaryLockingAmount)) {
+        const numericLockTime = parseInt(lockTime);
+        if (checkIncreaseLockAmountAndExtendLockTime(numericLockTime, monetaryLockingAmount)) {
           submitButtonLabel = 'Add more stake and extend lock time';
-        } else if (checkOnlyIncreaseLockAmount(intLockTime, monetaryLockingAmount)) {
+        } else if (checkOnlyIncreaseLockAmount(numericLockTime, monetaryLockingAmount)) {
           submitButtonLabel = 'Add more stake';
-        } else if (checkOnlyExtendLockTime(intLockTime, monetaryLockingAmount)) {
+        } else if (checkOnlyExtendLockTime(numericLockTime, monetaryLockingAmount)) {
           submitButtonLabel = 'Extend lock time';
         } else {
           submitButtonLabel = 'Stake';

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -72,11 +72,36 @@ const convertBlockNumbersToWeeks = (blockNumbers: number) => {
 };
 
 // ray test touch <<
-// https://kentcdodds.com/blog/inversion-of-control
-// const increaseLockAmountOrExtendLockTimeHandler = (
-//   lockAmount: GovernanceTokenMonetaryAmount,
-//   lockTime: number
-// ) => {};
+// When to increase lock amount and extend lock time
+const checkIncreaseLockAmountAndExtendLockTime = (
+  lockTime: number,
+  lockAmount: GovernanceTokenMonetaryAmount
+) => {
+  return (
+    lockTime > 0 &&
+    lockAmount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
+  );
+};
+// When to only increase lock amount
+const checkOnlyIncreaseLockAmount = (
+  lockTime: number,
+  lockAmount: GovernanceTokenMonetaryAmount
+) => {
+  return (
+    lockTime === 0 &&
+    lockAmount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
+  );
+};
+// When to only extend lock time
+const checkOnlyExtendLockTime = (
+  lockTime: number,
+  lockAmount: GovernanceTokenMonetaryAmount
+) => {
+  return (
+    lockTime > 0 &&
+    lockAmount.eq(ZERO_GOVERNANCE_TOKEN_AMOUNT)
+  );
+};
 // ray test touch >>
 
 const ZERO_VOTE_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, VOTE_GOVERNANCE_TOKEN, true);
@@ -292,10 +317,7 @@ const Staking = (): JSX.Element => {
         }
 
         // ray test touch <<
-        if ( // Increase lock amount and extend lock time
-          variables.time > 0 &&
-          variables.amount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
-        ) {
+        if (checkIncreaseLockAmountAndExtendLockTime(variables.time, variables.amount)) {
           const unlockHeight = stakedAmountAndEndBlock.endBlock + convertWeeksToBlockNumbers(variables.time);
 
           const txs = [
@@ -312,15 +334,9 @@ const Staking = (): JSX.Element => {
             undefined, // don't await success event
             true // don't wait for finalized blocks
           );
-        } else if ( // Only increase lock amount
-          variables.time === 0 &&
-          variables.amount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
-        ) {
+        } else if (checkOnlyIncreaseLockAmount(variables.time, variables.amount)) {
           return await window.bridge.escrow.increaseAmount(variables.amount);
-        } else if ( // Only extend lock time
-          variables.time > 0 &&
-          variables.amount.eq(ZERO_GOVERNANCE_TOKEN_AMOUNT)
-        ) {
+        } else if (checkOnlyExtendLockTime(variables.time, variables.amount)) {
           const unlockHeight = stakedAmountAndEndBlock.endBlock + convertWeeksToBlockNumbers(variables.time);
 
           return await window.bridge.escrow.increaseUnlockHeight(unlockHeight);

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -71,7 +71,6 @@ const convertBlockNumbersToWeeks = (blockNumbers: number) => {
   return blockNumbers * BLOCK_TIME / ONE_WEEK_SECONDS;
 };
 
-// ray test touch <<
 // When to increase lock amount and extend lock time
 const checkIncreaseLockAmountAndExtendLockTime = (
   lockTime: number,
@@ -102,7 +101,6 @@ const checkOnlyExtendLockTime = (
     lockAmount.eq(ZERO_GOVERNANCE_TOKEN_AMOUNT)
   );
 };
-// ray test touch >>
 
 const ZERO_VOTE_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, VOTE_GOVERNANCE_TOKEN, true);
 const ZERO_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, GOVERNANCE_TOKEN, true);
@@ -316,7 +314,6 @@ const Staking = (): JSX.Element => {
           throw new Error('Something went wrong!');
         }
 
-        // ray test touch <<
         if (checkIncreaseLockAmountAndExtendLockTime(variables.time, variables.amount)) {
           const unlockHeight = stakedAmountAndEndBlock.endBlock + convertWeeksToBlockNumbers(variables.time);
 
@@ -343,7 +340,6 @@ const Staking = (): JSX.Element => {
         } else {
           throw new Error('Something went wrong!');
         }
-        // ray test touch >>
       })();
     },
     {

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -733,7 +733,6 @@ const Staking = (): JSX.Element => {
     submitButtonLabel = 'Loading...';
   } else {
     if (accountSet) {
-      // ray test touch <<
       if (votingBalanceGreaterThanZero) {
         const intLockTime = parseInt(lockTime);
         if (checkIncreaseLockAmountAndExtendLockTime(intLockTime, monetaryLockingAmount)) {
@@ -743,13 +742,11 @@ const Staking = (): JSX.Element => {
         } else if (checkOnlyExtendLockTime(intLockTime, monetaryLockingAmount)) {
           submitButtonLabel = 'Extend lock time';
         } else {
-          // throw new Error('Something went wrong!');
-          submitButtonLabel = 'Something went wrong!';
+          submitButtonLabel = 'Stake';
         }
       } else {
         submitButtonLabel = 'Stake';
       }
-      // ray test touch >>
     } else {
       submitButtonLabel = t('connect_wallet');
     }

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -22,14 +22,8 @@ import {
 import Big from 'big.js';
 import clsx from 'clsx';
 import {
-  MonetaryAmount,
-  Currency
-} from '@interlay/monetary-js';
-import {
   DefaultTransactionAPI,
-  GovernanceUnit,
-  newMonetaryAmount,
-  VoteUnit
+  newMonetaryAmount
 } from '@interlay/interbtc-api';
 
 import Title from './Title';
@@ -51,7 +45,9 @@ import {
   GOVERNANCE_TOKEN_SYMBOL,
   VOTE_GOVERNANCE_TOKEN,
   GOVERNANCE_TOKEN,
-  STAKE_LOCK_TIME
+  STAKE_LOCK_TIME,
+  GovernanceTokenMonetaryAmount,
+  VoteGovernanceTokenMonetaryAmount
 } from 'config/relay-chains';
 import { BLOCK_TIME } from 'config/parachain';
 import { YEAR_MONTH_DAY_PATTERN } from 'utils/constants/date-time';
@@ -90,17 +86,17 @@ type StakingFormData = {
 }
 
 interface EstimatedRewardAmountAndAPY {
-  amount: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  amount: GovernanceTokenMonetaryAmount;
   apy: Big;
 }
 
 interface StakedAmountAndEndBlock {
-  amount: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  amount: GovernanceTokenMonetaryAmount;
   endBlock: number;
 }
 
 interface LockingAmountAndTime {
-  amount: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+  amount: GovernanceTokenMonetaryAmount;
   time: number; // Weeks
 }
 
@@ -158,14 +154,14 @@ const Staking = (): JSX.Element => {
     data: voteGovernanceTokenBalance,
     error: voteGovernanceTokenBalanceError,
     refetch: voteGovernanceTokenBalanceRefetch
-  } = useQuery<MonetaryAmount<Currency<VoteUnit>, VoteUnit>, Error>(
+  } = useQuery<VoteGovernanceTokenMonetaryAmount, Error>(
     [
       GENERIC_FETCHER,
       'escrow',
       'votingBalance',
       address
     ],
-    genericFetcher<MonetaryAmount<Currency<VoteUnit>, VoteUnit>>(),
+    genericFetcher<VoteGovernanceTokenMonetaryAmount>(),
     {
       enabled: !!bridgeLoaded
     }
@@ -179,14 +175,14 @@ const Staking = (): JSX.Element => {
     data: claimableRewardAmount,
     error: claimableRewardAmountError,
     refetch: claimableRewardAmountRefetch
-  } = useQuery<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>, Error>(
+  } = useQuery<GovernanceTokenMonetaryAmount, Error>(
     [
       GENERIC_FETCHER,
       'escrow',
       'getRewards',
       address
     ],
-    genericFetcher<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>>(),
+    genericFetcher<GovernanceTokenMonetaryAmount>(),
     {
       enabled: !!bridgeLoaded
     }
@@ -287,7 +283,8 @@ const Staking = (): JSX.Element => {
           throw new Error('Something went wrong!');
         }
 
-        if ( // Increase amount and extend lock time
+        // ray test touch <<
+        if ( // Increase lock amount and extend lock time
           variables.time > 0 &&
           variables.amount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
         ) {
@@ -307,7 +304,7 @@ const Staking = (): JSX.Element => {
             undefined, // don't await success event
             true // don't wait for finalized blocks
           );
-        } else if ( // Only increase amount
+        } else if ( // Only increase lock amount
           variables.time === 0 &&
           variables.amount.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT)
         ) {
@@ -322,6 +319,7 @@ const Staking = (): JSX.Element => {
         } else {
           throw new Error('Something went wrong!');
         }
+        // ray test touch >>
       })();
     },
     {
@@ -715,7 +713,9 @@ const Staking = (): JSX.Element => {
     submitButtonLabel = 'Loading...';
   } else {
     if (accountSet) {
+      // ray test touch <<
       submitButtonLabel = votingBalanceGreaterThanZero ? 'Add more stake' : 'Stake';
+      // ray test touch >>
     } else {
       submitButtonLabel = t('connect_wallet');
     }

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -733,6 +733,7 @@ const Staking = (): JSX.Element => {
     submitButtonLabel = 'Loading...';
   } else {
     if (accountSet) {
+      // TODO: should improve readability by handling nested conditions
       if (votingBalanceGreaterThanZero) {
         const numericLockTime = parseInt(lockTime);
         if (checkIncreaseLockAmountAndExtendLockTime(numericLockTime, monetaryLockingAmount)) {

--- a/src/pages/Vault/index.tsx
+++ b/src/pages/Vault/index.tsx
@@ -12,17 +12,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import clsx from 'clsx';
-import {
-  BitcoinAmount,
-  MonetaryAmount,
-  Currency
-} from '@interlay/monetary-js';
+import { BitcoinAmount } from '@interlay/monetary-js';
 import {
   CollateralIdLiteral,
   newAccountId,
   tickerToCurrencyIdLiteral,
-  WrappedIdLiteral,
-  GovernanceUnit
+  WrappedIdLiteral
 } from '@interlay/interbtc-api';
 
 import UpdateCollateralModal, { CollateralUpdateStatus } from './UpdateCollateralModal';
@@ -47,7 +42,8 @@ import {
   COLLATERAL_TOKEN_SYMBOL,
   WRAPPED_TOKEN,
   COLLATERAL_TOKEN,
-  GOVERNANCE_TOKEN_SYMBOL
+  GOVERNANCE_TOKEN_SYMBOL,
+  GovernanceTokenMonetaryAmount
 } from 'config/relay-chains';
 import {
   POLKADOT,
@@ -183,7 +179,7 @@ const Vault = (): JSX.Element => {
   const {
     data: governanceReward,
     error: governanceRewardError
-  } = useQuery<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>, Error>(
+  } = useQuery<GovernanceTokenMonetaryAmount, Error>(
     [
       GENERIC_FETCHER,
       'vaults',
@@ -192,7 +188,7 @@ const Vault = (): JSX.Element => {
       COLLATERAL_ID_LITERAL,
       GOVERNANCE_TOKEN_SYMBOL
     ],
-    genericFetcher<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>>(),
+    genericFetcher<GovernanceTokenMonetaryAmount>(),
     {
       enabled: !!bridgeLoaded
     }


### PR DESCRIPTION
- Simplify with:
```
type GovernanceTokenMonetaryAmount = MonetaryAmount<GovernanceToken, GovernanceUnit>;
type VoteGovernanceTokenMonetaryAmount = MonetaryAmount<VoteGovernanceToken, VoteUnit>;
```
(In the process of creating utility functions to handle user action specifically, I had to use the above types many times and found that they were repeated so simplified like so. It was quite straightforward so I made that change. @tomjeatt I'm sorry for that. It was made before we had discussed about refactoring approaches on the other PR. It's so straightforward that I have a lot of confidence.)

- It behaves like so:
1. Adding stake but not lock time: ‘Add more stake’.
2. Increasing lock time but not adding more stake: ‘Extend lock time’.
3. Adding stake and increasing lock time: ‘Add more stake and extend lock time’.

(FYI: `Something went wrong!` was updated to `Stake` already)
![submit-button-text](https://user-images.githubusercontent.com/84005068/158739483-d74255ae-024d-4298-9573-010c38af0189.gif)