### PR TITLE
fix: handle selecting vault in the UI

### DIFF
--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -273,8 +273,6 @@ const IssueForm = (): JSX.Element | null => {
         const vaults = await window.bridge.vaults.getVaultsWithIssuableTokens();
         const vaultId = getRandomVaultIdWithCapacity(Array.from(vaults || new Map()), wrappedTokenAmount);
 
-        // TODO: this is patching a bug in the lib. When that's fixed we should revert this to:
-        // const result = await window.bridge.issue.request(wrappedTokenAmount);
         const result = await window.bridge.issue.request(
           wrappedTokenAmount,
           vaultId.address,

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -271,7 +271,7 @@ const IssueForm = (): JSX.Element | null => {
         const wrappedTokenAmount = BitcoinAmount.from.BTC(data[BTC_AMOUNT] || '0');
 
         const vaults = await window.bridge.vaults.getVaultsWithIssuableTokens();
-        const vaultId = getRandomVaultIdWithCapacity(Array.from(vaults || new Map()), wrappedTokenAmount);
+        const vaultId = getRandomVaultIdWithCapacity(Array.from(vaults), wrappedTokenAmount);
 
         const result = await window.bridge.issue.request(
           wrappedTokenAmount,


### PR DESCRIPTION
This is a temporary fix for a bug with vault selection which seems to be occurring in the UI. This PR calls the vaults and selects a random vault in the UI. This should be happening in the lib (and was working before) so we should plan to revert this PR completely when we have a fix on the lib side.