### PR TITLE
fix: all date axes on graphs in the dashboard

### DIFF
--- a/src/pages/Dashboard/IssuedChart/index.tsx
+++ b/src/pages/Dashboard/IssuedChart/index.tsx
@@ -125,7 +125,7 @@ const IssuedChart = (): JSX.Element => {
         })
       ]}
       yLabels={
-        cutoffTimestamps.slice(1)
+        cutoffTimestamps.slice(0, -1)
           .map(timestamp => timestamp.toISOString().substring(0, 10))
       }
       yAxes={[

--- a/src/pages/Dashboard/cards/ActiveVaultsCard/index.tsx
+++ b/src/pages/Dashboard/cards/ActiveVaultsCard/index.tsx
@@ -38,7 +38,7 @@ interface VaultRegistration {
   registrationTimestamp: number;
 }
 
-const graphTimestamps = getLastMidnightTimestamps(5, true);
+const graphTimestamps = getLastMidnightTimestamps(6, true);
 
 const ActiveVaultsCard = ({ hasLinks }: Props): JSX.Element => {
   const { t } = useTranslation();
@@ -72,7 +72,7 @@ const ActiveVaultsCard = ({ hasLinks }: Props): JSX.Element => {
     }
 
     const vaultRegistrations = vaults.data.vaults;
-    const graphData = graphTimestamps.map(
+    const graphData = graphTimestamps.slice(1).map(
       timestamp => vaultRegistrations.filter(
         registration => new Date(registration.registrationTimestamp) <= timestamp
       ).length
@@ -114,7 +114,7 @@ const ActiveVaultsCard = ({ hasLinks }: Props): JSX.Element => {
           wrapperClassName='h-full'
           colors={[chartLineColor]}
           labels={[t('dashboard.vault.total_vaults_chart')]}
-          yLabels={graphTimestamps.map(date => new Date(date).toISOString().substring(0, 10))}
+          yLabels={graphTimestamps.slice(0, -1).map(date => new Date(date).toISOString().substring(0, 10))}
           yAxes={[
             {
               ticks: {

--- a/src/pages/Dashboard/cards/CollateralLockedCard/index.tsx
+++ b/src/pages/Dashboard/cards/CollateralLockedCard/index.tsx
@@ -126,7 +126,7 @@ const CollateralLockedCard = ({ hasLinks }: Props): JSX.Element => {
           colors={[chartLineColor]}
           labels={[t('dashboard.vault.total_collateral_locked')]}
           yLabels={cumulativeCollateralPerDay
-            .slice(1)
+            .slice(0, -1)
             .map(dataPoint => dataPoint.tillTimestamp.toISOString().substring(0, 10))}
           yAxes={[
             {

--- a/src/pages/Dashboard/sub-pages/Home/ActiveCollatorsCard/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Home/ActiveCollatorsCard/index.tsx
@@ -15,27 +15,17 @@ import {
   INTERLAY_DENIM,
   KINTSUGI_APPLE
 } from 'utils/constants/colors';
-import { range } from 'common/utils/utils';
+import { getLastMidnightTimestamps } from 'common/utils/utils';
 
 const ActiveCollatorsCard = (): JSX.Element => {
   const { t } = useTranslation();
 
   // TODO: this function should be removed once real data is pulled in
-  const dateToMidnightTemp = (date: Date): Date => {
-    date.setMilliseconds(0);
-    date.setSeconds(0);
-    date.setMinutes(0);
-    date.setHours(0);
-    return date;
-  };
+  const graphTimestamps = getLastMidnightTimestamps(5, false);
 
   // TODO: hardcoded
   const data = [3, 3, 3, 3, 3];
-  const dates = range(0, 5).map(i =>
-    dateToMidnightTemp(new Date(Date.now() - 86400 * 1000 * i))
-      .toISOString()
-      .substring(0, 10)
-  );
+  const dates = graphTimestamps.map(date => date.toISOString().substring(0, 10));
 
   let chartLineColor;
   if (process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT) {

--- a/src/pages/Dashboard/sub-pages/RedeemRequests/UpperContent/RedeemedChart/index.tsx
+++ b/src/pages/Dashboard/sub-pages/RedeemRequests/UpperContent/RedeemedChart/index.tsx
@@ -93,7 +93,7 @@ const RedeemedChart = (): JSX.Element => {
         t('dashboard.redeem.per_day_redeemed_chart')
       ]}
       yLabels={
-        cutoffTimestamps.slice(1)
+        cutoffTimestamps.slice(0, -1)
           .map(timestamp => timestamp.toLocaleDateString())
       }
       yAxes={[


### PR DESCRIPTION
 - on issue/TVL, registered vaults, and redeems graph, move the date 1 day back because the graph counts "value before the end of the given day" but it's more natural to display "value ON the given day (i.e. after the start of the given day".
 - on collators, it was completely wrong, so switched to using the same logic as all the other graphs to get correct timestamps.