### PR TITLE
feature: disable features and routes for Interlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,24 +74,24 @@ import {
 } from 'common/actions/general.actions';
 import { BitcoinNetwork } from 'types/bitcoin';
 
-const Bridge = React.lazy(() =>
-  import(/* webpackChunkName: 'bridge' */ 'pages/Bridge')
-);
+// const Bridge = React.lazy(() =>
+//   import(/* webpackChunkName: 'bridge' */ 'pages/Bridge')
+// );
 const Transfer = React.lazy(() =>
   import(/* webpackChunkName: 'transfer' */ 'pages/Transfer')
 );
-const Transactions = React.lazy(() =>
-  import(/* webpackChunkName: 'transactions' */ 'pages/Transactions')
-);
-const Staking = React.lazy(() =>
-  import(/* webpackChunkName: 'staking' */ 'pages/Staking')
-);
-const Dashboard = React.lazy(() =>
-  import(/* webpackChunkName: 'dashboard' */ 'pages/Dashboard')
-);
-const Vault = React.lazy(() =>
-  import(/* webpackChunkName: 'vault' */ 'pages/Vault')
-);
+// const Transactions = React.lazy(() =>
+//   import(/* webpackChunkName: 'transactions' */ 'pages/Transactions')
+// );
+// const Staking = React.lazy(() =>
+//   import(/* webpackChunkName: 'staking' */ 'pages/Staking')
+// );
+// const Dashboard = React.lazy(() =>
+//   import(/* webpackChunkName: 'dashboard' */ 'pages/Dashboard')
+// );
+// const Vault = React.lazy(() =>
+//   import(/* webpackChunkName: 'vault' */ 'pages/Vault')
+// );
 const NoMatch = React.lazy(() =>
   import(/* webpackChunkName: 'no-match' */ 'pages/NoMatch')
 );
