### PR TITLE
Feature/dashboard vaults sorting

### DIFF
--- a/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
@@ -309,43 +309,61 @@ const VaultsTable = (): JSX.Element => {
     ]
   );
 
-  const vaults: Array<Vault> = [];
-  if (
-    vaultsExt &&
-    btcToCollateralTokenRate &&
-    liquidationCollateralThreshold &&
-    secureCollateralThreshold &&
-    currentActiveBlockNumber
-  ) {
-    for (const vaultExt of vaultsExt) {
-      const statusLabel = getVaultStatusLabel(
-        vaultExt,
-        currentActiveBlockNumber,
-        liquidationCollateralThreshold,
-        secureCollateralThreshold,
-        btcToCollateralTokenRate,
-        t
-      );
+  // ray test touch <
+  const vaults: Array<Vault> | undefined = React.useMemo(() => {
+    if (
+      vaultsExt &&
+      btcToCollateralTokenRate &&
+      liquidationCollateralThreshold &&
+      secureCollateralThreshold &&
+      currentActiveBlockNumber
+    ) {
+      const rawVaults = vaultsExt.map(vaultExt => {
+        const statusLabel = getVaultStatusLabel(
+          vaultExt,
+          currentActiveBlockNumber,
+          liquidationCollateralThreshold,
+          secureCollateralThreshold,
+          btcToCollateralTokenRate,
+          t
+        );
 
-      const vaultCollateral = vaultExt.backingCollateral;
-      const settledTokens = vaultExt.issuedTokens;
-      const settledCollateralization = getCollateralization(vaultCollateral, settledTokens, btcToCollateralTokenRate);
-      const unsettledTokens = vaultExt.toBeIssuedTokens;
-      const unsettledCollateralization =
-        getCollateralization(vaultCollateral, unsettledTokens.add(settledTokens), btcToCollateralTokenRate);
+        const vaultCollateral = vaultExt.backingCollateral;
+        const settledTokens = vaultExt.issuedTokens;
+        const settledCollateralization = getCollateralization(vaultCollateral, settledTokens, btcToCollateralTokenRate);
+        const unsettledTokens = vaultExt.toBeIssuedTokens;
+        const unsettledCollateralization =
+          getCollateralization(vaultCollateral, unsettledTokens.add(settledTokens), btcToCollateralTokenRate);
 
-      vaults.push({
-        vaultId: vaultExt.id.accountId.toString(),
-        // TODO: fetch collateral reserved
-        lockedBTC: displayMonetaryAmount(settledTokens),
-        lockedDOT: displayMonetaryAmount(vaultCollateral),
-        pendingBTC: displayMonetaryAmount(unsettledTokens),
-        status: statusLabel,
-        unsettledCollateralization: unsettledCollateralization?.toString(),
-        settledCollateralization: settledCollateralization?.toString()
+        return {
+          vaultId: vaultExt.id.accountId.toString(),
+          // TODO: fetch collateral reserved
+          lockedBTC: displayMonetaryAmount(settledTokens),
+          lockedDOT: displayMonetaryAmount(vaultCollateral),
+          pendingBTC: displayMonetaryAmount(unsettledTokens),
+          status: statusLabel,
+          unsettledCollateralization: unsettledCollateralization?.toString(),
+          settledCollateralization: settledCollateralization?.toString()
+        };
       });
+
+      const sortedVaults = rawVaults.sort((vaultA, vaultB) => {
+        const vaultALockedBTC = vaultA.lockedBTC;
+        const vaultBLockedBTC = vaultB.lockedBTC;
+        return (vaultALockedBTC < vaultBLockedBTC ? 1 : (vaultALockedBTC > vaultBLockedBTC ? -1 : 0));
+      });
+
+      return sortedVaults;
     }
-  }
+  }, [
+    btcToCollateralTokenRate,
+    currentActiveBlockNumber,
+    liquidationCollateralThreshold,
+    secureCollateralThreshold,
+    t,
+    vaultsExt
+  ]);
+  // ray test touch >
 
   const {
     getTableProps,
@@ -356,7 +374,9 @@ const VaultsTable = (): JSX.Element => {
   } = useTable(
     {
       columns,
-      data: vaults
+      // ray test touch <
+      data: vaults ?? []
+      // ray test touch >
     }
   );
 

--- a/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
@@ -309,7 +309,6 @@ const VaultsTable = (): JSX.Element => {
     ]
   );
 
-  // ray test touch <
   const vaults: Array<Vault> | undefined = React.useMemo(() => {
     if (
       vaultsExt &&
@@ -363,7 +362,6 @@ const VaultsTable = (): JSX.Element => {
     t,
     vaultsExt
   ]);
-  // ray test touch >
 
   const {
     getTableProps,
@@ -374,9 +372,7 @@ const VaultsTable = (): JSX.Element => {
   } = useTable(
     {
       columns,
-      // ray test touch <
       data: vaults ?? []
-      // ray test touch >
     }
   );
 


### PR DESCRIPTION
- The vaults table in the dashboard is sorted by "Locked BTC" in a descending order.
- It's optimized via React.useMemo as it's an array manipulation.

![Capture](https://user-images.githubusercontent.com/84005068/170168249-8a5e22c1-6378-49e9-ab46-552ba5e15c74.PNG)