### PR TITLE
Copy address from account modal

### DIFF
--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -48,10 +48,11 @@ const CopyAddressButton = ({
       onClick={() => handleCopyAddress(address)}>
       {addressCopied ? (
         <CheckIcon
-          className={COPY_ADDRESS_ICON_CLASSES} />) : (
-        <DocumentDuplicateIcon
-          className={COPY_ADDRESS_ICON_CLASSES} />)
-      }
+          className={COPY_ADDRESS_ICON_CLASSES} />
+       ) : (
+         <DocumentDuplicateIcon
+           className={COPY_ADDRESS_ICON_CLASSES} />
+       )}
     </InterlayButtonBase>);
 };
 

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -5,14 +5,21 @@ import {
   CheckIcon
 } from '@heroicons/react/outline';
 
-import InterlayButtonBase from 'components/UI/InterlayButtonBase';
+import InterlayButtonBase, { Props as InterlayButtonBaseProps } from 'components/UI/InterlayButtonBase';
 import {
   KUSAMA,
   POLKADOT
 } from 'utils/constants/relay-chain-names';
 import { copyToClipboard } from 'common/utils/utils';
 
-const CopyAddressButton = ({ address }: { address: string;}): JSX.Element => {
+interface CustomProps {
+  address: string;
+}
+
+const CopyAddressButton = ({
+  address,
+  className
+}: CustomProps & InterlayButtonBaseProps): JSX.Element => {
   const [addressCopied, setAddressCopied] = React.useState<boolean>(false);
 
   const handleCopyAddress = ((address: string) => {
@@ -33,22 +40,12 @@ const CopyAddressButton = ({ address }: { address: string;}): JSX.Element => {
   return (
     <InterlayButtonBase
       className={clsx(
-        'px-5',
-        'py-3',
         'ml-2',
-        'rounded',
-        'border',
-        'border-solid',
-        'shadow-sm',
-        { 'text-interlayTextPrimaryInLightMode':
-                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-        // eslint-disable-next-line max-len
-        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
         { 'hover:bg-interlayHaiti-50':
-                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
         { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
         { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-        { 'dark:hover:bg-opacity-10': addressCopied }
+        className
       )}
       onClick={() => handleCopyAddress(address)}>
       {addressCopied ? (

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -16,11 +16,16 @@ interface CustomProps {
   address: string;
 }
 
+const COPY_ADDRESS_ICON_STYLES = clsx(
+  'w-6',
+  'h-6'
+);
+
 const CopyAddressButton = ({
   address,
   className
 }: CustomProps & InterlayButtonBaseProps): JSX.Element => {
-  const [addressCopied, setAddressCopied] = React.useState<boolean>(false);
+  const [addressCopied, setAddressCopied] = React.useState<boolean>(true);
 
   const handleCopyAddress = ((address: string) => {
     copyToClipboard(address);
@@ -32,7 +37,7 @@ const CopyAddressButton = ({
 
     const resetAddressCopied = setTimeout(() => {
       setAddressCopied(false);
-    }, 1000);
+    }, 10000);
 
     return () => clearTimeout(resetAddressCopied);
   }, [addressCopied]);
@@ -50,15 +55,10 @@ const CopyAddressButton = ({
       onClick={() => handleCopyAddress(address)}>
       {addressCopied ? (
         <CheckIcon
-          className={clsx(
-            'h-6',
-            'w-6'
-          )} />) : (
+          className={COPY_ADDRESS_ICON_STYLES} />) : (
         <DocumentDuplicateIcon
-          className={clsx(
-            'h-6',
-            'w-6'
-          )} />)}
+          className={COPY_ADDRESS_ICON_STYLES} />)
+      };
     </InterlayButtonBase>);
 };
 

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import {
+  DocumentDuplicateIcon,
+  CheckIcon
+} from '@heroicons/react/outline';
+
+import InterlayButtonBase from 'components/UI/InterlayButtonBase';
+import {
+  KUSAMA,
+  POLKADOT
+} from 'utils/constants/relay-chain-names';
+import { copyToClipboard } from 'common/utils/utils';
+
+const CopyAddressButton = ({ address }: { address: string;}): JSX.Element => {
+  const [addressCopied, setAddressCopied] = React.useState<boolean>(false);
+
+  const handleCopyAddress = ((address: string) => {
+    copyToClipboard(address);
+    setAddressCopied(true);
+  });
+
+  React.useEffect(() => {
+    if (!addressCopied) return;
+
+    const resetAddressCopied = setTimeout(() => {
+      setAddressCopied(false);
+    }, 1000);
+
+    return () => clearTimeout(resetAddressCopied);
+  }, [addressCopied]);
+
+  return (
+    <InterlayButtonBase
+      className={clsx(
+        'px-5',
+        'py-3',
+        'ml-2',
+        'rounded',
+        'border',
+        'border-solid',
+        'shadow-sm',
+        { 'text-interlayTextPrimaryInLightMode':
+                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+        // eslint-disable-next-line max-len
+        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+        { 'hover:bg-interlayHaiti-50':
+                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+        { 'dark:hover:bg-opacity-10': addressCopied }
+      )}
+      onClick={() => handleCopyAddress(address)}>
+      {addressCopied ? (
+        <CheckIcon
+          className={clsx(
+            'h-6',
+            'w-6'
+          )} />) : (
+        <DocumentDuplicateIcon
+          className={clsx(
+            'h-6',
+            'w-6'
+          )} />)}
+    </InterlayButtonBase>);
+};
+
+export default CopyAddressButton;

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -41,18 +41,15 @@ const CopyAddressButton = ({
 
   return (
     <InterlayButtonBase
-      className={clsx(
-        'ml-2',
-        className
-      )}
+      className={className}
       onClick={() => handleCopyAddress(address)}>
       {addressCopied ? (
         <CheckIcon
           className={COPY_ADDRESS_ICON_CLASSES} />
-       ) : (
-         <DocumentDuplicateIcon
-           className={COPY_ADDRESS_ICON_CLASSES} />
-       )}
+      ) : (
+        <DocumentDuplicateIcon
+          className={COPY_ADDRESS_ICON_CLASSES} />
+      )}
     </InterlayButtonBase>);
 };
 

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -6,10 +6,6 @@ import {
 } from '@heroicons/react/outline';
 
 import InterlayButtonBase, { Props as InterlayButtonBaseProps } from 'components/UI/InterlayButtonBase';
-import {
-  KUSAMA,
-  POLKADOT
-} from 'utils/constants/relay-chain-names';
 import { copyToClipboard } from 'common/utils/utils';
 
 interface CustomProps {
@@ -46,10 +42,6 @@ const CopyAddressButton = ({
     <InterlayButtonBase
       className={clsx(
         'ml-2',
-        { 'hover:bg-interlayHaiti-50':
-        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
         className
       )}
       onClick={() => handleCopyAddress(address)}>

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -1,3 +1,4 @@
+
 import * as React from 'react';
 import clsx from 'clsx';
 import {

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -58,7 +58,7 @@ const CopyAddressButton = ({
           className={COPY_ADDRESS_ICON_STYLES} />) : (
         <DocumentDuplicateIcon
           className={COPY_ADDRESS_ICON_STYLES} />)
-      };
+      }
     </InterlayButtonBase>);
 };
 

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -12,7 +12,7 @@ interface CustomProps {
   address: string;
 }
 
-const COPY_ADDRESS_ICON_STYLES = clsx(
+const COPY_ADDRESS_ICON_CLASSES = clsx(
   'w-6',
   'h-6'
 );
@@ -47,9 +47,9 @@ const CopyAddressButton = ({
       onClick={() => handleCopyAddress(address)}>
       {addressCopied ? (
         <CheckIcon
-          className={COPY_ADDRESS_ICON_STYLES} />) : (
+          className={COPY_ADDRESS_ICON_CLASSES} />) : (
         <DocumentDuplicateIcon
-          className={COPY_ADDRESS_ICON_STYLES} />)
+          className={COPY_ADDRESS_ICON_CLASSES} />)
       }
     </InterlayButtonBase>);
 };

--- a/src/components/CopyAddressButton/index.tsx
+++ b/src/components/CopyAddressButton/index.tsx
@@ -25,7 +25,7 @@ const CopyAddressButton = ({
   address,
   className
 }: CustomProps & InterlayButtonBaseProps): JSX.Element => {
-  const [addressCopied, setAddressCopied] = React.useState<boolean>(true);
+  const [addressCopied, setAddressCopied] = React.useState<boolean>(false);
 
   const handleCopyAddress = ((address: string) => {
     copyToClipboard(address);
@@ -37,7 +37,7 @@ const CopyAddressButton = ({
 
     const resetAddressCopied = setTimeout(() => {
       setAddressCopied(false);
-    }, 10000);
+    }, 1000);
 
     return () => clearTimeout(resetAddressCopied);
   }, [addressCopied]);

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -10,10 +10,6 @@ import {
   web3Enable,
   web3FromAddress
 } from '@polkadot/extension-dapp';
-import {
-  DocumentDuplicateIcon,
-  CheckIcon
-} from '@heroicons/react/outline';
 
 import ExternalLink from 'components/ExternalLink';
 import InterlayMulberryOutlinedButton from 'components/buttons/InterlayMulberryOutlinedButton';
@@ -23,6 +19,7 @@ import InterlayModal, {
   InterlayModalTitle
 } from 'components/UI/InterlayModal';
 import InterlayButtonBase from 'components/UI/InterlayButtonBase';
+import CopyAddressButton from 'components/CopyAddressButton';
 import {
   APP_NAME,
   TERMS_AND_CONDITIONS_LINK
@@ -32,10 +29,7 @@ import {
   POLKADOT
 } from 'utils/constants/relay-chain-names';
 import useGetAccounts from 'utils/hooks/use-get-accounts';
-import {
-  copyToClipboard,
-  shortAddress
-} from 'common/utils/utils';
+import { shortAddress } from 'common/utils/utils';
 import { StoreType } from 'common/types/util.types';
 import { changeAddressAction } from 'common/actions/general.actions';
 import { ReactComponent as PolkadotExtensionLogoIcon } from 'assets/img/polkadot-extension-logo.svg';
@@ -46,57 +40,6 @@ interface Props {
   open: boolean;
   onClose: () => void;
 }
-
-const CopyAddressButton = ({ address }: { address: string;}): JSX.Element => {
-  const [addressCopied, setAddressCopied] = React.useState<boolean>(false);
-
-  const handleCopyAddress = ((address: string) => {
-    copyToClipboard(address);
-    setAddressCopied(true);
-  });
-
-  React.useEffect(() => {
-    if (!addressCopied) return;
-
-    const timer = setTimeout(() => {
-      setAddressCopied(false);
-    }, 1000);
-    return () => clearTimeout(timer);
-  }, [addressCopied]);
-
-  return (
-    <InterlayButtonBase
-      className={clsx(
-        'px-5',
-        'py-3',
-        'ml-2',
-        'rounded',
-        'border',
-        'border-solid',
-        'shadow-sm',
-        { 'text-interlayTextPrimaryInLightMode':
-                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-        // eslint-disable-next-line max-len
-        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-        { 'hover:bg-interlayHaiti-50':
-                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
-      )}
-      onClick={() => handleCopyAddress(address)}>
-      {addressCopied ? (
-        <CheckIcon
-          className={clsx(
-            'h-6',
-            'w-6'
-          )} />) : (
-        <DocumentDuplicateIcon
-          className={clsx(
-            'h-6',
-            'w-6'
-          )} />)}
-    </InterlayButtonBase>);
-};
 
 const AccountModal = ({
   open,

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -111,8 +111,7 @@ const AccountModal = ({
                 return (
                   <li
                     key={account.address}
-                    className={clsx(
-                      'flex')}>
+                    className='flex'>
                     <InterlayButtonBase
                       className={clsx(
                         ACCOUNT_MODAL_BUTTON_CLASSES,

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -41,6 +41,16 @@ interface Props {
   onClose: () => void;
 }
 
+const ACCOUNT_MODAL_BUTTON_STYLES = clsx(
+  'px-5',
+  'py-3',
+  'space-x-1.5',
+  'rounded',
+  'border',
+  'border-solid',
+  'shadow-sm'
+);
+
 const AccountModal = ({
   open,
   onClose
@@ -88,15 +98,8 @@ const AccountModal = ({
                       'flex')}>
                     <InterlayButtonBase
                       className={clsx(
-                        'px-5',
-                        'py-3',
-                        'space-x-1.5',
+                        ACCOUNT_MODAL_BUTTON_STYLES,
                         'w-full',
-                        'rounded',
-                        'border',
-                        'border-solid',
-                        'shadow-sm',
-                        // TODO: could be reused
                         selected ? clsx(
                           { 'text-interlayDenim-700':
                             process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
@@ -109,8 +112,8 @@ const AccountModal = ({
                         ) : clsx(
                           { 'text-interlayTextPrimaryInLightMode':
                             process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                          // eslint-disable-next-line max-len
-                          { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+                          { 'dark:text-kintsugiTextPrimaryInDarkMode':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
                           { 'hover:bg-interlayHaiti-50':
                             process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
                           { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
@@ -125,7 +128,9 @@ const AccountModal = ({
                         {`(${shortAddress(account.address)})`}
                       </span>
                     </InterlayButtonBase>
-                    <CopyAddressButton address={account.address} />
+                    <CopyAddressButton
+                      className={ACCOUNT_MODAL_BUTTON_STYLES}
+                      address={account.address} />
                   </li>
                 );
               })}

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -111,7 +111,10 @@ const AccountModal = ({
                 return (
                   <li
                     key={account.address}
-                    className='flex'>
+                    className={clsx(
+                      'flex',
+                      'space-x-2'
+                    )}>
                     <InterlayButtonBase
                       className={clsx(
                         ACCOUNT_MODAL_BUTTON_CLASSES,

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -116,7 +116,7 @@ const AccountModal = ({
                       className={clsx(
                         ACCOUNT_MODAL_BUTTON_CLASSES,
                         'w-full',
-                        selected && ACCOUNT_MODAL_BUTTON_SELECTED_CLASSES
+                        { [ACCOUNT_MODAL_BUTTON_SELECTED_CLASSES]: selected }
                       )}
                       onClick={handleAccountSelect(account.address)}>
                       <span className='font-medium'>

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -10,6 +10,7 @@ import {
   web3Enable,
   web3FromAddress
 } from '@polkadot/extension-dapp';
+import { DocumentDuplicateIcon } from '@heroicons/react/outline';
 
 import ExternalLink from 'components/ExternalLink';
 import InterlayMulberryOutlinedButton from 'components/buttons/InterlayMulberryOutlinedButton';
@@ -28,7 +29,10 @@ import {
   POLKADOT
 } from 'utils/constants/relay-chain-names';
 import useGetAccounts from 'utils/hooks/use-get-accounts';
-import { shortAddress } from 'common/utils/utils';
+import {
+  copyToClipboard,
+  shortAddress
+} from 'common/utils/utils';
 import { StoreType } from 'common/types/util.types';
 import { changeAddressAction } from 'common/actions/general.actions';
 import { ReactComponent as PolkadotExtensionLogoIcon } from 'assets/img/polkadot-extension-logo.svg';
@@ -84,37 +88,37 @@ const AccountModal = ({
                   <li
                     key={account.address}
                     className={clsx(
-                      'rounded',
-                      'border',
-                      'border-solid',
-                      'shadow-sm',
-                      // TODO: could be reused
-                      selected ? clsx(
-                        { 'text-interlayDenim-700':
-                          process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                        { 'dark:text-kintsugiMidnight-700':
-                          process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                        { 'bg-interlayHaiti-50':
-                          process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                        { 'dark:bg-white':
-                          process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
-                      ) : clsx(
-                        { 'text-interlayTextPrimaryInLightMode':
-                          process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                        // eslint-disable-next-line max-len
-                        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                        { 'hover:bg-interlayHaiti-50':
-                          process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
-                      )
-                    )}>
+                      'flex')}>
                     <InterlayButtonBase
                       className={clsx(
                         'px-5',
                         'py-3',
                         'space-x-1.5',
-                        'w-full'
+                        'w-full',
+                        'rounded',
+                        'border',
+                        'border-solid',
+                        'shadow-sm',
+                        // TODO: could be reused
+                        selected ? clsx(
+                          { 'text-interlayDenim-700':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                          { 'dark:text-kintsugiMidnight-700':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+                          { 'bg-interlayHaiti-50':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                          { 'dark:bg-white':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+                        ) : clsx(
+                          { 'text-interlayTextPrimaryInLightMode':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                          // eslint-disable-next-line max-len
+                          { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+                          { 'hover:bg-interlayHaiti-50':
+                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                          { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+                          { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+                        )
                       )}
                       onClick={handleAccountSelect(account.address)}>
                       <span className='font-medium'>
@@ -123,6 +127,31 @@ const AccountModal = ({
                       <span>
                         {`(${shortAddress(account.address)})`}
                       </span>
+                    </InterlayButtonBase>
+                    <InterlayButtonBase
+                      className={clsx(
+                        'px-5',
+                        'py-3',
+                        'ml-2',
+                        'rounded',
+                        'border',
+                        'border-solid',
+                        'shadow-sm',
+                        { 'text-interlayTextPrimaryInLightMode':
+                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                        // eslint-disable-next-line max-len
+                        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+                        { 'hover:bg-interlayHaiti-50':
+                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+                        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+                        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+                      )}
+                      onClick={() => copyToClipboard(account.address)}>
+                      <DocumentDuplicateIcon
+                        className={clsx(
+                          'h-6',
+                          'w-6'
+                        )} />
                     </InterlayButtonBase>
                   </li>
                 );

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -10,7 +10,10 @@ import {
   web3Enable,
   web3FromAddress
 } from '@polkadot/extension-dapp';
-import { DocumentDuplicateIcon } from '@heroicons/react/outline';
+import {
+  DocumentDuplicateIcon,
+  CheckIcon
+} from '@heroicons/react/outline';
 
 import ExternalLink from 'components/ExternalLink';
 import InterlayMulberryOutlinedButton from 'components/buttons/InterlayMulberryOutlinedButton';
@@ -43,6 +46,57 @@ interface Props {
   open: boolean;
   onClose: () => void;
 }
+
+const CopyAddressButton = ({ address }: { address: string;}): JSX.Element => {
+  const [addressCopied, setAddressCopied] = React.useState<boolean>(false);
+
+  const handleCopyAddress = ((address: string) => {
+    copyToClipboard(address);
+    setAddressCopied(true);
+  });
+
+  React.useEffect(() => {
+    if (!addressCopied) return;
+
+    const timer = setTimeout(() => {
+      setAddressCopied(false);
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [addressCopied]);
+
+  return (
+    <InterlayButtonBase
+      className={clsx(
+        'px-5',
+        'py-3',
+        'ml-2',
+        'rounded',
+        'border',
+        'border-solid',
+        'shadow-sm',
+        { 'text-interlayTextPrimaryInLightMode':
+                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+        // eslint-disable-next-line max-len
+        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+        { 'hover:bg-interlayHaiti-50':
+                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+      )}
+      onClick={() => handleCopyAddress(address)}>
+      {addressCopied ? (
+        <CheckIcon
+          className={clsx(
+            'h-6',
+            'w-6'
+          )} />) : (
+        <DocumentDuplicateIcon
+          className={clsx(
+            'h-6',
+            'w-6'
+          )} />)}
+    </InterlayButtonBase>);
+};
 
 const AccountModal = ({
   open,
@@ -128,31 +182,7 @@ const AccountModal = ({
                         {`(${shortAddress(account.address)})`}
                       </span>
                     </InterlayButtonBase>
-                    <InterlayButtonBase
-                      className={clsx(
-                        'px-5',
-                        'py-3',
-                        'ml-2',
-                        'rounded',
-                        'border',
-                        'border-solid',
-                        'shadow-sm',
-                        { 'text-interlayTextPrimaryInLightMode':
-                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                        // eslint-disable-next-line max-len
-                        { 'dark:text-kintsugiTextPrimaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                        { 'hover:bg-interlayHaiti-50':
-                        process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                        { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                        { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
-                      )}
-                      onClick={() => copyToClipboard(account.address)}>
-                      <DocumentDuplicateIcon
-                        className={clsx(
-                          'h-6',
-                          'w-6'
-                        )} />
-                    </InterlayButtonBase>
+                    <CopyAddressButton address={account.address} />
                   </li>
                 );
               })}

--- a/src/parts/AccountModal/index.tsx
+++ b/src/parts/AccountModal/index.tsx
@@ -41,14 +41,31 @@ interface Props {
   onClose: () => void;
 }
 
-const ACCOUNT_MODAL_BUTTON_STYLES = clsx(
+const ACCOUNT_MODAL_BUTTON_CLASSES = clsx(
   'px-5',
   'py-3',
   'space-x-1.5',
   'rounded',
   'border',
   'border-solid',
-  'shadow-sm'
+  'shadow-sm',
+  { 'hover:bg-interlayHaiti-50':
+  process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+  { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+  { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
+);
+
+const ACCOUNT_MODAL_BUTTON_SELECTED_CLASSES = clsx(
+  { 'text-interlayDenim-700':
+    process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+  { 'dark:text-kintsugiMidnight-700':
+    process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+  { 'bg-interlayHaiti-50':
+    process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
+  { 'dark:bg-white':
+    process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
+  { 'dark:hover:bg-opacity-100':
+    process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
 );
 
 const AccountModal = ({
@@ -98,27 +115,9 @@ const AccountModal = ({
                       'flex')}>
                     <InterlayButtonBase
                       className={clsx(
-                        ACCOUNT_MODAL_BUTTON_STYLES,
+                        ACCOUNT_MODAL_BUTTON_CLASSES,
                         'w-full',
-                        selected ? clsx(
-                          { 'text-interlayDenim-700':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                          { 'dark:text-kintsugiMidnight-700':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                          { 'bg-interlayHaiti-50':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                          { 'dark:bg-white':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
-                        ) : clsx(
-                          { 'text-interlayTextPrimaryInLightMode':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                          { 'dark:text-kintsugiTextPrimaryInDarkMode':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                          { 'hover:bg-interlayHaiti-50':
-                            process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT },
-                          { 'dark:hover:bg-white': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA },
-                          { 'dark:hover:bg-opacity-10': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
-                        )
+                        selected && ACCOUNT_MODAL_BUTTON_SELECTED_CLASSES
                       )}
                       onClick={handleAccountSelect(account.address)}>
                       <span className='font-medium'>
@@ -129,7 +128,7 @@ const AccountModal = ({
                       </span>
                     </InterlayButtonBase>
                     <CopyAddressButton
-                      className={ACCOUNT_MODAL_BUTTON_STYLES}
+                      className={ACCOUNT_MODAL_BUTTON_CLASSES}
                       address={account.address} />
                   </li>
                 );


### PR DESCRIPTION
This PR adds a copy icon to the account selector so users can select an address. On click, the icon switches to a tick and is then reset after 1 second.

fixes #225

<img width="489" alt="Screenshot 2022-04-11 at 14 31 26" src="https://user-images.githubusercontent.com/40243778/162750642-3d047072-c214-403b-8c12-ca3ad0bc638c.png">

<img width="499" alt="Screenshot 2022-04-11 at 14 34 25" src="https://user-images.githubusercontent.com/40243778/162750994-f6abc9d9-0b22-424f-a8b8-d5e9879f25e2.png">