### PR TITLE
Tom/redeem form validation

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -141,6 +141,7 @@
     "enter_btc": "Please enter your Bitcoin address.",
     "you_have": "You have",
     "current_balance": "Please enter an amount smaller than your current balance: {{ currentBalance }}",
+    "request_exceeds_capacity": " Currently, at most {{ maxRedeemableAmount }} can be redeemed. Please enter a lower amount.",
     "amount_greater_dust_inclusion": "Please enter an amount above the combined Bridge Fee, Bitcoin Network Fee, and Bitcoin Dust limit (",
     "request_processed": "Request being processed...",
     "processed_by_vault": "Your redeem request is being processed by Vault:",

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -249,7 +249,6 @@ const RedeemForm = (): JSX.Element | null => {
           }
           if (vaultId === undefined) {
             let maxAmount = BitcoinAmount.zero;
-
             for (const redeemableTokens of premiumRedeemVaults.values()) {
               if (maxAmount.lt(redeemableTokens)) {
                 maxAmount = redeemableTokens;


### PR DESCRIPTION
@nud3l @crypto-engineer this should fix the issue on the redeem form. I've made as few changes as possible. This PR:

1. Fetches vaults with redeemable tokens on initial render and sets a value for max redeemable tokens
2. Validates against that amount when a user inputs an amount

On submit:
1. Vaults are refetched
2. Max redeemable capacity is recalculated
3. If the transaction amount exceeds the new amount an error is appended to the form field and the submit function returns before submitting the transaction.

This was difficult to test as I didn't have an account with more kBTC than vault capacity. I tested by manually setting the vault capacity values below the amount of kBTC in my test account. This worked, so the validation has been tested, but we need to test on an account in staging with enough kBTC.  