### PR TITLE
refactor: update collateral token to relay chain native token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { ACCOUNT_ID_TYPE_NAME } from 'config/general';
 import {
   APP_NAME,
   WRAPPED_TOKEN,
-  COLLATERAL_TOKEN,
+  RELAY_CHAIN_NATIVE_TOKEN,
   GOVERNANCE_TOKEN,
   PRICES_URL,
   RELAY_CHAIN_NAME,
@@ -168,7 +168,7 @@ const App = (): JSX.Element => {
           state
         ] = await Promise.all([
           window.bridge.tokens.total(WRAPPED_TOKEN),
-          window.bridge.tokens.total(COLLATERAL_TOKEN),
+          window.bridge.tokens.total(RELAY_CHAIN_NATIVE_TOKEN),
           window.bridge.tokens.total(GOVERNANCE_TOKEN),
           window.bridge.btcRelay.getLatestBlockHeight(),
           window.bridge.electrsAPI.getLatestBlockHeight(),
@@ -260,7 +260,7 @@ const App = (): JSX.Element => {
     (async () => {
       try {
         unsubscribeFromCollateral = await window.bridge.tokens.subscribeToBalance(
-          COLLATERAL_TOKEN,
+          RELAY_CHAIN_NATIVE_TOKEN,
           address,
           (_: string, balance: ChainBalance<CollateralUnit>) => {
             if (!balance.free.eq(collateralTokenBalance)) {

--- a/src/common/live-data/totals-watcher.ts
+++ b/src/common/live-data/totals-watcher.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from 'redux';
 
-import { COLLATERAL_TOKEN, WRAPPED_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN } from 'config/relay-chains';
 import { updateTotalsAction } from '../actions/general.actions';
 import { StoreState } from '../types/util.types';
 
@@ -12,7 +12,7 @@ export default async function fetchTotals(dispatch: Dispatch, store: StoreState)
   try {
     const [latestTotalWrappedTokenAmount, latestTotalLockedCollateralTokenAmount] = await Promise.all([
       window.bridge.tokens.total(WRAPPED_TOKEN),
-      window.bridge.tokens.total(COLLATERAL_TOKEN)
+      window.bridge.tokens.total(RELAY_CHAIN_NATIVE_TOKEN)
     ]);
 
     // update store only if there is a difference between the latest totals and current totals

--- a/src/common/reducers/general.reducer.ts
+++ b/src/common/reducers/general.reducer.ts
@@ -1,7 +1,7 @@
 import { BitcoinAmount } from '@interlay/monetary-js';
 import { newMonetaryAmount } from '@interlay/interbtc-api';
 
-import { COLLATERAL_TOKEN, GOVERNANCE_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, GOVERNANCE_TOKEN } from 'config/relay-chains';
 import {
   IS_BRIDGE_LOADED,
   IS_VAULT_CLIENT_LOADED,
@@ -29,11 +29,11 @@ const initialState = {
   showAccountModal: false,
   address: '',
   totalWrappedTokenAmount: BitcoinAmount.zero,
-  totalLockedCollateralTokenAmount: newMonetaryAmount(0, COLLATERAL_TOKEN),
+  totalLockedCollateralTokenAmount: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
   wrappedTokenBalance: BitcoinAmount.zero,
   wrappedTokenTransferableBalance: BitcoinAmount.zero,
-  collateralTokenBalance: newMonetaryAmount(0, COLLATERAL_TOKEN),
-  collateralTokenTransferableBalance: newMonetaryAmount(0, COLLATERAL_TOKEN),
+  collateralTokenBalance: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
+  collateralTokenTransferableBalance: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
   governanceTokenBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
   governanceTokenTransferableBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
   extensions: [],

--- a/src/common/reducers/vault.reducer.ts
+++ b/src/common/reducers/vault.reducer.ts
@@ -2,7 +2,7 @@ import { BitcoinAmount } from '@interlay/monetary-js';
 import { ReplaceRequestExt, newMonetaryAmount } from '@interlay/interbtc-api';
 import { H256 } from '@polkadot/types/interfaces';
 
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import {
   UPDATE_COLLATERALIZATION,
   UPDATE_COLLATERAL,
@@ -15,7 +15,7 @@ import { VaultState } from '../types/vault.types';
 const initialState = {
   requests: new Map<H256, ReplaceRequestExt>(),
   collateralization: '0',
-  collateral: newMonetaryAmount(0, COLLATERAL_TOKEN),
+  collateral: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
   lockedBTC: BitcoinAmount.zero,
   apy: '0'
 };

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -10,9 +10,9 @@ import {
   WRAPPED_TOKEN_SYMBOL,
   WrappedTokenLogoIcon,
   CollateralToken,
-  COLLATERAL_TOKEN,
-  COLLATERAL_TOKEN_SYMBOL,
-  CollateralTokenLogoIcon,
+  RELAY_CHAIN_NATIVE_TOKEN,
+  RELAY_CHAIN_NATIVE_TOKEN_SYMBOL,
+  RelayChainNativeTokenLogoIcon,
   GovernanceToken,
   GOVERNANCE_TOKEN,
   GOVERNANCE_TOKEN_SYMBOL,
@@ -78,12 +78,12 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
   React.useEffect(() => {
     const tokenOptions: Array<TokenOption> = [
       {
-        token: COLLATERAL_TOKEN,
+        token: RELAY_CHAIN_NATIVE_TOKEN,
         type: TokenType.COLLATERAL,
         balance: displayMonetaryAmount(collateralTokenBalance),
         transferableBalance: displayMonetaryAmount(collateralTokenTransferableBalance),
-        icon: <CollateralTokenLogoIcon height={variant === SELECT_VARIANTS.formField ? 46 : 26} />,
-        symbol: COLLATERAL_TOKEN_SYMBOL
+        icon: <RelayChainNativeTokenLogoIcon height={variant === SELECT_VARIANTS.formField ? 46 : 26} />,
+        symbol: RELAY_CHAIN_NATIVE_TOKEN_SYMBOL
       },
       {
         token: WRAPPED_TOKEN,

--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -40,7 +40,9 @@ if (!process.env.REACT_APP_RELAY_CHAIN_NAME) {
 }
 
 type WrappedToken = Currency<BitcoinUnit>;
+// ray test touch <
 type CollateralToken = Currency<CollateralUnit>;
+// ray test touch >
 type GovernanceToken = Currency<GovernanceUnit>;
 type VoteGovernanceToken = Currency<VoteUnit>;
 type GovernanceTokenMonetaryAmount = MonetaryAmount<GovernanceToken, GovernanceUnit>;
@@ -53,7 +55,9 @@ let EARN_LINK: string;
 let GOVERNANCE_LINK: string;
 let SUBSCAN_LINK: string;
 let WRAPPED_TOKEN: WrappedToken;
-let COLLATERAL_TOKEN: CollateralToken;
+// ray test touch <
+let RELAY_CHAIN_NATIVE_TOKEN: CollateralToken;
+// ray test touch >
 let GOVERNANCE_TOKEN: GovernanceToken;
 let VOTE_GOVERNANCE_TOKEN: VoteGovernanceToken;
 let PRICES_URL: string;
@@ -61,7 +65,9 @@ let RELAY_CHAIN_NAME: string;
 let BRIDGE_PARACHAIN_NAME: string;
 let WRAPPED_TOKEN_SYMBOL: string;
 let GOVERNANCE_TOKEN_SYMBOL: string;
-let COLLATERAL_TOKEN_SYMBOL: string;
+// ray test touch <
+let RELAY_CHAIN_NATIVE_TOKEN_SYMBOL: string;
+// ray test touch >
 let VOTE_GOVERNANCE_TOKEN_SYMBOL: string;
 let RelayChainLogoIcon: React.FunctionComponent<
   React.SVGProps<SVGSVGElement> & {
@@ -83,11 +89,13 @@ let GovernanceTokenLogoWithTextIcon: React.FunctionComponent<
     title?: string | undefined;
   }
 >;
-let CollateralTokenLogoIcon: React.FunctionComponent<
+// ray test touch <
+let RelayChainNativeTokenLogoIcon: React.FunctionComponent<
   React.SVGProps<SVGSVGElement> & {
     title?: string | undefined;
   }
 >;
+// ray test touch >
 let GovernanceTokenLogoIcon: React.FunctionComponent<
   React.SVGProps<SVGSVGElement> & {
     title?: string | undefined;
@@ -113,11 +121,15 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     GOVERNANCE_LINK = INTERLAY_GOVERNANCE_LINK;
     SUBSCAN_LINK = INTERLAY_SUBSCAN_LINK;
     WRAPPED_TOKEN = InterBtc;
-    COLLATERAL_TOKEN = Polkadot as Currency<CollateralUnit>;
+    // ray test touch <
+    RELAY_CHAIN_NATIVE_TOKEN = Polkadot as Currency<CollateralUnit>;
+    // ray test touch >
     GOVERNANCE_TOKEN = Interlay as GovernanceToken;
     VOTE_GOVERNANCE_TOKEN = Interlay as VoteGovernanceToken;
     WRAPPED_TOKEN_SYMBOL = 'interBTC';
-    COLLATERAL_TOKEN_SYMBOL = 'DOT';
+    // ray test touch <
+    RELAY_CHAIN_NATIVE_TOKEN_SYMBOL = 'DOT';
+    // ray test touch >
     GOVERNANCE_TOKEN_SYMBOL = 'INTR';
     VOTE_GOVERNANCE_TOKEN_SYMBOL = 'vINTR';
     RELAY_CHAIN_NAME = 'polkadot';
@@ -128,7 +140,9 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     BridgeParachainLogoIcon = InterlayLogoIcon;
     WrappedTokenLogoIcon = InterBTCLogoIcon;
     GovernanceTokenLogoWithTextIcon = InterlayLogoWithTextIcon;
-    CollateralTokenLogoIcon = DOTLogoIcon;
+    // ray test touch <
+    RelayChainNativeTokenLogoIcon = DOTLogoIcon;
+    // ray test touch >
     GovernanceTokenLogoIcon = InterlayLogoIcon;
     PUBLIC_ASSETS_FOLDER_NAME = 'interlay';
     APP_DOMAIN = 'https://bridge.interlay.io';
@@ -148,11 +162,15 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     GOVERNANCE_LINK = KINTSUGI_GOVERNANCE_LINK;
     SUBSCAN_LINK = KINTSUGI_SUBSCAN_LINK;
     WRAPPED_TOKEN = KBtc;
-    COLLATERAL_TOKEN = Kusama as Currency<CollateralUnit>;
+    // ray test touch <
+    RELAY_CHAIN_NATIVE_TOKEN = Kusama as Currency<CollateralUnit>;
+    // ray test touch >
     GOVERNANCE_TOKEN = Kintsugi as GovernanceToken;
     VOTE_GOVERNANCE_TOKEN = Kintsugi as VoteGovernanceToken;
     WRAPPED_TOKEN_SYMBOL = 'kBTC';
-    COLLATERAL_TOKEN_SYMBOL = 'KSM';
+    // ray test touch <
+    RELAY_CHAIN_NATIVE_TOKEN_SYMBOL = 'KSM';
+    // ray test touch >
     GOVERNANCE_TOKEN_SYMBOL = 'KINT';
     VOTE_GOVERNANCE_TOKEN_SYMBOL = 'vKINT';
     RELAY_CHAIN_NAME = 'kusama';
@@ -163,7 +181,7 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     BridgeParachainLogoIcon = KintsugiLogoIcon;
     WrappedTokenLogoIcon = KBTCLogoIcon;
     GovernanceTokenLogoWithTextIcon = KintsugiLogoWithTextIcon;
-    CollateralTokenLogoIcon = KusamaLogoIcon;
+    RelayChainNativeTokenLogoIcon = KusamaLogoIcon;
     GovernanceTokenLogoIcon = KintsugiLogoIcon;
     PUBLIC_ASSETS_FOLDER_NAME = 'kintsugi';
     APP_DOMAIN = ''; // TODO: should add the Kintsugi app domain once it's set up
@@ -181,7 +199,9 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
 }
 
 export type {
+  // ray test touch <
   CollateralToken,
+  // ray test touch >
   WrappedToken,
   GovernanceToken,
   WrappedTokenAmount,
@@ -197,11 +217,11 @@ export {
   GOVERNANCE_LINK,
   SUBSCAN_LINK,
   WRAPPED_TOKEN,
-  COLLATERAL_TOKEN,
+  RELAY_CHAIN_NATIVE_TOKEN,
   GOVERNANCE_TOKEN,
   VOTE_GOVERNANCE_TOKEN,
   WRAPPED_TOKEN_SYMBOL,
-  COLLATERAL_TOKEN_SYMBOL,
+  RELAY_CHAIN_NATIVE_TOKEN_SYMBOL,
   GOVERNANCE_TOKEN_SYMBOL,
   VOTE_GOVERNANCE_TOKEN_SYMBOL,
   RELAY_CHAIN_NAME,
@@ -211,7 +231,7 @@ export {
   BridgeParachainLogoIcon,
   WrappedTokenLogoIcon,
   GovernanceTokenLogoWithTextIcon,
-  CollateralTokenLogoIcon,
+  RelayChainNativeTokenLogoIcon,
   GovernanceTokenLogoIcon,
   PUBLIC_ASSETS_FOLDER_NAME,
   APP_DOMAIN,

--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -40,9 +40,7 @@ if (!process.env.REACT_APP_RELAY_CHAIN_NAME) {
 }
 
 type WrappedToken = Currency<BitcoinUnit>;
-// ray test touch <
 type CollateralToken = Currency<CollateralUnit>;
-// ray test touch >
 type GovernanceToken = Currency<GovernanceUnit>;
 type VoteGovernanceToken = Currency<VoteUnit>;
 type GovernanceTokenMonetaryAmount = MonetaryAmount<GovernanceToken, GovernanceUnit>;
@@ -55,9 +53,7 @@ let EARN_LINK: string;
 let GOVERNANCE_LINK: string;
 let SUBSCAN_LINK: string;
 let WRAPPED_TOKEN: WrappedToken;
-// ray test touch <
 let RELAY_CHAIN_NATIVE_TOKEN: CollateralToken;
-// ray test touch >
 let GOVERNANCE_TOKEN: GovernanceToken;
 let VOTE_GOVERNANCE_TOKEN: VoteGovernanceToken;
 let PRICES_URL: string;
@@ -65,9 +61,7 @@ let RELAY_CHAIN_NAME: string;
 let BRIDGE_PARACHAIN_NAME: string;
 let WRAPPED_TOKEN_SYMBOL: string;
 let GOVERNANCE_TOKEN_SYMBOL: string;
-// ray test touch <
 let RELAY_CHAIN_NATIVE_TOKEN_SYMBOL: string;
-// ray test touch >
 let VOTE_GOVERNANCE_TOKEN_SYMBOL: string;
 let RelayChainLogoIcon: React.FunctionComponent<
   React.SVGProps<SVGSVGElement> & {
@@ -89,13 +83,11 @@ let GovernanceTokenLogoWithTextIcon: React.FunctionComponent<
     title?: string | undefined;
   }
 >;
-// ray test touch <
 let RelayChainNativeTokenLogoIcon: React.FunctionComponent<
   React.SVGProps<SVGSVGElement> & {
     title?: string | undefined;
   }
 >;
-// ray test touch >
 let GovernanceTokenLogoIcon: React.FunctionComponent<
   React.SVGProps<SVGSVGElement> & {
     title?: string | undefined;
@@ -121,15 +113,11 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     GOVERNANCE_LINK = INTERLAY_GOVERNANCE_LINK;
     SUBSCAN_LINK = INTERLAY_SUBSCAN_LINK;
     WRAPPED_TOKEN = InterBtc;
-    // ray test touch <
     RELAY_CHAIN_NATIVE_TOKEN = Polkadot as Currency<CollateralUnit>;
-    // ray test touch >
     GOVERNANCE_TOKEN = Interlay as GovernanceToken;
     VOTE_GOVERNANCE_TOKEN = Interlay as VoteGovernanceToken;
     WRAPPED_TOKEN_SYMBOL = 'interBTC';
-    // ray test touch <
     RELAY_CHAIN_NATIVE_TOKEN_SYMBOL = 'DOT';
-    // ray test touch >
     GOVERNANCE_TOKEN_SYMBOL = 'INTR';
     VOTE_GOVERNANCE_TOKEN_SYMBOL = 'vINTR';
     RELAY_CHAIN_NAME = 'polkadot';
@@ -140,9 +128,7 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     BridgeParachainLogoIcon = InterlayLogoIcon;
     WrappedTokenLogoIcon = InterBTCLogoIcon;
     GovernanceTokenLogoWithTextIcon = InterlayLogoWithTextIcon;
-    // ray test touch <
     RelayChainNativeTokenLogoIcon = DOTLogoIcon;
-    // ray test touch >
     GovernanceTokenLogoIcon = InterlayLogoIcon;
     PUBLIC_ASSETS_FOLDER_NAME = 'interlay';
     APP_DOMAIN = 'https://bridge.interlay.io';
@@ -162,15 +148,11 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     GOVERNANCE_LINK = KINTSUGI_GOVERNANCE_LINK;
     SUBSCAN_LINK = KINTSUGI_SUBSCAN_LINK;
     WRAPPED_TOKEN = KBtc;
-    // ray test touch <
     RELAY_CHAIN_NATIVE_TOKEN = Kusama as Currency<CollateralUnit>;
-    // ray test touch >
     GOVERNANCE_TOKEN = Kintsugi as GovernanceToken;
     VOTE_GOVERNANCE_TOKEN = Kintsugi as VoteGovernanceToken;
     WRAPPED_TOKEN_SYMBOL = 'kBTC';
-    // ray test touch <
     RELAY_CHAIN_NATIVE_TOKEN_SYMBOL = 'KSM';
-    // ray test touch >
     GOVERNANCE_TOKEN_SYMBOL = 'KINT';
     VOTE_GOVERNANCE_TOKEN_SYMBOL = 'vKINT';
     RELAY_CHAIN_NAME = 'kusama';
@@ -199,9 +181,7 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
 }
 
 export type {
-  // ray test touch <
   CollateralToken,
-  // ray test touch >
   WrappedToken,
   GovernanceToken,
   WrappedTokenAmount,

--- a/src/pages/Bridge/BurnForm/index.tsx
+++ b/src/pages/Bridge/BurnForm/index.tsx
@@ -17,10 +17,10 @@ import ErrorModal from 'components/ErrorModal';
 import ErrorFallback from 'components/ErrorFallback';
 import Hr2 from 'components/hrs/Hr2';
 import {
-  COLLATERAL_TOKEN,
+  RELAY_CHAIN_NATIVE_TOKEN,
   WRAPPED_TOKEN_SYMBOL,
-  COLLATERAL_TOKEN_SYMBOL,
-  CollateralTokenLogoIcon,
+  RELAY_CHAIN_NATIVE_TOKEN_SYMBOL,
+  RelayChainNativeTokenLogoIcon,
   WrappedTokenLogoIcon
 } from 'config/relay-chains';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
@@ -65,7 +65,7 @@ const BurnForm = (): JSX.Element | null => {
   const [burnRate, setBurnRate] = React.useState(
     new ExchangeRate<Bitcoin, BitcoinUnit, Currency<CollateralUnit>, CollateralUnit>(
       Bitcoin,
-      COLLATERAL_TOKEN,
+      RELAY_CHAIN_NATIVE_TOKEN,
       new Big(0)
     )
   );
@@ -82,8 +82,8 @@ const BurnForm = (): JSX.Element | null => {
       try {
         setStatus(STATUSES.PENDING);
         const [theBurnRate, theBurnableTokens] = await Promise.all([
-          window.bridge.redeem.getBurnExchangeRate(COLLATERAL_TOKEN),
-          window.bridge.redeem.getMaxBurnableTokens(COLLATERAL_TOKEN as CollateralCurrency)
+          window.bridge.redeem.getBurnExchangeRate(RELAY_CHAIN_NATIVE_TOKEN),
+          window.bridge.redeem.getMaxBurnableTokens(RELAY_CHAIN_NATIVE_TOKEN as CollateralCurrency)
         ]);
         setBurnRate(theBurnRate);
         setBurnableTokens(theBurnableTokens);
@@ -116,7 +116,7 @@ const BurnForm = (): JSX.Element | null => {
         setSubmitStatus(STATUSES.PENDING);
         await window.bridge.redeem.burn(
           BitcoinAmount.from.BTC(data[WRAPPED_TOKEN_AMOUNT]),
-          COLLATERAL_TOKEN as CollateralCurrency
+          RELAY_CHAIN_NATIVE_TOKEN as CollateralCurrency
         );
         // TODO: should not manually update the balances everywhere
         // - Should be able to watch the balances in one place and update the context accordingly.
@@ -172,7 +172,7 @@ const BurnForm = (): JSX.Element | null => {
 
     const parsedInterBTCAmount = BitcoinAmount.from.BTC(wrappedTokenAmount || 0);
     const earnedCollateralTokenAmount = burnRate.rate.eq(0)
-      ? newMonetaryAmount(0, COLLATERAL_TOKEN)
+      ? newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN)
       : burnRate.toCounter(parsedInterBTCAmount || BitcoinAmount.zero);
     const accountSet = !!address;
 
@@ -182,7 +182,7 @@ const BurnForm = (): JSX.Element | null => {
           <FormTitle>
             {t('burn_page.burn_interbtc', {
               wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL,
-              collateralTokenSymbol: COLLATERAL_TOKEN_SYMBOL
+              collateralTokenSymbol: RELAY_CHAIN_NATIVE_TOKEN_SYMBOL
             })}
           </FormTitle>
           <PriceInfo
@@ -230,9 +230,9 @@ const BurnForm = (): JSX.Element | null => {
                 {t('you_will_receive')}
               </h5>
             }
-            unitIcon={<CollateralTokenLogoIcon width={20} />}
+            unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
             value={displayMonetaryAmount(earnedCollateralTokenAmount)}
-            unitName={COLLATERAL_TOKEN_SYMBOL}
+            unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
             approxUSD={getUsdAmount(earnedCollateralTokenAmount, prices.collateralToken?.usd)}
           />
           <SubmitButton

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -22,10 +22,10 @@ import ErrorFallback from 'components/ErrorFallback';
 import Hr2 from 'components/hrs/Hr2';
 import InformationTooltip from 'components/tooltips/InformationTooltip';
 import {
-  COLLATERAL_TOKEN,
+  RELAY_CHAIN_NATIVE_TOKEN,
   WRAPPED_TOKEN_SYMBOL,
-  COLLATERAL_TOKEN_SYMBOL,
-  CollateralTokenLogoIcon
+  RELAY_CHAIN_NATIVE_TOKEN_SYMBOL,
+  RelayChainNativeTokenLogoIcon
 } from 'config/relay-chains';
 import { BLOCKS_BEHIND_LIMIT } from 'config/parachain';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
@@ -81,7 +81,7 @@ const RedeemForm = (): JSX.Element | null => {
   const [btcToDotRate, setBtcToDotRate] = React.useState(
     new ExchangeRate<Bitcoin, BitcoinUnit, Currency<CollateralUnit>, CollateralUnit>(
       Bitcoin,
-      COLLATERAL_TOKEN,
+      RELAY_CHAIN_NATIVE_TOKEN,
       new Big(0)
     )
   );
@@ -122,7 +122,7 @@ const RedeemForm = (): JSX.Element | null => {
           window.bridge.redeem.getDustValue(),
           window.bridge.vaults.getPremiumRedeemVaults(),
           window.bridge.redeem.getPremiumRedeemFeeRate(),
-          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN),
+          window.bridge.oracle.getExchangeRate(RELAY_CHAIN_NATIVE_TOKEN),
           window.bridge.redeem.getFeeRate(),
           window.bridge.redeem.getCurrentInclusionFee(),
           window.bridge.vaults.getVaultsWithRedeemableTokens()
@@ -310,7 +310,7 @@ const RedeemForm = (): JSX.Element | null => {
 
     const totalDOT = wrappedTokenAmount
       ? btcToDotRate.toCounter(parsedInterBTCAmount).mul(premiumRedeemFee)
-      : newMonetaryAmount(0, COLLATERAL_TOKEN);
+      : newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN);
     const totalDOTInUSD = getUsdAmount(totalDOT, prices.collateralToken?.usd);
 
     const bitcoinNetworkFeeInBTC = displayMonetaryAmount(currentInclusionFee);
@@ -422,9 +422,9 @@ const RedeemForm = (): JSX.Element | null => {
           {premiumRedeemSelected && (
             <PriceInfo
               title={<h5 className='text-interlayConifer'>{t('redeem_page.earned_premium')}</h5>}
-              unitIcon={<CollateralTokenLogoIcon width={20} />}
+              unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
               value={displayMonetaryAmount(totalDOT)}
-              unitName={COLLATERAL_TOKEN_SYMBOL}
+              unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
               approxUSD={totalDOTInUSD}
             />
           )}

--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -17,7 +17,7 @@ import InterlayTabGroup, {
   InterlayTab,
   InterlayTabPanel
 } from 'components/UI/InterlayTabGroup';
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import useQueryParams from 'utils/hooks/use-query-params';
 import useUpdateQueryParameters, { QueryParameters } from 'utils/hooks/use-update-query-parameters';
 import TAB_IDS from 'utils/constants/tab-ids';
@@ -78,7 +78,7 @@ const Bridge = (): JSX.Element | null => {
     (async () => {
       try {
         const maxBurnableTokens = await window.bridge.redeem.getMaxBurnableTokens(
-          COLLATERAL_TOKEN as CollateralCurrency
+          RELAY_CHAIN_NATIVE_TOKEN as CollateralCurrency
         );
         setBurnable(maxBurnableTokens.gt(BitcoinAmount.zero));
       } catch (error) {

--- a/src/pages/Dashboard/cards/CollateralLockedCard/index.tsx
+++ b/src/pages/Dashboard/cards/CollateralLockedCard/index.tsx
@@ -8,7 +8,7 @@ import LineChart from '../../LineChart';
 import DashboardCard from '../DashboardCard';
 import Stats, { StatsDt, StatsDd, StatsRouterLink } from '../../Stats';
 import ErrorFallback from 'components/ErrorFallback';
-import { COLLATERAL_TOKEN_SYMBOL, COLLATERAL_TOKEN, WRAPPED_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN_SYMBOL, RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN } from 'config/relay-chains';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
 import { INTERLAY_DENIM, KINTSUGI_SUPERNOVA } from 'utils/constants/colors';
 import { PAGES } from 'utils/constants/links';
@@ -44,8 +44,8 @@ const CollateralLockedCard = ({ hasLinks }: Props): JSX.Element => {
       CUMULATIVE_VOLUMES_FETCHER,
       'Collateral' as VolumeType,
       cutoffTimestamps,
-      COLLATERAL_TOKEN, // returned amounts
-      COLLATERAL_TOKEN, // filter by this collateral...
+      RELAY_CHAIN_NATIVE_TOKEN, // returned amounts
+      RELAY_CHAIN_NATIVE_TOKEN, // filter by this collateral...
       WRAPPED_TOKEN //     and this backing currency
     ],
     cumulativeVolumesFetcher
@@ -79,7 +79,7 @@ const CollateralLockedCard = ({ hasLinks }: Props): JSX.Element => {
             <>
               <StatsDt>{t('dashboard.vault.locked_collateral')}</StatsDt>
               <StatsDd>
-                {displayMonetaryAmount(totalLockedCollateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
+                {displayMonetaryAmount(totalLockedCollateralTokenAmount)} {RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
               </StatsDd>
               <StatsDd>${getUsdAmount(totalLockedCollateralTokenAmount, prices.collateralToken?.usd)}</StatsDd>
             </>

--- a/src/pages/Dashboard/cards/CollateralizationCard/index.tsx
+++ b/src/pages/Dashboard/cards/CollateralizationCard/index.tsx
@@ -10,7 +10,7 @@ import DashboardCard from '../DashboardCard';
 import Stats, { StatsDt, StatsDd, StatsRouterLink } from '../../Stats';
 import ErrorFallback from 'components/ErrorFallback';
 import Ring64, { Ring64Title, Ring64Value } from 'components/Ring64';
-import { COLLATERAL_TOKEN, WRAPPED_TOKEN_SYMBOL } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN_SYMBOL } from 'config/relay-chains';
 import { PAGES } from 'utils/constants/links';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
 import { displayMonetaryAmount, safeRoundTwoDecimals } from 'common/utils/utils';
@@ -53,7 +53,7 @@ const CollateralizationCard = ({ hasLinks }: Props): JSX.Element => {
     data: secureCollateralThreshold,
     error: secureCollateralThresholdError
   } = useQuery<Big, Error>(
-    [GENERIC_FETCHER, 'vaults', 'getSecureCollateralThreshold', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'vaults', 'getSecureCollateralThreshold', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<Big>(),
     {
       enabled: !!bridgeLoaded && !TEMP_COLLATERALIZATION_DISPLAY_DISABLED

--- a/src/pages/Dashboard/cards/OracleStatusCard/index.tsx
+++ b/src/pages/Dashboard/cards/OracleStatusCard/index.tsx
@@ -10,7 +10,7 @@ import Stats, { StatsDt, StatsDd, StatsRouterLink } from '../../Stats';
 import ErrorFallback from 'components/ErrorFallback';
 import { StoreType } from 'common/types/util.types';
 import Ring64, { Ring64Title, Ring64Value } from 'components/Ring64';
-import { COLLATERAL_TOKEN, COLLATERAL_TOKEN_SYMBOL } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from 'config/relay-chains';
 import { PAGES } from 'utils/constants/links';
 import {
   BtcToCurrencyOracleStatus,
@@ -43,7 +43,7 @@ const OracleStatusCard = ({ hasLinks }: Props): JSX.Element => {
     data: oracleStatus,
     error: oracleStatusError
   } = useQuery<BtcToCurrencyOracleStatus<CollateralUnit> | undefined, Error>(
-    [ORACLE_LATEST_EXCHANGE_RATE_FETCHER, COLLATERAL_TOKEN, oracleTimeout],
+    [ORACLE_LATEST_EXCHANGE_RATE_FETCHER, RELAY_CHAIN_NATIVE_TOKEN, oracleTimeout],
     latestExchangeRateFetcher,
     {
       enabled: !!oracleTimeout
@@ -114,7 +114,7 @@ const OracleStatusCard = ({ hasLinks }: Props): JSX.Element => {
           </Ring64Title>
           {exchangeRate && (
             <Ring64Value>
-              {exchangeRate.toHuman(5)} BTC/{COLLATERAL_TOKEN_SYMBOL}
+              {exchangeRate.toHuman(5)} BTC/{RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
             </Ring64Value>
           )}
         </Ring64>

--- a/src/pages/Dashboard/sub-pages/Oracles/OraclesTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Oracles/OraclesTable/index.tsx
@@ -20,7 +20,7 @@ import InterlayTable, {
   InterlayTh,
   InterlayTd
 } from 'components/UI/InterlayTable';
-import { COLLATERAL_TOKEN, COLLATERAL_TOKEN_SYMBOL } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from 'config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
 import { formatDateTime } from 'common/utils/utils';
 import { StoreType } from 'common/types/util.types';
@@ -61,7 +61,7 @@ const OracleTable = (): JSX.Element => {
     data: oracleSubmissions,
     error: oracleSubmissionsError
   } = useQuery<BtcToCurrencyOracleStatus<CollateralUnit>[], Error>(
-    [ORACLE_ALL_LATEST_UPDATES_FETCHER, COLLATERAL_TOKEN, oracleTimeout, namesMap],
+    [ORACLE_ALL_LATEST_UPDATES_FETCHER, RELAY_CHAIN_NATIVE_TOKEN, oracleTimeout, namesMap],
     allLatestSubmissionsFetcher,
     {
       enabled: !!oracleTimeout && !!namesMap
@@ -96,7 +96,7 @@ const OracleTable = (): JSX.Element => {
         Cell: function FormattedCell({ value }: { value: BTCToCollateralTokenRate }) {
           return (
             <>
-              1 BTC = {value.toHuman(5)} {COLLATERAL_TOKEN_SYMBOL}
+              1 BTC = {value.toHuman(5)} {RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
             </>
           );
         }

--- a/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
@@ -22,7 +22,7 @@ import InterlayTable, {
   InterlayTh,
   InterlayTd
 } from 'components/UI/InterlayTable';
-import { COLLATERAL_TOKEN, COLLATERAL_TOKEN_SYMBOL } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from 'config/relay-chains';
 import { getCollateralization, getVaultStatusLabel } from 'utils/helpers/vaults';
 import { PAGES, URL_PARAMETERS } from 'utils/constants/links';
 import { shortAddress, displayMonetaryAmount } from 'common/utils/utils';
@@ -76,7 +76,7 @@ const VaultsTable = (): JSX.Element => {
     data: secureCollateralThreshold,
     error: secureCollateralThresholdError
   } = useQuery<Big, Error>(
-    [GENERIC_FETCHER, 'vaults', 'getSecureCollateralThreshold', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'vaults', 'getSecureCollateralThreshold', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<Big>(),
     {
       enabled: !!bridgeLoaded
@@ -90,7 +90,7 @@ const VaultsTable = (): JSX.Element => {
     data: liquidationCollateralThreshold,
     error: liquidationCollateralThresholdError
   } = useQuery<Big, Error>(
-    [GENERIC_FETCHER, 'vaults', 'getLiquidationCollateralThreshold', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'vaults', 'getLiquidationCollateralThreshold', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<Big>(),
     {
       enabled: !!bridgeLoaded
@@ -104,7 +104,7 @@ const VaultsTable = (): JSX.Element => {
     data: btcToCollateralTokenRate,
     error: btcToCollateralTokenRateError
   } = useQuery<BTCToCollateralTokenRate, Error>(
-    [GENERIC_FETCHER, 'oracle', 'getExchangeRate', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'oracle', 'getExchangeRate', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<BTCToCollateralTokenRate>(),
     {
       enabled: !!bridgeLoaded
@@ -132,7 +132,7 @@ const VaultsTable = (): JSX.Element => {
       },
       {
         Header: t('locked_dot', {
-          collateralTokenSymbol: COLLATERAL_TOKEN_SYMBOL
+          collateralTokenSymbol: RELAY_CHAIN_NATIVE_TOKEN_SYMBOL
         }),
         accessor: 'lockedDOT',
         classNames: ['text-right']

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/ReimbursedRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/ReimbursedRedeemRequest/index.tsx
@@ -12,10 +12,10 @@ import ExternalLink from 'components/ExternalLink';
 import PrimaryColorSpan from 'components/PrimaryColorSpan';
 import Hr2 from 'components/hrs/Hr2';
 import {
-  COLLATERAL_TOKEN,
+  RELAY_CHAIN_NATIVE_TOKEN,
   WRAPPED_TOKEN_SYMBOL,
-  COLLATERAL_TOKEN_SYMBOL,
-  CollateralTokenLogoIcon
+  RELAY_CHAIN_NATIVE_TOKEN_SYMBOL,
+  RelayChainNativeTokenLogoIcon
 } from 'config/relay-chains';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
 import { getUsdAmount, displayMonetaryAmount, getPolkadotLink } from 'common/utils/utils';
@@ -31,12 +31,12 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
   const { bridgeLoaded, prices } = useSelector((state: StoreType) => state.general);
   const [burnedBTCAmount, setBurnedBTCAmount] = React.useState(BitcoinAmount.zero);
   const [punishmentCollateralTokenAmount, setPunishmentCollateralTokenAmount] = React.useState(
-    newMonetaryAmount(0, COLLATERAL_TOKEN)
+    newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN)
   );
   const [burnCollateralTokenAmount, setBurnCollateralTokenAmount] = React.useState(
-    newMonetaryAmount(0, COLLATERAL_TOKEN)
+    newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN)
   );
-  const [collateralTokenAmount, setCollateralTokenAmount] = React.useState(newMonetaryAmount(0, COLLATERAL_TOKEN));
+  const [collateralTokenAmount, setCollateralTokenAmount] = React.useState(newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN));
 
   React.useEffect(() => {
     if (!bridgeLoaded) return;
@@ -47,7 +47,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
       try {
         const [punishmentFee, btcDotRate] = await Promise.all([
           window.bridge.vaults.getPunishmentFee(),
-          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN)
+          window.bridge.oracle.getExchangeRate(RELAY_CHAIN_NATIVE_TOKEN)
         ]);
 
         const burnedBTCAmount = request.request.requestedAmountBacking.add(request.bridgeFee);
@@ -72,7 +72,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
       <p className='w-full'>
         {t('redeem_page.burn_notice', {
           wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL,
-          collateralTokenSymbol: COLLATERAL_TOKEN_SYMBOL
+          collateralTokenSymbol: RELAY_CHAIN_NATIVE_TOKEN_SYMBOL
         })}
       </p>
       <p className='font-medium'>
@@ -85,7 +85,7 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
       <p className='font-medium'>
         <PrimaryColorSpan>{t('redeem_page.recover_receive_dot')}</PrimaryColorSpan>
         <PrimaryColorSpan>
-          &nbsp;{`${displayMonetaryAmount(collateralTokenAmount)} ${COLLATERAL_TOKEN_SYMBOL}`}
+          &nbsp;{`${displayMonetaryAmount(collateralTokenAmount)} ${RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}`}
         </PrimaryColorSpan>
         <span>&nbsp;{`(≈ $${getUsdAmount(collateralTokenAmount, prices.collateralToken?.usd)})`}</span>
         <PrimaryColorSpan>&nbsp;{t('redeem_page.recover_receive_total')}</PrimaryColorSpan>.
@@ -105,9 +105,9 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
               })}
             </h5>
           }
-          unitIcon={<CollateralTokenLogoIcon width={20} />}
+          unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(burnCollateralTokenAmount)}
-          unitName={COLLATERAL_TOKEN_SYMBOL}
+          unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
           approxUSD={getUsdAmount(burnCollateralTokenAmount, prices.collateralToken?.usd)}
         />
         <PriceInfo
@@ -122,9 +122,9 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
               {t('redeem_page.compensation_payment')}
             </h5>
           }
-          unitIcon={<CollateralTokenLogoIcon width={20} />}
+          unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(punishmentCollateralTokenAmount)}
-          unitName={COLLATERAL_TOKEN_SYMBOL}
+          unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
           approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}
         />
         <Hr2 className={clsx('border-t-2', 'my-2.5')} />
@@ -140,9 +140,9 @@ const ReimbursedRedeemRequest = ({ request }: Props): JSX.Element => {
               {t('you_received')}
             </h5>
           }
-          unitIcon={<CollateralTokenLogoIcon width={20} />}
+          unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(collateralTokenAmount)}
-          unitName={COLLATERAL_TOKEN_SYMBOL}
+          unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
           approxUSD={getUsdAmount(collateralTokenAmount, prices.collateralToken?.usd)}
         />
       </div>

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/RetriedRedeemRequest/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/RedeemRequestStatusUI/RetriedRedeemRequest/index.tsx
@@ -11,7 +11,7 @@ import PriceInfo from 'pages/Bridge/PriceInfo';
 import ExternalLink from 'components/ExternalLink';
 import PrimaryColorSpan from 'components/PrimaryColorSpan';
 import Hr2 from 'components/hrs/Hr2';
-import { COLLATERAL_TOKEN, COLLATERAL_TOKEN_SYMBOL, CollateralTokenLogoIcon } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL, RelayChainNativeTokenLogoIcon } from 'config/relay-chains';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
 import { getUsdAmount, displayMonetaryAmount, getPolkadotLink } from 'common/utils/utils';
 import { StoreType } from 'common/types/util.types';
@@ -25,7 +25,7 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
   const { t } = useTranslation();
   const { bridgeLoaded, prices } = useSelector((state: StoreType) => state.general);
   const [punishmentCollateralTokenAmount, setPunishmentCollateralTokenAmount] = React.useState(
-    newMonetaryAmount(0, COLLATERAL_TOKEN)
+    newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN)
   );
 
   React.useEffect(() => {
@@ -37,7 +37,7 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
       try {
         const [punishmentFee, btcDotRate] = await Promise.all([
           window.bridge.vaults.getPunishmentFee(),
-          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN)
+          window.bridge.oracle.getExchangeRate(RELAY_CHAIN_NATIVE_TOKEN)
         ]);
 
         const btcAmount = request.request.requestedAmountBacking;
@@ -60,7 +60,7 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
       <p className='font-medium'>
         <PrimaryColorSpan>{t('redeem_page.recover_receive_dot')}</PrimaryColorSpan>
         <PrimaryColorSpan>
-          &nbsp;{`${displayMonetaryAmount(punishmentCollateralTokenAmount)} ${COLLATERAL_TOKEN_SYMBOL}`}
+          &nbsp;{`${displayMonetaryAmount(punishmentCollateralTokenAmount)} ${RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}`}
         </PrimaryColorSpan>
         <span>&nbsp;({`≈ $${getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}`})</span>
         <PrimaryColorSpan>&nbsp;{t('redeem_page.recover_receive_total')}.</PrimaryColorSpan>
@@ -77,9 +77,9 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
               {t('redeem_page.compensation_payment')}
             </h5>
           }
-          unitIcon={<CollateralTokenLogoIcon width={20} />}
+          unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(punishmentCollateralTokenAmount)}
-          unitName={COLLATERAL_TOKEN_SYMBOL}
+          unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
           approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}
         />
         <Hr2 className={clsx('border-t-2', 'my-2.5')} />
@@ -95,9 +95,9 @@ const RetriedRedeemRequest = ({ request }: Props): JSX.Element => {
               {t('you_received')}
             </h5>
           }
-          unitIcon={<CollateralTokenLogoIcon width={20} />}
+          unitIcon={<RelayChainNativeTokenLogoIcon width={20} />}
           value={displayMonetaryAmount(punishmentCollateralTokenAmount)}
-          unitName={COLLATERAL_TOKEN_SYMBOL}
+          unitName={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
           approxUSD={getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)}
         />
       </div>

--- a/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/ReimburseStatusUI/index.tsx
+++ b/src/pages/Transactions/RedeemRequestsTable/RedeemRequestModal/ReimburseStatusUI/index.tsx
@@ -15,7 +15,7 @@ import InterlayDenimOrKintsugiMidnightOutlinedButton from 'components/buttons/In
 import InterlayConiferOutlinedButton from 'components/buttons/InterlayConiferOutlinedButton';
 import ErrorFallback from 'components/ErrorFallback';
 import PrimaryColorSpan from 'components/PrimaryColorSpan';
-import { COLLATERAL_TOKEN, WRAPPED_TOKEN_SYMBOL, COLLATERAL_TOKEN_SYMBOL } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN_SYMBOL, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from 'config/relay-chains';
 import { POLKADOT, KUSAMA } from 'utils/constants/relay-chain-names';
 import { getUsdAmount, displayMonetaryAmount } from 'common/utils/utils';
 import { StoreType } from 'common/types/util.types';
@@ -30,9 +30,9 @@ interface Props {
 const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
   const { bridgeLoaded, prices } = useSelector((state: StoreType) => state.general);
   const [punishmentCollateralTokenAmount, setPunishmentCollateralTokenAmount] = React.useState(
-    newMonetaryAmount(0, COLLATERAL_TOKEN)
+    newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN)
   );
-  const [collateralTokenAmount, setCollateralTokenAmount] = React.useState(newMonetaryAmount(0, COLLATERAL_TOKEN));
+  const [collateralTokenAmount, setCollateralTokenAmount] = React.useState(newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN));
   const { t } = useTranslation();
   const handleError = useErrorHandler();
 
@@ -46,7 +46,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
       try {
         const [punishment, btcDotRate] = await Promise.all([
           window.bridge.vaults.getPunishmentFee(),
-          window.bridge.oracle.getExchangeRate(COLLATERAL_TOKEN)
+          window.bridge.oracle.getExchangeRate(RELAY_CHAIN_NATIVE_TOKEN)
         ]);
         const wrappedTokenAmount = request ? request.request.requestedAmountBacking : BitcoinAmount.zero;
         setCollateralTokenAmount(btcDotRate.toCounter(wrappedTokenAmount));
@@ -135,13 +135,13 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
         >
           <span>{t('redeem_page.vault_did_not_send')}</span>
           <PrimaryColorSpan>
-            &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
+            &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
           </PrimaryColorSpan>
           <span>&nbsp;{`(≈ $ ${getUsdAmount(punishmentCollateralTokenAmount, prices.collateralToken?.usd)})`}</span>
           <span>
             &nbsp;
             {t('redeem_page.compensation', {
-              collateralTokenSymbol: COLLATERAL_TOKEN_SYMBOL
+              collateralTokenSymbol: RELAY_CHAIN_NATIVE_TOKEN_SYMBOL
             })}
           </span>
           .
@@ -165,7 +165,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
             <p className='text-justify'>
               <span>{t('redeem_page.receive_compensation')}</span>
               <PrimaryColorSpan>
-                &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
+                &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
               </PrimaryColorSpan>
               <span>
                 &nbsp;
@@ -192,7 +192,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
                 })}
               </span>
               <PrimaryColorSpan>
-                &nbsp;{displayMonetaryAmount(collateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
+                &nbsp;{displayMonetaryAmount(collateralTokenAmount)} {RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
               </PrimaryColorSpan>
               <span>
                 &nbsp;
@@ -201,7 +201,7 @@ const ReimburseStatusUI = ({ request, onClose }: Props): JSX.Element => {
                 })}
               </span>
               <PrimaryColorSpan>
-                &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {COLLATERAL_TOKEN_SYMBOL}
+                &nbsp;{displayMonetaryAmount(punishmentCollateralTokenAmount)} {RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
               </PrimaryColorSpan>
               <span>
                 &nbsp;

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -15,7 +15,7 @@ import ErrorFallback from 'components/ErrorFallback';
 import FormTitle from 'components/FormTitle';
 import SubmitButton from 'components/SubmitButton';
 import ErrorModal from 'components/ErrorModal';
-import { COLLATERAL_TOKEN, COLLATERAL_TOKEN_SYMBOL } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from 'config/relay-chains';
 import { showAccountModalAction } from 'common/actions/general.actions';
 import { displayMonetaryAmount, getUsdAmount } from 'common/utils/utils';
 import { StoreType, ParachainStatus } from 'common/types/util.types';
@@ -34,7 +34,7 @@ import {
 
 const TRANSFER_AMOUNT = 'transfer-amount';
 
-const transferFee = newMonetaryAmount(RELAY_CHAIN_TRANSFER_FEE, COLLATERAL_TOKEN);
+const transferFee = newMonetaryAmount(RELAY_CHAIN_TRANSFER_FEE, RELAY_CHAIN_NATIVE_TOKEN);
 
 type CrossChainTransferFormData = {
   [TRANSFER_AMOUNT]: string;
@@ -86,14 +86,14 @@ const CrossChainTransferForm = (): JSX.Element => {
           api,
           address,
           destination.address,
-          newMonetaryAmount(data[TRANSFER_AMOUNT], COLLATERAL_TOKEN, true)
+          newMonetaryAmount(data[TRANSFER_AMOUNT], RELAY_CHAIN_NATIVE_TOKEN, true)
         );
       } else {
         await transferToRelayChain(
           window.bridge.api,
           address,
           destination.address,
-          newMonetaryAmount(data[TRANSFER_AMOUNT], COLLATERAL_TOKEN, true)
+          newMonetaryAmount(data[TRANSFER_AMOUNT], RELAY_CHAIN_NATIVE_TOKEN, true)
         );
       }
 
@@ -114,26 +114,26 @@ const CrossChainTransferForm = (): JSX.Element => {
   const handleUpdateUsdAmount = (event: any) => {
     if (!event.target.value) return;
 
-    const value = newMonetaryAmount(event.target.value, COLLATERAL_TOKEN, true);
+    const value = newMonetaryAmount(event.target.value, RELAY_CHAIN_NATIVE_TOKEN, true);
     const usd = getUsdAmount(value, prices.collateralToken?.usd);
 
     setApproxUsdValue(usd);
   };
 
   const validateRelayChainTransferAmount = (value: number): string | undefined => {
-    const transferAmount = newMonetaryAmount(value, COLLATERAL_TOKEN, true);
+    const transferAmount = newMonetaryAmount(value, RELAY_CHAIN_NATIVE_TOKEN, true);
 
     return relayChainBalance?.lt(transferAmount) ? t('insufficient_funds') : undefined;
   };
 
   const validateParachainTransferAmount = (value: number): string | undefined => {
-    const transferAmount = newMonetaryAmount(value, COLLATERAL_TOKEN, true);
+    const transferAmount = newMonetaryAmount(value, RELAY_CHAIN_NATIVE_TOKEN, true);
 
     // TODO: this api check won't be necessary when the api call is moved out of
     // the component
     const existentialDeposit = api
-      ? newMonetaryAmount(getExistentialDeposit(api), COLLATERAL_TOKEN)
-      : newMonetaryAmount('0', COLLATERAL_TOKEN);
+      ? newMonetaryAmount(getExistentialDeposit(api), RELAY_CHAIN_NATIVE_TOKEN)
+      : newMonetaryAmount('0', RELAY_CHAIN_NATIVE_TOKEN);
 
     // TODO: we need to handle and validate transfer fees properly. Implemented here initially
     // because it was an issue during testing.
@@ -146,7 +146,7 @@ const CrossChainTransferForm = (): JSX.Element => {
       // Check the transfer amount is more than the fee
     } else if (transferAmount.lte(transferFee)) {
       return t('transfer_page.cross_chain_transfer_form.insufficient_funds_to_pay_fees', {
-        transferFee: `${displayMonetaryAmount(transferFee)} ${COLLATERAL_TOKEN_SYMBOL}`
+        transferFee: `${displayMonetaryAmount(transferFee)} ${RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}`
       });
     } else {
       return undefined;
@@ -227,13 +227,13 @@ const CrossChainTransferForm = (): JSX.Element => {
                 <AvailableBalanceUI
                   label={t('transfer_page.cross_chain_transfer_form.relay_chain_balance')}
                   balance={displayMonetaryAmount(relayChainBalance)}
-                  tokenSymbol={COLLATERAL_TOKEN_SYMBOL}
+                  tokenSymbol={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
                 />
               ) : (
                 <AvailableBalanceUI
                   label={t('transfer_page.cross_chain_transfer_form.parachain_balance')}
                   balance={displayMonetaryAmount(collateralTokenTransferableBalance)}
-                  tokenSymbol={COLLATERAL_TOKEN_SYMBOL}
+                  tokenSymbol={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
                 />
               )}
               <TokenField
@@ -252,7 +252,7 @@ const CrossChainTransferForm = (): JSX.Element => {
                 })}
                 error={!!errors[TRANSFER_AMOUNT]}
                 helperText={errors[TRANSFER_AMOUNT]?.message}
-                label={COLLATERAL_TOKEN_SYMBOL}
+                label={RELAY_CHAIN_NATIVE_TOKEN_SYMBOL}
                 approxUSD={`≈ $ ${approxUsdValue}`}
               />
             </div>

--- a/src/pages/Vaults/Vault/VaultStatusStatPanel/index.tsx
+++ b/src/pages/Vaults/Vault/VaultStatusStatPanel/index.tsx
@@ -9,7 +9,7 @@ import { BitcoinUnit } from '@interlay/monetary-js';
 
 import StatPanel from '../StatPanel';
 import ErrorFallback from 'components/ErrorFallback';
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import { getVaultStatusLabel } from 'utils/helpers/vaults';
 import { COLLATERAL_TOKEN_ID_LITERAL } from 'utils/constants/currency';
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
@@ -53,7 +53,7 @@ const VaultStatusStatPanel = ({ vaultAccountId }: Props): JSX.Element => {
     data: liquidationCollateralThreshold,
     error: liquidationCollateralThresholdError
   } = useQuery<Big, Error>(
-    [GENERIC_FETCHER, 'vaults', 'getLiquidationCollateralThreshold', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'vaults', 'getLiquidationCollateralThreshold', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<Big>(),
     {
       enabled: !!bridgeLoaded
@@ -67,7 +67,7 @@ const VaultStatusStatPanel = ({ vaultAccountId }: Props): JSX.Element => {
     data: secureCollateralThreshold,
     error: secureCollateralThresholdError
   } = useQuery<Big, Error>(
-    [GENERIC_FETCHER, 'vaults', 'getSecureCollateralThreshold', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'vaults', 'getSecureCollateralThreshold', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<Big>(),
     {
       enabled: !!bridgeLoaded
@@ -81,7 +81,7 @@ const VaultStatusStatPanel = ({ vaultAccountId }: Props): JSX.Element => {
     data: btcToCollateralTokenRate,
     error: btcToCollateralTokenRateError
   } = useQuery<BTCToCollateralTokenRate, Error>(
-    [GENERIC_FETCHER, 'oracle', 'getExchangeRate', COLLATERAL_TOKEN],
+    [GENERIC_FETCHER, 'oracle', 'getExchangeRate', RELAY_CHAIN_NATIVE_TOKEN],
     genericFetcher<BTCToCollateralTokenRate>(),
     {
       enabled: !!bridgeLoaded

--- a/src/services/fetchers/issue-request-fetcher.ts
+++ b/src/services/fetchers/issue-request-fetcher.ts
@@ -1,7 +1,7 @@
 import { BitcoinAmount } from '@interlay/monetary-js';
 import { newMonetaryAmount, IssueStatus } from '@interlay/interbtc-api';
 
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import issueRequestsQuery from 'services/queries/issue-requests-query';
 import graphqlFetcher, { GRAPHQL_FETCHER } from 'services/fetchers/graphql-fetcher';
 import getTxDetailsForRequest from 'services/fetchers/request-btctx-fetcher';
@@ -14,7 +14,7 @@ const ISSUE_FETCHER = 'issue-fetcher';
 function decodeIssueValues(issue: any): any {
   issue.request.amountWrapped = BitcoinAmount.from.Satoshi(issue.request.amountWrapped);
   issue.request.bridgeFeeWrapped = BitcoinAmount.from.Satoshi(issue.request.bridgeFeeWrapped);
-  issue.griefingCollateral = newMonetaryAmount(issue.griefingCollateral, COLLATERAL_TOKEN);
+  issue.griefingCollateral = newMonetaryAmount(issue.griefingCollateral, RELAY_CHAIN_NATIVE_TOKEN);
   if (issue.execution) {
     issue.execution.amountWrapped = BitcoinAmount.from.Satoshi(issue.execution.amountWrapped);
     issue.execution.bridgeFeeWrapped = BitcoinAmount.from.Satoshi(issue.execution.bridgeFeeWrapped);

--- a/src/services/fetchers/redeem-request-fetcher.ts
+++ b/src/services/fetchers/redeem-request-fetcher.ts
@@ -1,7 +1,7 @@
 import { BitcoinAmount } from '@interlay/monetary-js';
 import { newMonetaryAmount, RedeemStatus } from '@interlay/interbtc-api';
 
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import redeemRequestQuery from 'services/queries/redeem-request-query';
 import graphqlFetcher, { GRAPHQL_FETCHER } from 'services/fetchers/graphql-fetcher';
 import getTxDetailsForRequest from 'services/fetchers/request-btctx-fetcher';
@@ -17,9 +17,9 @@ function decodeRedeemValues(redeem: any): any {
   redeem.btcTransferFee = BitcoinAmount.from.Satoshi(redeem.btcTransferFee);
 
   // TODO: get actual vault collateral when it's added to events
-  redeem.collateralPremium = newMonetaryAmount(redeem.collateralPremium, COLLATERAL_TOKEN);
+  redeem.collateralPremium = newMonetaryAmount(redeem.collateralPremium, RELAY_CHAIN_NATIVE_TOKEN);
   if (redeem.cancellation) {
-    redeem.cancellation.slashedCollateral = newMonetaryAmount(redeem.cancellation.slashedCollateral, COLLATERAL_TOKEN);
+    redeem.cancellation.slashedCollateral = newMonetaryAmount(redeem.cancellation.slashedCollateral, RELAY_CHAIN_NATIVE_TOKEN);
   }
 
   return redeem;

--- a/src/utils/constants/currency.ts
+++ b/src/utils/constants/currency.ts
@@ -5,9 +5,9 @@ import {
   newMonetaryAmount
 } from '@interlay/interbtc-api';
 
-import { COLLATERAL_TOKEN, WRAPPED_TOKEN, GOVERNANCE_TOKEN, VOTE_GOVERNANCE_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN, GOVERNANCE_TOKEN, VOTE_GOVERNANCE_TOKEN } from 'config/relay-chains';
 
-const COLLATERAL_TOKEN_ID_LITERAL = tickerToCurrencyIdLiteral(COLLATERAL_TOKEN.ticker) as CollateralIdLiteral;
+const COLLATERAL_TOKEN_ID_LITERAL = tickerToCurrencyIdLiteral(RELAY_CHAIN_NATIVE_TOKEN.ticker) as CollateralIdLiteral;
 
 const WRAPPED_TOKEN_ID_LITERAL = tickerToCurrencyIdLiteral(WRAPPED_TOKEN.ticker) as WrappedIdLiteral;
 

--- a/src/utils/relay-chain-api/get-relay-chain-balance.ts
+++ b/src/utils/relay-chain-api/get-relay-chain-balance.ts
@@ -1,14 +1,14 @@
 import { ApiPromise } from '@polkadot/api';
 import { AddressOrPair } from '@polkadot/api-base/types';
 import { newMonetaryAmount } from '@interlay/interbtc-api';
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import { RelayChainMonetaryAmount } from './';
 
 const getRelayChainBalance = async (api: ApiPromise, address: AddressOrPair): Promise<RelayChainMonetaryAmount> => {
   // TODO: resolve type error related to Codec type and cast properly
   const account = (await api.query.system.account(address)) as any;
 
-  return newMonetaryAmount(account.data.free, COLLATERAL_TOKEN);
+  return newMonetaryAmount(account.data.free, RELAY_CHAIN_NATIVE_TOKEN);
 };
 
 export { getRelayChainBalance };

--- a/src/utils/relay-chain-api/transfer-to-relay-chain.ts
+++ b/src/utils/relay-chain-api/transfer-to-relay-chain.ts
@@ -3,7 +3,7 @@ import { ApiPromise } from '@polkadot/api';
 import { decodeAddress } from '@polkadot/keyring';
 import { AddressOrPair } from '@polkadot/api/types';
 
-import { COLLATERAL_TOKEN } from 'config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from 'config/relay-chains';
 import { TRANSFER_WEIGHT } from './constants';
 import { RelayChainMonetaryAmount } from './';
 
@@ -26,7 +26,7 @@ const transferToRelayChain = async (
 
   const dest = createDest(api, id);
   // TODO: does this need to be done here, or can it be imported from the lib?
-  const currencyId = newCurrencyId(api, tickerToCurrencyIdLiteral(COLLATERAL_TOKEN.ticker));
+  const currencyId = newCurrencyId(api, tickerToCurrencyIdLiteral(RELAY_CHAIN_NATIVE_TOKEN.ticker));
 
   const xcmTransaction = api.tx.xTokens.transfer(currencyId, transferAmount.toString(), dest, TRANSFER_WEIGHT);
 


### PR DESCRIPTION
I found that we were referring to a relay chain's native tokens like DOT or KSM as collateral token. I think it's not correct. In the past, the relay chain's native token was the only collateral but now we are supporting multi-collaterals including KINT and USDC and more will be added. So I think we should update names accordingly.

This PR does not include any logical changes but just renaming. So I'd say it's safe to merge this PR without having a look at every single line of change in detail.