### PR TITLE
Bugfix/lock period validation

### DIFF
--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -457,6 +457,7 @@ const Staking = (): JSX.Element => {
       throw new Error('Something went wrong!');
     }
     const remainingWeeksToUnstake = convertBlockNumbersToWeeks(remainingBlockNumbersToUnstake);
+    // ray test touch <<
     const availableLockTime = Math.floor(STAKE_LOCK_TIME.MAX - remainingWeeksToUnstake);
     if (
       numericValue < STAKE_LOCK_TIME.MIN ||
@@ -464,6 +465,7 @@ const Staking = (): JSX.Element => {
     ) {
       return `Please enter a number between ${STAKE_LOCK_TIME.MIN}-${availableLockTime}.`;
     }
+    // ray test touch >>
 
     return undefined;
   };

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -382,6 +382,39 @@ const Staking = (): JSX.Element => {
     trigger
   ]);
 
+  const getStakedAmount = () => {
+    if (
+      stakedAmountAndEndBlockIdle ||
+      stakedAmountAndEndBlockLoading
+    ) {
+      return undefined;
+    }
+    if (stakedAmountAndEndBlock === undefined) {
+      throw new Error('Something went wrong!');
+    }
+
+    return stakedAmountAndEndBlock.amount;
+  };
+  const stakedAmount = getStakedAmount();
+
+  const availableBalance = React.useMemo(() => {
+    if (
+      !governanceTokenBalance ||
+      stakedAmountAndEndBlockIdle ||
+      stakedAmountAndEndBlockLoading
+    ) return;
+    if (stakedAmount === undefined) {
+      throw new Error('Something went wrong!');
+    }
+
+    return governanceTokenBalance.sub(stakedAmount).sub(TRANSACTION_FEE_AMOUNT);
+  }, [
+    governanceTokenBalance,
+    stakedAmountAndEndBlockIdle,
+    stakedAmountAndEndBlockLoading,
+    stakedAmount
+  ]);
+
   const onSubmit = (data: StakingFormData) => {
     if (!bridgeLoaded) return;
     if (currentBlockNumber === undefined) {
@@ -453,19 +486,15 @@ const Staking = (): JSX.Element => {
       return undefined;
     }
 
-    if (remainingBlockNumbersToUnstake === undefined) {
+    if (availableLockTime === undefined) {
       throw new Error('Something went wrong!');
     }
-    const remainingWeeksToUnstake = convertBlockNumbersToWeeks(remainingBlockNumbersToUnstake);
-    // ray test touch <<
-    const availableLockTime = Math.floor(STAKE_LOCK_TIME.MAX - remainingWeeksToUnstake);
     if (
       numericValue < STAKE_LOCK_TIME.MIN ||
       numericValue > availableLockTime
     ) {
       return `Please enter a number between ${STAKE_LOCK_TIME.MIN}-${availableLockTime}.`;
     }
-    // ray test touch >>
 
     return undefined;
   };
@@ -526,38 +555,16 @@ const Staking = (): JSX.Element => {
   };
   const remainingBlockNumbersToUnstake = getRemainingBlockNumbersToUnstake();
 
-  const getStakedAmount = () => {
-    if (
-      stakedAmountAndEndBlockIdle ||
-      stakedAmountAndEndBlockLoading
-    ) {
+  const getAvailableLockTime = () => {
+    if (remainingBlockNumbersToUnstake === undefined) {
       return undefined;
     }
-    if (stakedAmountAndEndBlock === undefined) {
-      throw new Error('Something went wrong!');
-    }
 
-    return stakedAmountAndEndBlock.amount;
+    const remainingWeeksToUnstake = convertBlockNumbersToWeeks(remainingBlockNumbersToUnstake);
+
+    return Math.floor(STAKE_LOCK_TIME.MAX - remainingWeeksToUnstake);
   };
-  const stakedAmount = getStakedAmount();
-
-  const availableBalance = React.useMemo(() => {
-    if (
-      !governanceTokenBalance ||
-      stakedAmountAndEndBlockIdle ||
-      stakedAmountAndEndBlockLoading
-    ) return;
-    if (stakedAmount === undefined) {
-      throw new Error('Something went wrong!');
-    }
-
-    return governanceTokenBalance.sub(stakedAmount).sub(TRANSACTION_FEE_AMOUNT);
-  }, [
-    governanceTokenBalance,
-    stakedAmountAndEndBlockIdle,
-    stakedAmountAndEndBlockLoading,
-    stakedAmount
-  ]);
+  const availableLockTime = getAvailableLockTime();
 
   const renderAvailableBalanceLabel = () => {
     return (
@@ -694,7 +701,9 @@ const Staking = (): JSX.Element => {
 
   const lockTimeFieldDisabled =
     votingBalanceGreaterThanZero === undefined ||
-    remainingBlockNumbersToUnstake === undefined;
+    remainingBlockNumbersToUnstake === undefined ||
+    availableLockTime === undefined ||
+    availableLockTime <= 0;
 
   const lockingAmountFieldDisabled = availableBalance === undefined;
 


### PR DESCRIPTION
A user reported this issue:
> Hey, it's impossible to stake, always an error on the "extend time" zone
it's compulsory to put 0
![unknown](https://user-images.githubusercontent.com/84005068/158736079-e7ffeea0-980d-45d8-9258-caa7d939bb6f.png)

I updated the handling on the locking period. If people cannot extend the lock time, the weeks input field is disabled with zero as a default value.
![Capture PNG](https://user-images.githubusercontent.com/84005068/158735836-66fa5092-c602-471e-b0f6-965675fcb0d8.png)