### PR TITLE
refactor: subtract transfer fees from relay chain balance

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -203,7 +203,7 @@
       "to_chain": "To chain",
       "target_account": "Destination",
       "please_enter_amount": "Please enter amount",
-      "relay_chain_balance": "Relay chain balance",
+      "relay_chain_balance": "Transferable relay chain balance",
       "parachain_balance": "Transferable balance",
       "insufficient_funds_to_pay_fees": "Please transfer an amount greater than the transfer fee of {{transferFee}}",
       "insufficient_funds_to_maintain_existential_depoit": "Insufficient amount to maintain existential deposit"

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -196,6 +196,7 @@ const CrossChainTransferForm = (): JSX.Element => {
   React.useEffect(() => {
     if (!api) return;
     if (!handleError) return;
+    if (relayChainBalance) return;
 
     const fetchRelayChainBalance = async () => {
       try {

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -52,6 +52,8 @@ import {
 
 const TRANSFER_AMOUNT = 'transfer-amount';
 
+const transferFee = newMonetaryAmount(RELAY_CHAIN_TRANSFER_FEE, COLLATERAL_TOKEN);
+
 type CrossChainTransferFormData = {
   [TRANSFER_AMOUNT]: string;
 }
@@ -147,7 +149,6 @@ const CrossChainTransferForm = (): JSX.Element => {
 
   const validateParachainTransferAmount = (value: number): string | undefined => {
     const transferAmount = newMonetaryAmount(value, COLLATERAL_TOKEN, true);
-    const transferFee = newMonetaryAmount(RELAY_CHAIN_TRANSFER_FEE, COLLATERAL_TOKEN);
 
     // TODO: this api check won't be necessary when the api call is moved out of
     // the component
@@ -199,7 +200,7 @@ const CrossChainTransferForm = (): JSX.Element => {
     const fetchRelayChainBalance = async () => {
       try {
         const balance: any = await getRelayChainBalance(api, address);
-        setRelayChainBalance(balance);
+        setRelayChainBalance(balance.sub(transferFee));
       } catch (error) {
         handleError(error);
       }


### PR DESCRIPTION
This subtracts the transfer fee from the relay chain balance, and shows it to the user as a transferable balance (i.e. less than they actually have). This fixes the issue where users were seeing a successful transaction in our UI which then failed on the chain, but doesn't require any additional validation.

I've also fixed an infinite loop bug. This means that the relay chain balance only updates on refresh now, but this is how it was intended to work and how it is described in the docs. We may want another task to update the relay chain balance automatically, but I don't think this needs to be done until we migrate the xcm api out of the UI.