### PR TITLE
Feature/staking

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -449,7 +449,7 @@
     "tooltip_issue_capacity_zero": "Vault issue capacity is 0."
   },
   "staking_page": {
-    "estimated_governance_token_rewards_tooltip_label": "The estimated amount of {{governanceTokenSymbol}} you will receive as rewards. Depends on your proportion of the total {{voteGovernanceTokenSymbol}}.",
+    "the_estimated_amount_of_governance_token_you_will_receive_as_rewards": "The estimated amount of {{governanceTokenSymbol}} you will receive as rewards. Depends on your proportion of the total {{voteGovernanceTokenSymbol}}.",
     "new_vote_governance_token_gained": "New {{voteGovernanceTokenSymbol}} Gained",
     "the_increase_in_your_vote_governance_token_balance": "The increase in your {{voteGovernanceTokenSymbol}} balance"
   },

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -449,7 +449,9 @@
     "tooltip_issue_capacity_zero": "Vault issue capacity is 0."
   },
   "staking_page": {
-    "estimated_governance_token_rewards_tooltip_label": "The estimated amount of {{governanceTokenSymbol}} you will receive as rewards. Depends on your proportion of the total {{voteGovernanceTokenSymbol}}."
+    "estimated_governance_token_rewards_tooltip_label": "The estimated amount of {{governanceTokenSymbol}} you will receive as rewards. Depends on your proportion of the total {{voteGovernanceTokenSymbol}}.",
+    "new_vote_governance_token_gained": "New {{voteGovernanceTokenSymbol}} Gained",
+    "the_increase_in_your_vote_governance_token_balance": "The increase in your {{voteGovernanceTokenSymbol}} balance"
   },
   "about": {
     "research_paper": "Research Paper",

--- a/src/pages/Staking/BalancesUI/index.tsx
+++ b/src/pages/Staking/BalancesUI/index.tsx
@@ -128,7 +128,7 @@ const BalancesUI = ({
         label={`Projected ${GOVERNANCE_TOKEN_SYMBOL} Rewards`}
         value={projectedRewardAmount}
         tokenSymbol={GOVERNANCE_TOKEN_SYMBOL}
-        tooltip={t('staking_page.estimated_governance_token_rewards_tooltip_label', {
+        tooltip={t('staking_page.the_estimated_amount_of_governance_token_you_will_receive_as_rewards', {
           governanceTokenSymbol: GOVERNANCE_TOKEN_SYMBOL,
           voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
         })} />

--- a/src/pages/Staking/TotalStakedUI/index.tsx
+++ b/src/pages/Staking/TotalStakedUI/index.tsx
@@ -53,7 +53,7 @@ const TotalStakedUI = (): JSX.Element => {
   return (
     <div>
       <InformationUI
-        label={`Total Staked ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`}
+        label={`Total ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`}
         value={`${totalStakedVoteGovernanceTokenAmountLabel} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`} />
     </div>
   );

--- a/src/pages/Staking/TotalsUI/index.tsx
+++ b/src/pages/Staking/TotalsUI/index.tsx
@@ -16,7 +16,7 @@ import { displayMonetaryAmount } from 'common/utils/utils';
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
 import { StoreType } from 'common/types/util.types';
 
-const TotalStakedUI = (): JSX.Element => {
+const TotalsUI = (): JSX.Element => {
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
   const {
@@ -59,7 +59,7 @@ const TotalStakedUI = (): JSX.Element => {
   );
 };
 
-export default withErrorBoundary(TotalStakedUI, {
+export default withErrorBoundary(TotalsUI, {
   FallbackComponent: ErrorFallback,
   onReset: () => {
     window.location.reload();

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -523,7 +523,6 @@ const Staking = (): JSX.Element => {
     return undefined;
   };
 
-  // ray test touch <
   const renderVoteStakedAmountLabel = () => {
     if (
       voteGovernanceTokenBalanceIdle ||
@@ -537,7 +536,6 @@ const Staking = (): JSX.Element => {
 
     return displayMonetaryAmount(voteGovernanceTokenBalance);
   };
-  // ray test touch >
 
   const renderProjectedRewardAmountLabel = () => {
     if (
@@ -653,7 +651,6 @@ const Staking = (): JSX.Element => {
     return format(unlockDate, YEAR_MONTH_DAY_PATTERN);
   };
 
-  // ray test touch <
   const renderNewVoteGovernanceTokenGainedLabel = () => {
     const newTotalStakeAmount = getNewTotalStake();
     if (
@@ -698,7 +695,6 @@ const Staking = (): JSX.Element => {
 
     return `${displayMonetaryAmount(newTotalStakeAmount)} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
   };
-  // ray test touch >
 
   const renderEstimatedAPYLabel = () => {
     if (

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -523,6 +523,7 @@ const Staking = (): JSX.Element => {
     return undefined;
   };
 
+  // ray test touch <
   const renderVoteStakedAmountLabel = () => {
     if (
       voteGovernanceTokenBalanceIdle ||
@@ -536,6 +537,7 @@ const Staking = (): JSX.Element => {
 
     return displayMonetaryAmount(voteGovernanceTokenBalance);
   };
+  // ray test touch >
 
   const renderProjectedRewardAmountLabel = () => {
     if (
@@ -652,12 +654,12 @@ const Staking = (): JSX.Element => {
   };
 
   // ray test touch <
-  const renderNewTotalStakeLabel = () => {
+  const getNewTotalStakeAmount = () => {
     if (
       remainingBlockNumbersToUnstake === undefined ||
       stakedAmount === undefined
     ) {
-      return '-';
+      return undefined;
     }
     if (remainingBlockNumbersToUnstake === null) {
       throw new Error('Something went wrong!');
@@ -672,7 +674,14 @@ const Staking = (): JSX.Element => {
     const newLockingAmount = monetaryLockingAmount.add(stakedAmount);
 
     // Multiplying the new total staked governance token with the staking time divided by the maximum lock time
-    const newTotalStakeAmount = newLockingAmount.mul(newLockTime / STAKE_LOCK_TIME.MAX);
+    return newLockingAmount.mul(newLockTime / STAKE_LOCK_TIME.MAX);
+  };
+
+  const renderNewTotalStakeLabel = () => {
+    const newTotalStakeAmount = getNewTotalStakeAmount();
+    if (newTotalStakeAmount === undefined) {
+      return '-';
+    }
 
     return displayMonetaryAmount(newTotalStakeAmount);
   };
@@ -872,16 +881,26 @@ const Staking = (): JSX.Element => {
                 value={renderUnlockDateLabel()}
                 tooltip='Your staked amount will be locked until this date.' />
             )}
+            {/* ray test touch < */}
+            <InformationUI
+              label={t('staking_page.new_vote_governance_token_gained', {
+                voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
+              })}
+              value={`TEST ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`}
+              tooltip={t('staking_page.the_increase_in_your_vote_governance_token_balance', {
+                voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
+              })} />
+            {/* ray test touch > */}
             {votingBalanceGreaterThanZero && (
               <InformationUI
                 label='New total Stake'
                 value={`${renderNewTotalStakeLabel()} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`}
-                tooltip='Your total stake after this transaction.' />
+                tooltip='Your total stake after this transaction' />
             )}
             <InformationUI
               label='Estimated APY'
               value={renderEstimatedAPYLabel()}
-              tooltip={`The APY may change as the amount of total ${VOTE_GOVERNANCE_TOKEN_SYMBOL} changes`} />
+              tooltip={`The APY may change as the amount of total ${VOTE_GOVERNANCE_TOKEN_SYMBOL} changes.`} />
             <InformationUI
               label={`Estimated ${GOVERNANCE_TOKEN_SYMBOL} Rewards`}
               value={renderEstimatedRewardAmountLabel()}

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -654,7 +654,26 @@ const Staking = (): JSX.Element => {
   };
 
   // ray test touch <
-  const getNewTotalStakeAmount = () => {
+  const renderNewVoteGovernanceTokenGainedLabel = () => {
+    const newTotalStakeAmount = getNewTotalStake();
+    if (
+      voteGovernanceTokenBalance === undefined ||
+      newTotalStakeAmount === undefined
+    ) {
+      return '-';
+    }
+    // ray test touch <
+    console.log('ray : ***** newTotalStakeAmount.toString()', newTotalStakeAmount.toString());
+    console.log('ray : ***** voteGovernanceTokenBalance.toString()', voteGovernanceTokenBalance.toString());
+    const test = newTotalStakeAmount.sub(voteGovernanceTokenBalance);
+    console.log('ray : ***** test.toString()', test.toString());
+    // ray test touch >
+
+    // eslint-disable-next-line max-len
+    return `${displayMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
+  };
+
+  const getNewTotalStake = () => {
     if (
       remainingBlockNumbersToUnstake === undefined ||
       stakedAmount === undefined
@@ -673,17 +692,27 @@ const Staking = (): JSX.Element => {
     // New total staked governance token
     const newLockingAmount = monetaryLockingAmount.add(stakedAmount);
 
+    // ray test touch <
+    console.log('ray : ***** monetaryLockingAmount.toString()', monetaryLockingAmount.toString());
+    console.log('ray : ***** newLockingAmount.toString()', newLockingAmount.toString());
+    console.log('ray : ***** extendingLockTime', extendingLockTime);
+    console.log('ray : ***** currentLockTime', currentLockTime);
+    // ray test touch >
+
     // Multiplying the new total staked governance token with the staking time divided by the maximum lock time
-    return newLockingAmount.mul(newLockTime / STAKE_LOCK_TIME.MAX);
+    // ray test touch <
+    // return newLockingAmount.mul(newLockTime / STAKE_LOCK_TIME.MAX);
+    return newLockingAmount.mul(newLockTime).div(STAKE_LOCK_TIME.MAX);
+    // ray test touch >
   };
 
   const renderNewTotalStakeLabel = () => {
-    const newTotalStakeAmount = getNewTotalStakeAmount();
+    const newTotalStakeAmount = getNewTotalStake();
     if (newTotalStakeAmount === undefined) {
       return '-';
     }
 
-    return displayMonetaryAmount(newTotalStakeAmount);
+    return `${displayMonetaryAmount(newTotalStakeAmount)} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
   };
   // ray test touch >
 
@@ -886,7 +915,7 @@ const Staking = (): JSX.Element => {
               label={t('staking_page.new_vote_governance_token_gained', {
                 voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
               })}
-              value={`TEST ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`}
+              value={renderNewVoteGovernanceTokenGainedLabel()}
               tooltip={t('staking_page.the_increase_in_your_vote_governance_token_balance', {
                 voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
               })} />
@@ -894,7 +923,7 @@ const Staking = (): JSX.Element => {
             {votingBalanceGreaterThanZero && (
               <InformationUI
                 label='New total Stake'
-                value={`${renderNewTotalStakeLabel()} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`}
+                value={`${renderNewTotalStakeLabel()}`}
                 tooltip='Your total stake after this transaction' />
             )}
             <InformationUI

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -665,7 +665,7 @@ const Staking = (): JSX.Element => {
 
     // ray test touch <
     // eslint-disable-next-line max-len
-    return `${displayMonetaryAmount(newMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance).toBig().round(), VOTE_GOVERNANCE_TOKEN))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
+    return `${displayMonetaryAmount(newMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance).toBig(VOTE_GOVERNANCE_TOKEN.base).round(5), VOTE_GOVERNANCE_TOKEN, true))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
     // ray test touch >
   };
 
@@ -676,9 +676,11 @@ const Staking = (): JSX.Element => {
     ) {
       return undefined;
     }
+    // ray test touch <
     if (remainingBlockNumbersToUnstake === null) {
       throw new Error('Something went wrong!');
     }
+    // ray test touch >
 
     const currentLockTime = convertBlockNumbersToWeeks(remainingBlockNumbersToUnstake); // Weeks
     const extendingLockTime = parseInt(lockTime); // Weeks

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -482,7 +482,7 @@ const Staking = (): JSX.Element => {
       throw new Error('Something went wrong!');
     }
     if (monetaryLockingAmount.gt(availableBalance)) {
-      return 'Locking amount must be less than available balance!';
+      return 'Locking amount must not be greater than available balance!';
     }
 
     const planckLockingAmount = monetaryLockingAmount.to.Planck();

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -664,8 +664,11 @@ const Staking = (): JSX.Element => {
     }
 
     // ray test touch <
-    // eslint-disable-next-line max-len
-    return `${displayMonetaryAmount(newMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance).toBig(VOTE_GOVERNANCE_TOKEN.base).round(5), VOTE_GOVERNANCE_TOKEN, true))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
+    const newVoteGovernanceTokenAmountGained = newTotalStakeAmount.sub(voteGovernanceTokenBalance);
+    const rounded = newVoteGovernanceTokenAmountGained.toBig(VOTE_GOVERNANCE_TOKEN.base).round(5);
+    const typed = newMonetaryAmount(rounded, VOTE_GOVERNANCE_TOKEN, true);
+
+    return `${displayMonetaryAmount(typed)} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
     // ray test touch >
   };
 

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -49,9 +49,7 @@ import {
   STAKE_LOCK_TIME,
   GovernanceTokenMonetaryAmount,
   VoteGovernanceTokenMonetaryAmount,
-  // ray test touch <
   VOTE_GOVERNANCE_TOKEN
-  // ray test touch >
 } from 'config/relay-chains';
 import { BLOCK_TIME } from 'config/parachain';
 import { YEAR_MONTH_DAY_PATTERN } from 'utils/constants/date-time';
@@ -663,13 +661,11 @@ const Staking = (): JSX.Element => {
       return '-';
     }
 
-    // ray test touch <
     const newVoteGovernanceTokenAmountGained = newTotalStakeAmount.sub(voteGovernanceTokenBalance);
     const rounded = newVoteGovernanceTokenAmountGained.toBig(VOTE_GOVERNANCE_TOKEN.base).round(5);
     const typed = newMonetaryAmount(rounded, VOTE_GOVERNANCE_TOKEN, true);
 
     return `${displayMonetaryAmount(typed)} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
-    // ray test touch >
   };
 
   const getNewTotalStake = () => {
@@ -680,7 +676,6 @@ const Staking = (): JSX.Element => {
       return undefined;
     }
 
-    // ray test touch <
     const extendingLockTime = parseInt(lockTime); // Weeks
 
     let newLockTime: number;
@@ -697,7 +692,6 @@ const Staking = (): JSX.Element => {
       // New total staked governance token
       newLockingAmount = monetaryLockingAmount.add(stakedAmount);
     }
-    // ray test touch >
 
     // Multiplying the new total staked governance token with the staking time divided by the maximum lock time
     return newLockingAmount.mul(newLockTime).div(STAKE_LOCK_TIME.MAX);
@@ -906,7 +900,6 @@ const Staking = (): JSX.Element => {
                 value={renderUnlockDateLabel()}
                 tooltip='Your staked amount will be locked until this date.' />
             )}
-            {/* ray test touch < */}
             <InformationUI
               label={t('staking_page.new_vote_governance_token_gained', {
                 voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
@@ -915,7 +908,6 @@ const Staking = (): JSX.Element => {
               tooltip={t('staking_page.the_increase_in_your_vote_governance_token_balance', {
                 voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
               })} />
-            {/* ray test touch > */}
             {votingBalanceGreaterThanZero && (
               <InformationUI
                 label='New total Stake'

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -48,7 +48,10 @@ import {
   GOVERNANCE_TOKEN,
   STAKE_LOCK_TIME,
   GovernanceTokenMonetaryAmount,
-  VoteGovernanceTokenMonetaryAmount
+  VoteGovernanceTokenMonetaryAmount,
+  // ray test touch <
+  VOTE_GOVERNANCE_TOKEN
+  // ray test touch >
 } from 'config/relay-chains';
 import { BLOCK_TIME } from 'config/parachain';
 import { YEAR_MONTH_DAY_PATTERN } from 'utils/constants/date-time';
@@ -660,8 +663,10 @@ const Staking = (): JSX.Element => {
       return '-';
     }
 
+    // ray test touch <
     // eslint-disable-next-line max-len
-    return `${displayMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
+    return `${displayMonetaryAmount(newMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance).toBig().round(), VOTE_GOVERNANCE_TOKEN))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
+    // ray test touch >
   };
 
   const getNewTotalStake = () => {

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -651,6 +651,7 @@ const Staking = (): JSX.Element => {
     return format(unlockDate, YEAR_MONTH_DAY_PATTERN);
   };
 
+  // ray test touch <
   const renderNewTotalStakeLabel = () => {
     if (
       remainingBlockNumbersToUnstake === undefined ||
@@ -675,6 +676,7 @@ const Staking = (): JSX.Element => {
 
     return displayMonetaryAmount(newTotalStakeAmount);
   };
+  // ray test touch >
 
   const renderEstimatedAPYLabel = () => {
     if (

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -921,7 +921,7 @@ const Staking = (): JSX.Element => {
             <InformationUI
               label={`Estimated ${GOVERNANCE_TOKEN_SYMBOL} Rewards`}
               value={renderEstimatedRewardAmountLabel()}
-              tooltip={t('staking_page.estimated_governance_token_rewards_tooltip_label', {
+              tooltip={t('staking_page.the_estimated_amount_of_governance_token_you_will_receive_as_rewards', {
                 governanceTokenSymbol: GOVERNANCE_TOKEN_SYMBOL,
                 voteGovernanceTokenSymbol: VOTE_GOVERNANCE_TOKEN_SYMBOL
               })} />

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -31,7 +31,7 @@ import WithdrawButton from './WithdrawButton';
 import ClaimRewardsButton from './ClaimRewardsButton';
 import InformationUI from './InformationUI';
 import LockTimeField from './LockTimeField';
-import TotalStakedUI from './TotalStakedUI';
+import TotalsUI from './TotalsUI';
 import MainContainer from 'parts/MainContainer';
 import TitleWithUnderline from 'components/TitleWithUnderline';
 import Panel from 'components/Panel';
@@ -821,7 +821,7 @@ const Staking = (): JSX.Element => {
                 stakedAmount={renderStakedAmountLabel()}
                 remainingBlockNumbersToUnstake={remainingBlockNumbersToUnstake} />
             )}
-            <TotalStakedUI />
+            <TotalsUI />
             <div className='space-y-2'>
               <AvailableBalanceUI
                 label='Available balance'

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -676,19 +676,25 @@ const Staking = (): JSX.Element => {
     ) {
       return undefined;
     }
+
     // ray test touch <
-    if (remainingBlockNumbersToUnstake === null) {
-      throw new Error('Something went wrong!');
+    const extendingLockTime = parseInt(lockTime); // Weeks
+
+    let newLockTime: number;
+    let newLockingAmount: GovernanceTokenMonetaryAmount;
+    if (remainingBlockNumbersToUnstake === null) { // If the user has not staked
+      newLockTime = extendingLockTime;
+      newLockingAmount = monetaryLockingAmount;
+    } else { // If the user has staked
+      const currentLockTime = convertBlockNumbersToWeeks(remainingBlockNumbersToUnstake); // Weeks
+
+      // New lock-time that is applied to the entire staked governance token
+      newLockTime = currentLockTime + extendingLockTime; // Weeks
+
+      // New total staked governance token
+      newLockingAmount = monetaryLockingAmount.add(stakedAmount);
     }
     // ray test touch >
-
-    const currentLockTime = convertBlockNumbersToWeeks(remainingBlockNumbersToUnstake); // Weeks
-    const extendingLockTime = parseInt(lockTime); // Weeks
-    // New lock-time that is applied to the entire staked governance token
-    const newLockTime = currentLockTime + extendingLockTime; // Weeks
-
-    // New total staked governance token
-    const newLockingAmount = monetaryLockingAmount.add(stakedAmount);
 
     // Multiplying the new total staked governance token with the staking time divided by the maximum lock time
     return newLockingAmount.mul(newLockTime).div(STAKE_LOCK_TIME.MAX);

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -662,12 +662,6 @@ const Staking = (): JSX.Element => {
     ) {
       return '-';
     }
-    // ray test touch <
-    console.log('ray : ***** newTotalStakeAmount.toString()', newTotalStakeAmount.toString());
-    console.log('ray : ***** voteGovernanceTokenBalance.toString()', voteGovernanceTokenBalance.toString());
-    const test = newTotalStakeAmount.sub(voteGovernanceTokenBalance);
-    console.log('ray : ***** test.toString()', test.toString());
-    // ray test touch >
 
     // eslint-disable-next-line max-len
     return `${displayMonetaryAmount(newTotalStakeAmount.sub(voteGovernanceTokenBalance))} ${VOTE_GOVERNANCE_TOKEN_SYMBOL}`;
@@ -692,18 +686,8 @@ const Staking = (): JSX.Element => {
     // New total staked governance token
     const newLockingAmount = monetaryLockingAmount.add(stakedAmount);
 
-    // ray test touch <
-    console.log('ray : ***** monetaryLockingAmount.toString()', monetaryLockingAmount.toString());
-    console.log('ray : ***** newLockingAmount.toString()', newLockingAmount.toString());
-    console.log('ray : ***** extendingLockTime', extendingLockTime);
-    console.log('ray : ***** currentLockTime', currentLockTime);
-    // ray test touch >
-
     // Multiplying the new total staked governance token with the staking time divided by the maximum lock time
-    // ray test touch <
-    // return newLockingAmount.mul(newLockTime / STAKE_LOCK_TIME.MAX);
     return newLockingAmount.mul(newLockTime).div(STAKE_LOCK_TIME.MAX);
-    // ray test touch >
   };
 
   const renderNewTotalStakeLabel = () => {


### PR DESCRIPTION
Correct `Total staked vKINT` to `Total vKINT` because we don't have "Total staked vKINT` but only total vKINT in circulation.

![Capture](https://user-images.githubusercontent.com/84005068/168197355-c1859d04-7d92-4d55-8766-3516b5fd839e.PNG)

`New vKINT Gained` field is added for users to see with each new amount of KINT that they stake, how much new vKINT they get.

![Capture](https://user-images.githubusercontent.com/84005068/168301045-59b3e189-1914-4f30-8b47-2c11b35ec4a2.PNG)
![Capture-1](https://user-images.githubusercontent.com/84005068/168301052-99ec0fbf-281c-41e4-af40-9a2dfc53a2d4.PNG)