### PR TITLE
refetch premium redeem vaults on submission

### DIFF
--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -182,7 +182,8 @@ const RedeemForm = (): JSX.Element | null => {
         }
         if (premiumRedeemVaultsResult.status === 'fulfilled' && premiumRedeemVaultsResult.value.size > 0) {
           // Premium redeem vaults are refetched on submission so we only need to set
-          // true/false rather than keep them in state.
+          // true/false rather than keep them in state. No need to set false as this is
+          // set as a default on render.
           setHasPremiumRedeemVaults(true);
         }
 


### PR DESCRIPTION
I think this works as a quick fix - anything better would need quite a bit of refactoring. Solution here is different from the issue form:

1. We are already calling `getVaultsWithRedeemableTokens()` on submit when the relevant condition is met, so this value will always be up to date.
2. Premium redeem vaults were being fetched on initial render. I've kept the api call as it's required to control layout, but only stored a boolean value in state as we need to refetch the premium redeem vaults on submission so would never use the value itself.
3. Premium redeem vaults are called again on submit, and this is the value that is used to handle the transaction.

This hasn't really been tested with premium redeem vaults as a value isn't being returned locally. Will start a discussion in Discord and hopefully we can find a way to test this on the feature branch.
