### PR TITLE
feat: handle undefined price values

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -370,9 +370,9 @@ const App = (): JSX.Element => {
       const newPrices = await response.json();
       // Update the store only if the price is actually changed
       if (
-        newPrices.bitcoin.usd !== prices.bitcoin.usd ||
-        newPrices[RELAY_CHAIN_NAME].usd !== prices.collateralToken.usd ||
-        newPrices[BRIDGE_PARACHAIN_NAME].usd !== prices.governanceToken.usd
+        newPrices.bitcoin?.usd !== prices.bitcoin?.usd ||
+        newPrices[RELAY_CHAIN_NAME]?.usd !== prices.collateralToken?.usd ||
+        newPrices[BRIDGE_PARACHAIN_NAME]?.usd !== prices.governanceToken?.usd
       ) {
         dispatch(
           updateOfPricesAction({

--- a/src/common/types/util.types.ts
+++ b/src/common/types/util.types.ts
@@ -50,13 +50,13 @@ export enum ParachainStatus {
 export type Prices = {
   bitcoin: {
     usd: number;
-  };
+  } | undefined;
   collateralToken: {
     usd: number;
-  };
+  } | undefined;
   governanceToken: {
     usd: number;
-  };
+  } | undefined;
 };
 
 export type GeneralState = {

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -52,7 +52,11 @@ function getLastMidnightTimestamps(daysBack: number, startFromTonight = false): 
 
 // TODO: replace these functions with internationalization functions
 // always round USD amounts to two decimals
-function getUsdAmount<C extends CurrencyUnit>(amount: MonetaryAmount<Currency<C>, C>, rate: number): string {
+function getUsdAmount<C extends CurrencyUnit>(amount: MonetaryAmount<Currency<C>, C>, rate: number | undefined): string {
+  // If price data is unavailable dash is shown.
+  if (rate === undefined) {
+    return '—';
+  }
   return amount.toBig(amount.currency.base).mul(new Big(rate)).toFixed(2).toString();
 }
 

--- a/src/pages/Bridge/BurnForm/index.tsx
+++ b/src/pages/Bridge/BurnForm/index.tsx
@@ -201,7 +201,7 @@ const BurnForm = (): JSX.Element | null => {
             unitIcon={<WrappedTokenLogoIcon width={20} />}
             value={displayMonetaryAmount(burnableTokens)}
             unitName={WRAPPED_TOKEN_SYMBOL}
-            approxUSD={getUsdAmount(burnableTokens, prices.bitcoin.usd)}
+            approxUSD={getUsdAmount(burnableTokens, prices.bitcoin?.usd)}
           />
           <TokenField
             id={WRAPPED_TOKEN_AMOUNT}
@@ -214,7 +214,7 @@ const BurnForm = (): JSX.Element | null => {
               },
               validate: (value) => validateForm(value)
             })}
-            approxUSD={`≈ $ ${getUsdAmount(parsedInterBTCAmount || BitcoinAmount.zero, prices.bitcoin.usd)}`}
+            approxUSD={`≈ $ ${getUsdAmount(parsedInterBTCAmount || BitcoinAmount.zero, prices.bitcoin?.usd)}`}
             error={!!errors[WRAPPED_TOKEN_AMOUNT]}
             helperText={errors[WRAPPED_TOKEN_AMOUNT]?.message}
           />
@@ -233,7 +233,7 @@ const BurnForm = (): JSX.Element | null => {
             unitIcon={<CollateralTokenLogoIcon width={20} />}
             value={displayMonetaryAmount(earnedCollateralTokenAmount)}
             unitName={COLLATERAL_TOKEN_SYMBOL}
-            approxUSD={getUsdAmount(earnedCollateralTokenAmount, prices.collateralToken.usd)}
+            approxUSD={getUsdAmount(earnedCollateralTokenAmount, prices.collateralToken?.usd)}
           />
           <SubmitButton
             // TODO: should not check everywhere like this

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -332,7 +332,7 @@ const IssueForm = (): JSX.Element | null => {
                 },
                 validate: (value) => validateForm(value)
               })}
-              approxUSD={`≈ $ ${getUsdAmount(parsedBTCAmount || BitcoinAmount.zero, prices.bitcoin.usd)}`}
+              approxUSD={`≈ $ ${getUsdAmount(parsedBTCAmount || BitcoinAmount.zero, prices.bitcoin?.usd)}`}
               error={!!errors[BTC_AMOUNT]}
               helperText={errors[BTC_AMOUNT]?.message}
             />
@@ -379,7 +379,7 @@ const IssueForm = (): JSX.Element | null => {
             unitIcon={<BitcoinLogoIcon width={23} height={23} />}
             value={displayMonetaryAmount(bridgeFee)}
             unitName='BTC'
-            approxUSD={getUsdAmount(bridgeFee, prices.bitcoin.usd)}
+            approxUSD={getUsdAmount(bridgeFee, prices.bitcoin?.usd)}
             tooltip={
               <InformationTooltip
                 className={clsx(
@@ -404,7 +404,7 @@ const IssueForm = (): JSX.Element | null => {
             unitIcon={<GovernanceTokenLogoIcon width={20} />}
             value={displayMonetaryAmount(securityDeposit)}
             unitName={GOVERNANCE_TOKEN_SYMBOL}
-            approxUSD={getUsdAmount(securityDeposit, prices.governanceToken.usd)}
+            approxUSD={getUsdAmount(securityDeposit, prices.governanceToken?.usd)}
             tooltip={
               <InformationTooltip
                 className={clsx(
@@ -429,7 +429,7 @@ const IssueForm = (): JSX.Element | null => {
             unitIcon={<GovernanceTokenLogoIcon width={20} />}
             value={displayMonetaryAmount(extraRequiredCollateralTokenAmount)}
             unitName={GOVERNANCE_TOKEN_SYMBOL}
-            approxUSD={getUsdAmount(extraRequiredCollateralTokenAmount, prices.governanceToken.usd)}
+            approxUSD={getUsdAmount(extraRequiredCollateralTokenAmount, prices.governanceToken?.usd)}
             tooltip={
               <InformationTooltip
                 className={clsx(
@@ -455,7 +455,7 @@ const IssueForm = (): JSX.Element | null => {
             unitIcon={<WrappedTokenLogoIcon width={20} />}
             value={displayMonetaryAmount(wrappedTokenAmount)}
             unitName={WRAPPED_TOKEN_SYMBOL}
-            approxUSD={getUsdAmount(wrappedTokenAmount, prices.bitcoin.usd)}
+            approxUSD={getUsdAmount(wrappedTokenAmount, prices.bitcoin?.usd)}
           />
           <SubmitButton
             disabled={

--- a/src/pages/Bridge/RedeemForm/SubmittedRedeemRequestModal/index.tsx
+++ b/src/pages/Bridge/RedeemForm/SubmittedRedeemRequestModal/index.tsx
@@ -69,7 +69,7 @@ const SubmittedRedeemRequestModal = ({
                   'text-center'
                 )}
               >
-                {`≈ $${getUsdAmount(request.amountBTC, prices.bitcoin.usd)}`}
+                {`≈ $${getUsdAmount(request.amountBTC, prices.bitcoin?.usd)}`}
               </span>
             </div>
             <div>

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -51,7 +51,7 @@ const RedeemForm = (): JSX.Element | null => {
 
   const handleError = useErrorHandler();
 
-  const usdPrice = useSelector((state: StoreType) => state.general.prices.bitcoin.usd);
+  const usdPrice = useSelector((state: StoreType) => state.general.prices.bitcoin?.usd);
   const {
     wrappedTokenBalance,
     bridgeLoaded,
@@ -301,20 +301,20 @@ const RedeemForm = (): JSX.Element | null => {
     };
 
     const redeemFeeInBTC = displayMonetaryAmount(redeemFee);
-    const redeemFeeInUSD = getUsdAmount(redeemFee, prices.bitcoin.usd);
+    const redeemFeeInUSD = getUsdAmount(redeemFee, prices.bitcoin?.usd);
     const parsedInterBTCAmount = BitcoinAmount.from.BTC(wrappedTokenAmount || 0);
     const totalBTC = wrappedTokenAmount
       ? parsedInterBTCAmount.sub(redeemFee).sub(currentInclusionFee)
       : BitcoinAmount.zero;
-    const totalBTCInUSD = getUsdAmount(totalBTC, prices.bitcoin.usd);
+    const totalBTCInUSD = getUsdAmount(totalBTC, prices.bitcoin?.usd);
 
     const totalDOT = wrappedTokenAmount
       ? btcToDotRate.toCounter(parsedInterBTCAmount).mul(premiumRedeemFee)
       : newMonetaryAmount(0, COLLATERAL_TOKEN);
-    const totalDOTInUSD = getUsdAmount(totalDOT, prices.collateralToken.usd);
+    const totalDOTInUSD = getUsdAmount(totalDOT, prices.collateralToken?.usd);
 
     const bitcoinNetworkFeeInBTC = displayMonetaryAmount(currentInclusionFee);
-    const bitcoinNetworkFeeInUSD = getUsdAmount(currentInclusionFee, prices.bitcoin.usd);
+    const bitcoinNetworkFeeInUSD = getUsdAmount(currentInclusionFee, prices.bitcoin?.usd);
     const accountSet = !!address;
 
     return (

--- a/src/pages/Dashboard/cards/CollateralLockedCard/index.tsx
+++ b/src/pages/Dashboard/cards/CollateralLockedCard/index.tsx
@@ -81,7 +81,7 @@ const CollateralLockedCard = ({ hasLinks }: Props): JSX.Element => {
               <StatsDd>
                 {displayMonetaryAmount(totalLockedCollateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
               </StatsDd>
-              <StatsDd>${getUsdAmount(totalLockedCollateralTokenAmount, prices.collateralToken.usd)}</StatsDd>
+              <StatsDd>${getUsdAmount(totalLockedCollateralTokenAmount, prices.collateralToken?.usd)}</StatsDd>
             </>
           }
           rightPart={<>{hasLinks && <StatsRouterLink to={PAGES.DASHBOARD_VAULTS}>View vaults</StatsRouterLink>}</>}

--- a/src/pages/Dashboard/sub-pages/Home/WrappedTokenCard/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Home/WrappedTokenCard/index.tsx
@@ -26,7 +26,7 @@ const WrappedTokenCard = (): JSX.Element => {
                   wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL
                 })}
               </StatsDd>
-              <StatsDd>${getUsdAmount(totalWrappedTokenAmount, prices.bitcoin.usd)}</StatsDd>
+              <StatsDd>${getUsdAmount(totalWrappedTokenAmount, prices.bitcoin?.usd)}</StatsDd>
             </>
           }
           rightPart={

--- a/src/pages/Dashboard/sub-pages/IssueRequests/UpperContent/index.tsx
+++ b/src/pages/Dashboard/sub-pages/IssueRequests/UpperContent/index.tsx
@@ -59,7 +59,7 @@ const UpperContent = (): JSX.Element => {
                 wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL
               })}
             </StatsDd>
-            <StatsDd>${getUsdAmount(totalWrappedTokenAmount, prices.bitcoin.usd).toLocaleString()}</StatsDd>
+            <StatsDd>${getUsdAmount(totalWrappedTokenAmount, prices.bitcoin?.usd).toLocaleString()}</StatsDd>
             <StatsDt className='!text-interlayConifer'>{t('dashboard.issue.issue_requests')}</StatsDt>
             <StatsDd>{totalSuccessfulIssueCount}</StatsDd>
           </>

--- a/src/pages/Dashboard/sub-pages/RedeemRequests/UpperContent/index.tsx
+++ b/src/pages/Dashboard/sub-pages/RedeemRequests/UpperContent/index.tsx
@@ -89,7 +89,9 @@ const UpperContent = (): JSX.Element => {
             </StatsDd>
             <StatsDd>
               {/* eslint-disable-next-line max-len */}$
-              {(prices.bitcoin.usd * Number(totalRedeemedAmount.str.BTC())).toLocaleString()}
+              {prices.bitcoin === undefined
+                ? '—'
+                : (prices.bitcoin.usd * Number(totalRedeemedAmount.str.BTC())).toLocaleString()}
             </StatsDd>
             <StatsDt className='!text-interlayConifer'>{t('dashboard.redeem.total_redeems')}</StatsDt>
             <StatsDd>{totalSuccessfulRedeemCount}</StatsDd>

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -614,7 +614,7 @@ const Staking = (): JSX.Element => {
     }
   };
 
-  const valueInUSDOfLockingAmount = getUsdAmount(monetaryLockingAmount, prices.governanceToken.usd);
+  const valueInUSDOfLockingAmount = getUsdAmount(monetaryLockingAmount, prices.governanceToken?.usd);
 
   const claimRewardsButtonEnabled = claimableRewardAmount?.gt(ZERO_GOVERNANCE_TOKEN_AMOUNT);
 

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/BTCPaymentPendingStatusUI/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/BTCPaymentPendingStatusUI/index.tsx
@@ -51,7 +51,7 @@ const BTCPaymentPendingStatusUI = ({ request }: Props): JSX.Element => {
             'block'
           )}
         >
-          {`≈ $ ${getUsdAmount(amountBTCToSend, prices.bitcoin.usd)}`}
+          {`≈ $ ${getUsdAmount(amountBTCToSend, prices.bitcoin?.usd)}`}
         </span>
       </div>
       <div>

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/WhoopsStatusUI/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/WhoopsStatusUI/index.tsx
@@ -57,7 +57,7 @@ const WhoopsStatusUI = ({ request }: Props): JSX.Element => {
         unitIcon={<BitcoinLogoIcon width={23} height={23} />}
         value={displayMonetaryAmount(request.request.amountWrapped)}
         unitName={WRAPPED_TOKEN_SYMBOL}
-        approxUSD={getUsdAmount(request.request.amountWrapped, prices.bitcoin.usd)}
+        approxUSD={getUsdAmount(request.request.amountWrapped, prices.bitcoin?.usd)}
       />
       <PriceInfo
         className='w-full'
@@ -65,7 +65,7 @@ const WhoopsStatusUI = ({ request }: Props): JSX.Element => {
         unitIcon={<BitcoinLogoIcon width={23} height={23} />}
         value={displayMonetaryAmount(request.backingPayment.amount)}
         unitName='BTC'
-        approxUSD={getUsdAmount(request.backingPayment.amount, prices.bitcoin.usd)}
+        approxUSD={getUsdAmount(request.backingPayment.amount, prices.bitcoin?.usd)}
       />
       <PriceInfo
         className='w-full'
@@ -73,7 +73,7 @@ const WhoopsStatusUI = ({ request }: Props): JSX.Element => {
         unitIcon={<BitcoinLogoIcon width={23} height={23} />}
         value={displayMonetaryAmount(request.execution.amountWrapped)}
         unitName={WRAPPED_TOKEN_SYMBOL}
-        approxUSD={getUsdAmount(request.execution.amountWrapped, prices.bitcoin.usd)}
+        approxUSD={getUsdAmount(request.execution.amountWrapped, prices.bitcoin?.usd)}
       />
       <Hr2 className={clsx('border-t-2', 'my-2.5', 'w-full')} />
       <PriceInfo
@@ -93,7 +93,7 @@ const WhoopsStatusUI = ({ request }: Props): JSX.Element => {
         unitName='BTC'
         approxUSD={getUsdAmount(
           request.backingPayment.amountWrapped.sub(request.execution.amountWrapped),
-          prices.bitcoin.usd
+          prices.bitcoin?.usd
         )}
       />
       <p

--- a/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/index.tsx
+++ b/src/pages/Transactions/IssueRequestsTable/IssueRequestModal/index.tsx
@@ -87,7 +87,7 @@ const IssueRequestModal = ({
                   'block'
                 )}
               >
-                {`≈ $ ${getUsdAmount(receivedWrappedTokenAmount, prices.bitcoin.usd)}`}
+                {`≈ $ ${getUsdAmount(receivedWrappedTokenAmount, prices.bitcoin?.usd)}`}
               </span>
             </div>
             <div>
@@ -105,7 +105,7 @@ const IssueRequestModal = ({
                 unitIcon={<BitcoinLogoIcon width={23} height={23} />}
                 value={displayMonetaryAmount(bridgeFee)}
                 unitName='BTC'
-                approxUSD={getUsdAmount(bridgeFee, prices.bitcoin.usd)}
+                approxUSD={getUsdAmount(bridgeFee, prices.bitcoin?.usd)}
               />
               <Hr2 className={clsx('border-t-2', 'my-2.5')} />
               <PriceInfo
@@ -122,7 +122,7 @@ const IssueRequestModal = ({
                 unitIcon={<BitcoinLogoIcon width={23} height={23} />}
                 value={displayMonetaryAmount(sentBackingTokenAmount)}
                 unitName='BTC'
-                approxUSD={getUsdAmount(sentBackingTokenAmount, prices.bitcoin.usd)}
+                approxUSD={getUsdAmount(sentBackingTokenAmount, prices.bitcoin?.usd)}
               />
             </div>
             <div className='space-y-4'>

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/ReimbursedRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/ReimbursedRedeemRequest/index.tsx
@@ -79,7 +79,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
         <span className='text-interlayCinnabar'>
           {`${displayMonetaryAmount(burnedBTCAmount)} ${WRAPPED_TOKEN_SYMBOL}`}
         </span>
-        <span>&nbsp;{`(≈ $${getUsdAmount(burnedBTCAmount, prices.bitcoin.usd)})`}</span>
+        <span>&nbsp;{`(≈ $${getUsdAmount(burnedBTCAmount, prices.bitcoin?.usd)})`}</span>
         <span className='text-interlayCinnabar'>&nbsp;{t('redeem_page.reimbursed').toLowerCase()}</span>.
       </p>
       <p className='font-medium'>
@@ -87,7 +87,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
         <PrimaryColorSpan>
           &nbsp;{`${displayMonetaryAmount(collateralTokenAmount)} ${COLLATERAL_TOKEN_SYMBOL}`}
         </PrimaryColorSpan>
-        <span>&nbsp;{`(≈ $${getUsdAmount(collateralTokenAmount, prices.collateralToken.usd)})`}</span>
+        <span>&nbsp;{`(≈ $${getUsdAmount(collateralTokenAmount, prices.collateralToken?.usd)})`}</span>
         <PrimaryColorSpan>&nbsp;{t('redeem_page.recover_receive_total')}</PrimaryColorSpan>.
       </p>
       <div className='w-full'>
@@ -108,7 +108,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
           unitIcon={<CollateralTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(burnCollateralTokenAmount)}
           unitName={COLLATERAL_TOKEN_SYMBOL}
-          approxUSD={getUsdAmount(burnCollateralTokenAmount, prices.collateralToken.usd)}
+          approxUSD={getUsdAmount(burnCollateralTokenAmount, prices.collateralToken?.usd)}
         />
         <PriceInfo
           className='w-full'
@@ -125,7 +125,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
           unitIcon={<CollateralTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(punishmentCollateralTokenAmount)}
           unitName={COLLATERAL_TOKEN_SYMBOL}
-          approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)}
+          approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}
         />
         <Hr2 className={clsx('border-t-2', 'my-2.5')} />
         <PriceInfo
@@ -143,7 +143,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
           unitIcon={<CollateralTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(collateralTokenAmount)}
           unitName={COLLATERAL_TOKEN_SYMBOL}
-          approxUSD={getUsdAmount(collateralTokenAmount, prices.collateralToken.usd)}
+          approxUSD={getUsdAmount(collateralTokenAmount, prices.collateralToken?.usd)}
         />
       </div>
       <ExternalLink className='text-sm' href={getPolkadotLink(request.request.height.absolute)}>

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/RetriedRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/RetriedRedeemRequest/index.tsx
@@ -62,7 +62,7 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
         <PrimaryColorSpan>
           &nbsp;{`${displayMonetaryAmount(punishmentCollateralTokenAmount)} ${COLLATERAL_TOKEN_SYMBOL}`}
         </PrimaryColorSpan>
-        <span>&nbsp;({`≈ $${getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)}`})</span>
+        <span>&nbsp;({`≈ $${getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}`})</span>
         <PrimaryColorSpan>&nbsp;{t('redeem_page.recover_receive_total')}.</PrimaryColorSpan>
       </p>
       <div className='w-full'>
@@ -80,7 +80,7 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
           unitIcon={<CollateralTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(punishmentCollateralTokenAmount)}
           unitName={COLLATERAL_TOKEN_SYMBOL}
-          approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)}
+          approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}
         />
         <Hr2 className={clsx('border-t-2', 'my-2.5')} />
         <PriceInfo
@@ -98,7 +98,7 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
           unitIcon={<CollateralTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(punishmentCollateralTokenAmount)}
           unitName={COLLATERAL_TOKEN_SYMBOL}
-          approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)}
+          approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}
         />
       </div>
       <ExternalLink className='text-sm' href={getPolkadotLink(request.request.height.absolute)}>

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/ReimburseStatusUI/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/ReimburseStatusUI/index.tsx
@@ -137,7 +137,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
           <PrimaryColorSpan>
             &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
           </PrimaryColorSpan>
-          <span>&nbsp;{`(≈ $ ${getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)})`}</span>
+          <span>&nbsp;{`(≈ $ ${getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)})`}</span>
           <span>
             &nbsp;
             {t('redeem_page.compensation', {
@@ -170,7 +170,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
               <span>
                 &nbsp;
                 {t('redeem_page.retry_with_another', {
-                  compensationPrice: getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)
+                  compensationPrice: getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)
                 })}
               </span>
               .
@@ -197,7 +197,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
               <span>
                 &nbsp;
                 {t('redeem_page.with_added', {
-                  amountPrice: getUsdAmount(collateralTokenAmount, prices.collateralToken.usd)
+                  amountPrice: getUsdAmount(collateralTokenAmount, prices.collateralToken?.usd)
                 })}
               </span>
               <PrimaryColorSpan>
@@ -206,7 +206,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
               <span>
                 &nbsp;
                 {t('redeem_page.as_compensation_instead', {
-                  compensationPrice: getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken.usd)
+                  compensationPrice: getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)
                 })}
               </span>
             </p>

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/index.tsx
@@ -73,7 +73,7 @@ const RedeemRequestModal = ({
                   'block'
                 )}
               >
-                {`≈ $ ${getUsdAmount(redeemedWrappedTokenAmount, prices.bitcoin.usd)}`}
+                {`≈ $ ${getUsdAmount(redeemedWrappedTokenAmount, prices.bitcoin?.usd)}`}
               </span>
             </div>
             <div>
@@ -91,7 +91,7 @@ const RedeemRequestModal = ({
                 unitIcon={<BitcoinLogoIcon width={23} height={23} />}
                 value={displayMonetaryAmount(request.bridgeFee)}
                 unitName='BTC'
-                approxUSD={getUsdAmount(request.bridgeFee, prices.bitcoin.usd)}
+                approxUSD={getUsdAmount(request.bridgeFee, prices.bitcoin?.usd)}
               />
               <PriceInfo
                 title={
@@ -107,7 +107,7 @@ const RedeemRequestModal = ({
                 unitIcon={<BitcoinLogoIcon width={23} height={23} />}
                 value={displayMonetaryAmount(request.btcTransferFee)}
                 unitName='BTC'
-                approxUSD={getUsdAmount(request.btcTransferFee, prices.bitcoin.usd)}
+                approxUSD={getUsdAmount(request.btcTransferFee, prices.bitcoin?.usd)}
               />
               <Hr2 className={clsx('border-t-2', 'my-2.5')} />
               <PriceInfo
@@ -124,7 +124,7 @@ const RedeemRequestModal = ({
                 unitIcon={<BitcoinLogoIcon width={23} height={23} />}
                 value={displayMonetaryAmount(request.request.requestedAmountBacking)}
                 unitName='BTC'
-                approxUSD={getUsdAmount(request.request.requestedAmountBacking, prices.bitcoin.usd)}
+                approxUSD={getUsdAmount(request.request.requestedAmountBacking, prices.bitcoin?.usd)}
               />
             </div>
             <div className='space-y-4'>

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -115,7 +115,7 @@ const CrossChainTransferForm = (): JSX.Element => {
     if (!event.target.value) return;
 
     const value = newMonetaryAmount(event.target.value, COLLATERAL_TOKEN, true);
-    const usd = getUsdAmount(value, prices.collateralToken.usd);
+    const usd = getUsdAmount(value, prices.collateralToken?.usd);
 
     setApproxUsdValue(usd);
   };

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -257,7 +257,7 @@ const RequestIssueModal = ({ onClose, open, vaultAddress }: Props): JSX.Element 
                   },
                   validate: (value) => validateForm(value)
                 })}
-                approxUSD={`≈ $ ${getUsdAmount(parsedBTCAmount || BitcoinAmount.zero, prices.bitcoin.usd)}`}
+                approxUSD={`≈ $ ${getUsdAmount(parsedBTCAmount || BitcoinAmount.zero, prices.bitcoin?.usd)}`}
                 error={!!errors[WRAPPED_TOKEN_AMOUNT]}
                 helperText={errors[WRAPPED_TOKEN_AMOUNT]?.message}
               />
@@ -276,7 +276,7 @@ const RequestIssueModal = ({ onClose, open, vaultAddress }: Props): JSX.Element 
               unitIcon={<BitcoinLogoIcon width={23} height={23} />}
               value={displayMonetaryAmount(bridgeFee)}
               unitName='BTC'
-              approxUSD={getUsdAmount(bridgeFee, prices.bitcoin.usd)}
+              approxUSD={getUsdAmount(bridgeFee, prices.bitcoin?.usd)}
               tooltip={
                 <InformationTooltip
                   className={clsx(
@@ -301,7 +301,7 @@ const RequestIssueModal = ({ onClose, open, vaultAddress }: Props): JSX.Element 
               unitIcon={<GovernanceTokenLogoIcon width={20} />}
               value={displayMonetaryAmount(securityDeposit)}
               unitName={GOVERNANCE_TOKEN_SYMBOL}
-              approxUSD={getUsdAmount(securityDeposit, prices.governanceToken.usd)}
+              approxUSD={getUsdAmount(securityDeposit, prices.governanceToken?.usd)}
               tooltip={
                 <InformationTooltip
                   className={clsx(
@@ -326,7 +326,7 @@ const RequestIssueModal = ({ onClose, open, vaultAddress }: Props): JSX.Element 
               unitIcon={<GovernanceTokenLogoIcon width={20} />}
               value={displayMonetaryAmount(extraRequiredCollateralTokenAmount)}
               unitName={GOVERNANCE_TOKEN_SYMBOL}
-              approxUSD={getUsdAmount(extraRequiredCollateralTokenAmount, prices.governanceToken.usd)}
+              approxUSD={getUsdAmount(extraRequiredCollateralTokenAmount, prices.governanceToken?.usd)}
               tooltip={
                 <InformationTooltip
                   className={clsx(
@@ -352,7 +352,7 @@ const RequestIssueModal = ({ onClose, open, vaultAddress }: Props): JSX.Element 
               unitIcon={<WrappedTokenLogoIcon width={20} />}
               value={displayMonetaryAmount(wrappedTokenAmount)}
               unitName={WRAPPED_TOKEN_SYMBOL}
-              approxUSD={getUsdAmount(wrappedTokenAmount, prices.bitcoin.usd)}
+              approxUSD={getUsdAmount(wrappedTokenAmount, prices.bitcoin?.usd)}
             />
             <SubmitButton
               disabled={


### PR DESCRIPTION
This PR adds handling of the prices in cases when CoinGecko API does not return requested data. Majority of changes are just additions of optional chaining operator `?.`.

_Visual preview_
When price data is unavailable, dash is shown (bottom-right corner)
![image](https://user-images.githubusercontent.com/47864599/170987297-c9cd23b8-7e18-4085-b905-85f420222819.png)