@@ -423,7 +423,7 @@ const App = (): JSX.Element => {
           render={({ location }) => (
             <React.Suspense fallback={<FullLoadingSpinner />}>
               <Switch location={location}>
-                <Route path={PAGES.VAULT}>
+                {/* <Route path={PAGES.VAULT}>
                   <Vault />
                 </Route>
                 <Route path={PAGES.DASHBOARD}>
@@ -437,14 +437,14 @@ const App = (): JSX.Element => {
                 </Route>
                 <Route path={PAGES.BRIDGE}>
                   <Bridge />
-                </Route>
+                </Route> */}
                 <Route path={PAGES.TRANSFER}>
                   <Transfer />
                 </Route>
                 <Redirect
                   exact
                   from={PAGES.HOME}
-                  to={PAGES.BRIDGE} />
+                  to={PAGES.TRANSFER} />
                 <Route path='*'>
                   <NoMatch />
                 </Route>

--- a/src/pages/Transfer/index.tsx
+++ b/src/pages/Transfer/index.tsx
@@ -1,75 +1,11 @@
 
-import * as React from 'react';
 import clsx from 'clsx';
-import { useTranslation } from 'react-i18next';
 
 import TransferForm from './TransferForm';
-import CrossChainTransferForm from './CrossChainTransferForm';
 import MainContainer from 'parts/MainContainer';
 import Panel from 'components/Panel';
-import Hr1 from 'components/hrs/Hr1';
-import InterlayTabGroup, {
-  InterlayTabList,
-  InterlayTabPanels,
-  InterlayTab,
-  InterlayTabPanel
-} from 'components/UI/InterlayTabGroup';
-import useQueryParams from 'utils/hooks/use-query-params';
-import useUpdateQueryParameters, { QueryParameters } from 'utils/hooks/use-update-query-parameters';
-import { QUERY_PARAMETERS } from 'utils/constants/links';
-
-const TAB_IDS = Object.freeze({
-  transfer: 'transfer',
-  crossChainTransfer: 'crossChainTransfer'
-});
-
-const TAB_ITEMS = [
-  {
-    id: TAB_IDS.transfer,
-    label: 'transfer'
-  },
-  {
-    id: TAB_IDS.crossChainTransfer,
-    label: 'cross chain transfer'
-  }
-];
 
 const Transfer = (): JSX.Element | null => {
-  const queryParams = useQueryParams();
-  const selectedTabId = queryParams.get(QUERY_PARAMETERS.TAB);
-  const updateQueryParameters = useUpdateQueryParameters();
-
-  const { t } = useTranslation();
-
-  const updateQueryParametersRef = React.useRef<(newQueryParameters: QueryParameters) => void>();
-
-  React.useLayoutEffect(() => {
-    updateQueryParametersRef.current = updateQueryParameters;
-  });
-
-  React.useEffect(() => {
-    if (!updateQueryParametersRef.current) return;
-
-    const tabIdValues = Object.values(TAB_IDS);
-    switch (true) {
-    case selectedTabId === null:
-    case selectedTabId && !tabIdValues.includes(selectedTabId):
-      updateQueryParametersRef.current({
-        [QUERY_PARAMETERS.TAB]: TAB_IDS.crossChainTransfer
-      });
-    }
-  }, [
-    selectedTabId
-  ]);
-
-  const selectedTabIndex = TAB_ITEMS.findIndex(tabItem => tabItem.id === selectedTabId);
-
-  const handleTabSelect = (index: number) => {
-    updateQueryParameters({
-      [QUERY_PARAMETERS.TAB]: TAB_ITEMS[index].id
-    });
-  };
-
   return (
     <MainContainer>
       <Panel
@@ -79,32 +15,7 @@ const Transfer = (): JSX.Element | null => {
           'md:max-w-xl',
           'p-10'
         )}>
-        <InterlayTabGroup
-          defaultIndex={selectedTabIndex}
-          onChange={handleTabSelect}>
-          <InterlayTabList>
-            {TAB_ITEMS.map((tabItem => (
-              <InterlayTab
-                key={tabItem.id}
-                className='uppercase'>
-                {t(tabItem.label)}
-              </InterlayTab>
-            )))}
-          </InterlayTabList>
-          <Hr1
-            className={clsx(
-              'border-t-2',
-              'my-2'
-            )} />
-          <InterlayTabPanels className='mt-2'>
-            <InterlayTabPanel>
-              <TransferForm />
-            </InterlayTabPanel>
-            <InterlayTabPanel>
-              <CrossChainTransferForm />
-            </InterlayTabPanel>
-          </InterlayTabPanels>
-        </InterlayTabGroup>
+        <TransferForm />
       </Panel>
     </MainContainer>
   );

--- a/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
+++ b/src/parts/Sidebar/SidebarContent/Navigation/index.tsx
@@ -4,12 +4,12 @@ import { useLocation } from 'react-router-dom';
 import { matchPath } from 'react-router';
 import { useSelector } from 'react-redux';
 import {
-  ClipboardListIcon,
+  // ClipboardListIcon,
   CashIcon,
   BookOpenIcon,
-  RefreshIcon,
-  ChartSquareBarIcon,
-  ChipIcon,
+  // RefreshIcon,
+  // ChartSquareBarIcon,
+  // ChipIcon,
   SwitchHorizontalIcon,
   DocumentTextIcon
 } from '@heroicons/react/outline';
@@ -29,8 +29,8 @@ import {
   POLKADOT
 } from 'utils/constants/relay-chain-names';
 import {
-  PAGES,
-  URL_PARAMETERS
+  PAGES
+  // URL_PARAMETERS
 } from 'utils/constants/links';
 import { StoreType } from 'common/types/util.types';
 
@@ -59,7 +59,7 @@ const Navigation = ({
   const location = useLocation();
   const { t } = useTranslation();
   const {
-    vaultClientLoaded,
+    // vaultClientLoaded,
     address
   } = useSelector((state: StoreType) => state.general);
 
@@ -67,40 +67,40 @@ const Navigation = ({
     if (!address) return [];
 
     return [
-      {
-        name: 'nav_bridge',
-        link: PAGES.BRIDGE,
-        icon: RefreshIcon,
-        hidden: false
-      },
+      // {
+      //   name: 'nav_bridge',
+      //   link: PAGES.BRIDGE,
+      //   icon: RefreshIcon,
+      //   hidden: false
+      // },
       {
         name: 'nav_transfer',
         link: PAGES.TRANSFER,
         icon: SwitchHorizontalIcon
       },
-      {
-        name: 'nav_transactions',
-        link: PAGES.TRANSACTIONS,
-        icon: ClipboardListIcon,
-        hidden: false
-      },
-      {
-        name: 'nav_staking',
-        link: PAGES.STAKING,
-        icon: CashIcon
-      },
-      {
-        name: 'nav_dashboard',
-        link: PAGES.DASHBOARD,
-        icon: ChartSquareBarIcon,
-        hidden: false
-      },
-      {
-        name: 'nav_vault',
-        link: `${PAGES.VAULT.replace(`:${URL_PARAMETERS.VAULT_ACCOUNT_ADDRESS}`, address)}`,
-        icon: ChipIcon,
-        hidden: !vaultClientLoaded
-      },
+      // {
+      //   name: 'nav_transactions',
+      //   link: PAGES.TRANSACTIONS,
+      //   icon: ClipboardListIcon,
+      //   hidden: false
+      // },
+      // {
+      //   name: 'nav_staking',
+      //   link: PAGES.STAKING,
+      //   icon: CashIcon
+      // },
+      // {
+      //   name: 'nav_dashboard',
+      //   link: PAGES.DASHBOARD,
+      //   icon: ChartSquareBarIcon,
+      //   hidden: false
+      // },
+      // {
+      //   name: 'nav_vault',
+      //   link: `${PAGES.VAULT.replace(`:${URL_PARAMETERS.VAULT_ACCOUNT_ADDRESS}`, address)}`,
+      //   icon: ChipIcon,
+      //   hidden: !vaultClientLoaded
+      // },
       {
         name: 'separator',
         link: '#',
@@ -141,10 +141,7 @@ const Navigation = ({
         }
       }
     ];
-  }, [
-    address,
-    vaultClientLoaded
-  ]);
+  }, [address]);
 
   return (
     <nav


### PR DESCRIPTION
Change the navigation and routing so that only the transfer feature is available on Interlay. The changes to transfer can be reverted when we're ready to support XCM on Interlay.

This PR also changes the redirect so the transfer feature will be loaded at the base URL.

<img width="1714" alt="Screenshot 2022-04-19 at 13 39 21" src="https://user-images.githubusercontent.com/40243778/164005949-ed6bb9fd-efe9-4ef9-9ee1-0e6bbe4ec410.png">
