### PR TITLE
Fetch relay chain balance and validate on submit

### DIFF
--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -12,7 +12,6 @@ import {
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
-import { ApiPromise } from '@polkadot/api';
 import { newMonetaryAmount } from '@interlay/interbtc-api';
 
 import Accounts from 'components/Accounts';
@@ -42,6 +41,7 @@ import {
   createRelayChainApi,
   getRelayChainBalance,
   transferToParachain,
+  RelayChainApi,
   RelayChainMonetaryAmount
 } from 'utils/relay-chain-api';
 
@@ -55,7 +55,7 @@ const CrossChainTransferForm = (): JSX.Element => {
   // TODO: review how we're handling the relay chain api - for now it can
   // be scoped to this component, but long term it needs to be handled at
   // the application level.
-  const [api, setApi] = React.useState<ApiPromise | undefined>(undefined);
+  const [api, setApi] = React.useState<RelayChainApi | undefined>(undefined);
   const [relayChainBalance, setRelayChainBalance] = React.useState<RelayChainMonetaryAmount | undefined>(undefined);
   const [destination, setDestination] = React.useState<InjectedAccountWithMeta | undefined>(undefined);
   const [submitStatus, setSubmitStatus] = React.useState(STATUSES.IDLE);

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -45,9 +45,11 @@ import {
 } from 'common/types/util.types';
 import { ChainType } from 'types/chains.types';
 import STATUSES from 'utils/constants/statuses';
-import { createRelayChainApi } from 'utils/relay-chain-api/create-relay-chain-api';
-import { xcmTransfer } from 'utils/relay-chain-api/transfer';
-import { getRelayChainBalance } from 'utils/relay-chain-api/get-relay-chain-balance';
+import {
+  createRelayChainApi,
+  getRelayChainBalance,
+  transferToParachain
+} from 'utils/relay-chain-api';
 
 const TRANSFER_AMOUNT = 'transfer-amount';
 
@@ -96,7 +98,7 @@ const CrossChainTransferForm = (): JSX.Element => {
 
       if (!api) return;
 
-      await xcmTransfer(
+      await transferToParachain(
         api,
         address,
         destination.address,

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -123,7 +123,10 @@ const CrossChainTransferForm = (): JSX.Element => {
     const transferAmount = newMonetaryAmount(value, COLLATERAL_TOKEN, true);
 
     return relayChainBalance?.lt(transferAmount) ? t('insufficient_funds') : undefined;
-  }, [relayChainBalance, t]);
+  }, [
+    relayChainBalance,
+    t
+  ]);
 
   React.useEffect(() => {
     if (api) return;

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -119,14 +119,11 @@ const CrossChainTransferForm = (): JSX.Element => {
     setApproxUsdValue(usd);
   };
 
-  const validateTransferAmount = React.useCallback((value: number): string | undefined => {
+  const validateTransferAmount = (value: number): string | undefined => {
     const transferAmount = newMonetaryAmount(value, COLLATERAL_TOKEN, true);
 
     return relayChainBalance?.lt(transferAmount) ? t('insufficient_funds') : undefined;
-  }, [
-    relayChainBalance,
-    t
-  ]);
+  };
 
   React.useEffect(() => {
     if (api) return;

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -13,14 +13,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 import { ApiPromise } from '@polkadot/api';
-import {
-  CollateralUnit,
-  newMonetaryAmount
-} from '@interlay/interbtc-api';
-import {
-  MonetaryAmount,
-  Currency
-} from '@interlay/monetary-js';
+import { newMonetaryAmount } from '@interlay/interbtc-api';
 
 import Accounts from 'components/Accounts';
 import AvailableBalanceUI from 'components/AvailableBalanceUI';
@@ -48,7 +41,8 @@ import STATUSES from 'utils/constants/statuses';
 import {
   createRelayChainApi,
   getRelayChainBalance,
-  transferToParachain
+  transferToParachain,
+  RelayChainMonetaryAmount
 } from 'utils/relay-chain-api';
 
 const TRANSFER_AMOUNT = 'transfer-amount';
@@ -62,8 +56,7 @@ const CrossChainTransferForm = (): JSX.Element => {
   // be scoped to this component, but long term it needs to be handled at
   // the application level.
   const [api, setApi] = React.useState<ApiPromise | undefined>(undefined);
-  const [relayChainBalance, setRelayChainBalance] =
-    React.useState<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit> | undefined>(undefined);
+  const [relayChainBalance, setRelayChainBalance] = React.useState<RelayChainMonetaryAmount | undefined>(undefined);
   const [destination, setDestination] = React.useState<InjectedAccountWithMeta | undefined>(undefined);
   const [submitStatus, setSubmitStatus] = React.useState(STATUSES.IDLE);
   const [submitError, setSubmitError] = React.useState<Error | null>(null);

--- a/src/utils/relay-chain-api/create-relay-chain-api.ts
+++ b/src/utils/relay-chain-api/create-relay-chain-api.ts
@@ -1,9 +1,9 @@
 import { createSubstrateAPI } from '@interlay/interbtc-api';
-import { ApiPromise } from '@polkadot/api';
 
 import { RELAY_CHAIN_URL } from '../../constants';
+import { RelayChainApi } from './';
 
-const createRelayChainApi = async (): Promise<ApiPromise | undefined> => {
+const createRelayChainApi = async (): Promise<RelayChainApi | undefined> => {
   // Return api as undefined if relay chain isn't set. This should never happen
   // as XCM features should be suppressed if the relaychain is undefined.
   if (!RELAY_CHAIN_URL) {

--- a/src/utils/relay-chain-api/get-relay-chain-balance.ts
+++ b/src/utils/relay-chain-api/get-relay-chain-balance.ts
@@ -6,11 +6,12 @@ import {
   Currency
 } from '@interlay/monetary-js';
 import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RelayChainMonetaryAmount } from './';
 
 const getRelayChainBalance = async (
   api: ApiPromise,
   address: AddressOrPair
-): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> => {
+): Promise<RelayChainMonetaryAmount> => {
   const account = await api.query.system.account(address) as any;
 
   return newMonetaryAmount(account.data.free, COLLATERAL_TOKEN);

--- a/src/utils/relay-chain-api/get-relay-chain-balance.ts
+++ b/src/utils/relay-chain-api/get-relay-chain-balance.ts
@@ -1,10 +1,6 @@
 import { ApiPromise } from '@polkadot/api';
 import { AddressOrPair } from '@polkadot/api-base/types';
-import { CollateralUnit, newMonetaryAmount } from '@interlay/interbtc-api';
-import {
-  MonetaryAmount,
-  Currency
-} from '@interlay/monetary-js';
+import { newMonetaryAmount } from '@interlay/interbtc-api';
 import { COLLATERAL_TOKEN } from 'config/relay-chains';
 import { RelayChainMonetaryAmount } from './';
 

--- a/src/utils/relay-chain-api/get-relay-chain-balance.ts
+++ b/src/utils/relay-chain-api/get-relay-chain-balance.ts
@@ -8,6 +8,7 @@ const getRelayChainBalance = async (
   api: ApiPromise,
   address: AddressOrPair
 ): Promise<RelayChainMonetaryAmount> => {
+  // TODO: resolve type error related to Codec type and cast properly
   const account = await api.query.system.account(address) as any;
 
   return newMonetaryAmount(account.data.free, COLLATERAL_TOKEN);

--- a/src/utils/relay-chain-api/get-relay-chain-balance.ts
+++ b/src/utils/relay-chain-api/get-relay-chain-balance.ts
@@ -1,0 +1,19 @@
+import { ApiPromise } from '@polkadot/api';
+import { AddressOrPair } from '@polkadot/api-base/types';
+import { CollateralUnit, newMonetaryAmount } from '@interlay/interbtc-api';
+import {
+  MonetaryAmount,
+  Currency
+} from '@interlay/monetary-js';
+import { COLLATERAL_TOKEN } from 'config/relay-chains';
+
+const getRelayChainBalance = async (
+  api: ApiPromise,
+  address: AddressOrPair
+): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> => {
+  const account = await api.query.system.account(address) as any;
+
+  return newMonetaryAmount(account.data.free, COLLATERAL_TOKEN);
+};
+
+export { getRelayChainBalance };

--- a/src/utils/relay-chain-api/index.tsx
+++ b/src/utils/relay-chain-api/index.tsx
@@ -1,7 +1,9 @@
 import { createRelayChainApi } from './create-relay-chain-api';
 import { getRelayChainBalance } from './get-relay-chain-balance';
 import { transferToParachain } from './transfer-to-parachain';
+import { RelayChainMonetaryAmount } from './types';
 
+export type { RelayChainMonetaryAmount };
 export {
   createRelayChainApi,
   getRelayChainBalance,

--- a/src/utils/relay-chain-api/index.tsx
+++ b/src/utils/relay-chain-api/index.tsx
@@ -1,9 +1,16 @@
 import { createRelayChainApi } from './create-relay-chain-api';
 import { getRelayChainBalance } from './get-relay-chain-balance';
 import { transferToParachain } from './transfer-to-parachain';
-import { RelayChainMonetaryAmount } from './types';
+import {
+  RelayChainApi,
+  RelayChainMonetaryAmount
+} from './types';
 
-export type { RelayChainMonetaryAmount };
+export type {
+  RelayChainApi,
+  RelayChainMonetaryAmount
+};
+
 export {
   createRelayChainApi,
   getRelayChainBalance,

--- a/src/utils/relay-chain-api/index.tsx
+++ b/src/utils/relay-chain-api/index.tsx
@@ -1,0 +1,9 @@
+import { createRelayChainApi } from './create-relay-chain-api';
+import { getRelayChainBalance } from './get-relay-chain-balance';
+import { transferToParachain } from './transfer-to-parachain';
+
+export {
+  createRelayChainApi,
+  getRelayChainBalance,
+  transferToParachain
+};

--- a/src/utils/relay-chain-api/transfer-to-parachain.ts
+++ b/src/utils/relay-chain-api/transfer-to-parachain.ts
@@ -1,19 +1,11 @@
-import {
-  CollateralUnit,
-  DefaultTransactionAPI
-} from '@interlay/interbtc-api';
-import {
-  Currency,
-  MonetaryAmount
-} from '@interlay/monetary-js';
+import { DefaultTransactionAPI } from '@interlay/interbtc-api';
 import { web3FromAddress } from '@polkadot/extension-dapp';
 import { AddressOrPair } from '@polkadot/api/types';
 import { ApiPromise } from '@polkadot/api';
 import { decodeAddress } from '@polkadot/keyring';
 
 import { PARACHAIN_ID } from '../../constants';
-
-type XCMTransferAmount = MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
+import { RelayChainMonetaryAmount } from './';
 
 const createDest = (api: ApiPromise) => {
   const x1 = api.createType('XcmV1Junction', { parachain: PARACHAIN_ID });
@@ -41,7 +33,7 @@ const createBeneficiary = (api: ApiPromise, id: string) => {
   });
 };
 
-const createAssets = (api: ApiPromise, transferAmount: XCMTransferAmount) => {
+const createAssets = (api: ApiPromise, transferAmount: RelayChainMonetaryAmount) => {
   const fungible = transferAmount.toString();
   const fun = api.createType('XcmV1MultiassetFungibility', { fungible });
   const interior = api.createType('XcmV1MultilocationJunctions', { here: true });
@@ -59,7 +51,7 @@ const transferToParachain = async (
   api: ApiPromise,
   originatingAccount: AddressOrPair,
   destinationAddress: string,
-  transferAmount: XCMTransferAmount
+  transferAmount: RelayChainMonetaryAmount
 ): Promise<void> => {
   // Create transaction api instance on the relaychain
   const transactionApi = new DefaultTransactionAPI(api, originatingAccount);

--- a/src/utils/relay-chain-api/transfer-to-parachain.ts
+++ b/src/utils/relay-chain-api/transfer-to-parachain.ts
@@ -55,7 +55,7 @@ const createAssets = (api: ApiPromise, transferAmount: XCMTransferAmount) => {
 };
 
 // Originating account is passed into avoid creating a dependency on the interBTC api instance
-const xcmTransfer = async (
+const transferToParachain = async (
   api: ApiPromise,
   originatingAccount: AddressOrPair,
   destinationAddress: string,
@@ -78,4 +78,4 @@ const xcmTransfer = async (
   await transactionApi.sendLogged(xcmTransaction);
 };
 
-export { xcmTransfer };
+export { transferToParachain };

--- a/src/utils/relay-chain-api/transfer.ts
+++ b/src/utils/relay-chain-api/transfer.ts
@@ -12,7 +12,6 @@ import { ApiPromise } from '@polkadot/api';
 import { decodeAddress } from '@polkadot/keyring';
 
 import { PARACHAIN_ID } from '../../constants';
-import { createRelayChainApi } from './create-relay-chain-api';
 
 type XCMTransferAmount = MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
 
@@ -57,14 +56,11 @@ const createAssets = (api: ApiPromise, transferAmount: XCMTransferAmount) => {
 
 // Originating account is passed into avoid creating a dependency on the interBTC api instance
 const xcmTransfer = async (
+  api: ApiPromise,
   originatingAccount: AddressOrPair,
   destinationAddress: string,
   transferAmount: XCMTransferAmount
 ): Promise<void> => {
-  const api = await createRelayChainApi();
-
-  if (!api) return;
-
   // Create transaction api instance on the relaychain
   const transactionApi = new DefaultTransactionAPI(api, originatingAccount);
 

--- a/src/utils/relay-chain-api/types.ts
+++ b/src/utils/relay-chain-api/types.ts
@@ -1,9 +1,14 @@
+import { ApiPromise } from '@polkadot/api';
 import {
   MonetaryAmount,
   Currency
 } from '@interlay/monetary-js';
 import { CollateralUnit } from '@interlay/interbtc-api';
 
+type RelayChainApi = ApiPromise;
 type RelayChainMonetaryAmount = MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>
 
-export type { RelayChainMonetaryAmount };
+export type {
+  RelayChainApi,
+  RelayChainMonetaryAmount
+};

--- a/src/utils/relay-chain-api/types.ts
+++ b/src/utils/relay-chain-api/types.ts
@@ -1,0 +1,9 @@
+import {
+  MonetaryAmount,
+  Currency
+} from '@interlay/monetary-js';
+import { CollateralUnit } from '@interlay/interbtc-api';
+
+type RelayChainMonetaryAmount = MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>
+
+export type { RelayChainMonetaryAmount };


### PR DESCRIPTION
This PR does three things: 

1. Extends the relay chain api utilities to fetch the collateral token balance
2. Displays the available amount on the XCM transfer form
3. Validates the amount so that a user can't send a transaction for greater than the balance.

This resolves the issue where a user could send a transaction for greater than the amount they hold, causing them to lose their transaction fee.

All code relating the relay chain api (including types) is being kept together. This was implemented quite quickly, and we'll be reviewing how its been implemented before doing any more work to support cross-chain transfer.