### PR TITLE
fix: added margin around btc qr code

### DIFF
--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/BTCPaymentPendingStatusUI/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/BTCPaymentPendingStatusUI/index.tsx
@@ -135,6 +135,7 @@ const BTCPaymentPendingStatusUI = ({
         </span>
       </p>
       <QRCode
+        includeMargin
         className='mx-auto'
         // eslint-disable-next-line max-len
         value={`bitcoin:${request.vaultWrappedAddress || request.vaultBackingAddress}?amount=${displayMonetaryAmount(amountBTCToSend)}`} />


### PR DESCRIPTION
~~Increasing the size to 256px with a margin around the code (this is critical to work with Bitcoin.com wallet and probably some other too).~~
Adding margin around the Bitcoin QR code. The problem was lack of white margin around the QR code square. With the margin added, the code gets read instantly. Tested with 3 different wallets and QR code reader.
