### PR TITLE
feat: remove MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -328,7 +328,6 @@
     "issue_request_for": "Issue Request for",
     "updated": "Updated",
     "error_more_than_6_blocks_behind": "You can't issue {{wrappedTokenSymbol}} at the moment because {{wrappedTokenSymbol}} parachain is more than 6 blocks behind.",
-    "validation_max_value": "The maximum amount you can issue (per request) on the testnet is {{maximumIssuableWrappedTokenAmount}} {{wrappedTokenSymbol}}. Please enter a lower amount.",
     "validation_min_value": "Please enter an amount greater than Bitcoin dust limit (",
     "enter_valid_amount": "Please enter a valid amount.",
     "proof_data": "Fetching proof data for Bitcoin transaction: {{txId}}",

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -63,7 +63,6 @@ import {
   ParachainStatus,
   StoreType
 } from 'common/types/util.types';
-import { BitcoinNetwork } from 'types/bitcoin';
 import { updateIssuePeriodAction } from 'common/actions/issue.actions';
 import { showAccountModalAction } from 'common/actions/general.actions';
 import { ReactComponent as BitcoinLogoIcon } from 'assets/img/bitcoin-logo.svg';
@@ -81,7 +80,6 @@ if (process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT) {
 }
 const extraRequiredCollateralTokenAmount =
   newMonetaryAmount(EXTRA_REQUIRED_COLLATERAL_TOKEN_AMOUNT, GOVERNANCE_TOKEN, true);
-const MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT = 1;
 
 type IssueFormData = {
   [BTC_AMOUNT]: string;
@@ -220,15 +218,7 @@ const IssueForm = (): JSX.Element | null => {
         });
       }
 
-      if (
-        process.env.REACT_APP_BITCOIN_NETWORK !== BitcoinNetwork.Mainnet &&
-        numericValue > MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT
-      ) {
-        return t('issue_page.validation_max_value', {
-          wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL,
-          maximumIssuableWrappedTokenAmount: MAXIMUM_ISSUABLE_WRAPPED_TOKEN_AMOUNT
-        });
-      } else if (btcAmount.lt(dustValue)) {
+      if (btcAmount.lt(dustValue)) {
         return `${t('issue_page.validation_min_value')}${displayMonetaryAmount(dustValue)} BTC).`;
       }
 


### PR DESCRIPTION
This PR removes the limitation of 1 BTC on the testnet.
![Capture](https://user-images.githubusercontent.com/84005068/160630309-6a602235-ad17-42e7-88f1-b6ee889fac32.PNG)
