### PR TITLE
fix: relay fees

### DIFF
--- a/src/utils/relay-chain-api/constants.ts
+++ b/src/utils/relay-chain-api/constants.ts
@@ -7,11 +7,11 @@ const PARACHAIN_ID = process.env.REACT_APP_PARACHAIN_ID;
 const RELAY_CHAIN_TRANSFER_FEE =
   // First condition sets fee for both environments in testnet
   BITCOIN_NETWORK === BitcoinNetwork.Testnet ?
-    '32000000000' :
+    '1291039733' :
     process.env.REACT_APP_RELAY_CHAIN_NAME === 'kusama' ?
-      '106666660' :
+      '165940672' :
       process.env.REACT_APP_RELAY_CHAIN_NAME === 'polkadot' ?
-        '320000000' :
+        '482771107' :
         '';
 
 const TRANSFER_WEIGHT = '4000000000';


### PR DESCRIPTION
The fees for the relay chain have been modified, see https://github.com/paritytech/polkadot/pull/5202/files.

The weight of the message we are trying to send = `weight = 4_000_000_000`

For Kusama:
ExtrinsicBaseWeight = 80_350 * WEIGHT_PER_NANOS = 80_350_000
PricePerBaseWeight = 1/10 cent = 10^12 / 30_000 / 10
fee = (weight/ExtrinsicBaseWeight) * PricePerBaseWeight = (4_000_000_000 / 80_350_000) * (10^12 / 300_00 / 10)
= 165940676.208 (theoretical)
.. But due to rounding is actually 165940672

For polkadot:
ExtrinsicBaseWeight = 82_855 * WEIGHT_PER_NANOS = 82_855_000
PricePerBaseWeight = 1/10 cent = 10^10 / 100 / 10
(weight/ExtrinsicBaseWeight) * PricePerBaseWeight = (4_000_000_000 / 82_855_000) * (10^10 / 100 / 10)
= 482771106.149

For rococo:
ExtrinsicBaseWeight = 3_098_278 * WEIGHT_PER_NANOS = 3_098_278_000
PricePerBaseWeight = 1/10 cent = 10^12 / 100 / 10
(weight/ExtrinsicBaseWeight) * PricePerBaseWeight = (4_000_000_000 / 3_098_278_000) * (10^12 / 100 / 10)
= 1291039732.39 

In the mid-term we should probably move away from hardcoding these values, and instead use the `transactionPayment.weightToFee` constant. In the example below, we would multiply the weight by 0.0414. Which gives a result that is slightly off, so I think that polkadotjs rounds the percentage shown.

```
const transactionPayment.weightToFee: Vec<FrameSupportWeightsWeightToFeeCoefficient>

[
  {
    coeffInteger: 0
    coeffFrac: 4.14%
    negative: false
    degree: 1
  }
]
```