### PR TITLE
refactor: issue modal styling

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -2,6 +2,7 @@
   "previous": "Previous",
   "prev": "Prev",
   "send": "Send",
+  "receive": "You will receive",
   "click_to_copy": "Click to copy",
   "confirm": "Confirm",
   "connect_wallet": "Connect Wallet",

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/index.tsx
@@ -113,16 +113,21 @@ const IssueRequestModal = ({
               {/* TODO: could componentize */}
               <h4
                 className={clsx(
-                  'font-medium',
-                  { 'text-interlayDenim':
-                    process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                  { 'dark:text-kintsugiSupernova': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                  'space-x-1'
+                  'space-x-1',
+                  'text-xl'
                 )}>
-                <span className='text-5xl'>
+                <span className='text-xl'>
+                  {t('receive')}
+                </span>
+                <span
+                  className={clsx(
+                    { 'text-interlayDenim':
+                    process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                    { 'dark:text-kintsugiSupernova': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+                  )}>
                   {displayMonetaryAmount(receivedWrappedTokenAmount)}
                 </span>
-                <span className='text-2xl'>
+                <span>
                   {WRAPPED_TOKEN_SYMBOL}
                 </span>
               </h4>

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/index.tsx
@@ -116,7 +116,7 @@ const IssueRequestModal = ({
                   'space-x-1',
                   'text-xl'
                 )}>
-                <span className='text-xl'>
+                <span>
                   {t('receive')}
                 </span>
                 <span


### PR DESCRIPTION
This PR updates the modal styling to make the difference between amount/received much clearer.

<img width="377" alt="Screenshot 2022-03-28 at 11 00 16" src="https://user-images.githubusercontent.com/40243778/160374819-0413942a-2ef9-454d-a813-ec9a13faabc1.png">

<img width="1057" alt="Screenshot 2022-03-28 at 10 49 38" src="https://user-images.githubusercontent.com/40243778/160373680-47c6222f-ba2b-4b96-ae84-27e4d29974a6.png">

