### PR TITLE
Feature/testnet validation

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -320,7 +320,7 @@
     "issue_request_for": "Issue Request for",
     "updated": "Updated",
     "error_more_than_6_blocks_behind": "You can't issue {{wrappedTokenSymbol}} at the moment because {{wrappedTokenSymbol}} parachain is more than 6 blocks behind.",
-    "validation_max_value": "The maximum amount you can issue (per request) on the testnet is 1.0 {{wrappedTokenSymbol}}. Please enter a lower amount.",
+    "validation_max_value": "The maximum amount you can issue (per request) on the testnet is {{maximumIssuableWrappedTokenAmount}} {{wrappedTokenSymbol}}. Please enter a lower amount.",
     "validation_min_value": "Please enter an amount greater than Bitcoin dust limit (",
     "enter_valid_amount": "Please enter a valid amount.",
     "proof_data": "Fetching proof data for Bitcoin transaction: {{txId}}",

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -225,10 +225,13 @@ const IssueForm = (): JSX.Element | null => {
         });
       }
 
+      // ray test touch <<
       if (value > MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT) {
         return t('issue_page.validation_max_value', {
-          wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL
+          wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL,
+          maximumIssuableWrappedTokenAmount: MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT
         });
+      // ray test touch >>
       } else if (btcAmount.lt(dustValue)) {
         return `${t('issue_page.validation_min_value')}${displayMonetaryAmount(dustValue)} BTC).`;
       }

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -62,6 +62,9 @@ import {
   ParachainStatus,
   StoreType
 } from 'common/types/util.types';
+// ray test touch <<
+import { BitcoinNetwork } from 'types/bitcoin';
+// ray test touch >>
 import { updateIssuePeriodAction } from 'common/actions/issue.actions';
 import { showAccountModalAction } from 'common/actions/general.actions';
 import { ReactComponent as BitcoinLogoIcon } from 'assets/img/bitcoin-logo.svg';
@@ -226,7 +229,10 @@ const IssueForm = (): JSX.Element | null => {
       }
 
       // ray test touch <<
-      if (value > MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT) {
+      if (
+        process.env.REACT_APP_BITCOIN_NETWORK !== BitcoinNetwork.Mainnet &&
+        value > MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT
+      ) {
         return t('issue_page.validation_max_value', {
           wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL,
           maximumIssuableWrappedTokenAmount: MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -62,9 +62,7 @@ import {
   ParachainStatus,
   StoreType
 } from 'common/types/util.types';
-// ray test touch <<
 import { BitcoinNetwork } from 'types/bitcoin';
-// ray test touch >>
 import { updateIssuePeriodAction } from 'common/actions/issue.actions';
 import { showAccountModalAction } from 'common/actions/general.actions';
 import { ReactComponent as BitcoinLogoIcon } from 'assets/img/bitcoin-logo.svg';
@@ -228,7 +226,6 @@ const IssueForm = (): JSX.Element | null => {
         });
       }
 
-      // ray test touch <<
       if (
         process.env.REACT_APP_BITCOIN_NETWORK !== BitcoinNetwork.Mainnet &&
         value > MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT
@@ -237,7 +234,6 @@ const IssueForm = (): JSX.Element | null => {
           wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL,
           maximumIssuableWrappedTokenAmount: MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT
         });
-      // ray test touch >>
       } else if (btcAmount.lt(dustValue)) {
         return `${t('issue_page.validation_min_value')}${displayMonetaryAmount(dustValue)} BTC).`;
       }


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/84005068/158919151-276e6049-f993-4590-babd-bea3ddd80701.PNG)
After:
![after](https://user-images.githubusercontent.com/84005068/158919158-d14a2bc6-85ae-4b65-8375-ee55c4965d6f.PNG)

@nud3l 
Please try the preview Vercel Kintsugi version to confirm since I only tested in development environment. I could not test it there because I do not have any KINT. In any case, "Insufficnet funds" message comes first and suppresses the max amount limitation validation according to how it's coded. But I'm 100% sure it should work as expected.