### PR TITLE
fix: locked collateral card handles undefined price of governance token

### DIFF
--- a/src/pages/Dashboard/sub-pages/Home/LockedCollateralsCard/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Home/LockedCollateralsCard/index.tsx
@@ -40,9 +40,6 @@ const LockedCollateralsCard = (): JSX.Element => {
 
   const relayChainNativeTokenPriceInUSD = prices.collateralToken?.usd;
   const governanceTokenPriceInUSD = prices.governanceToken?.usd;
-  if (relayChainNativeTokenPriceInUSD === undefined || governanceTokenPriceInUSD === undefined) {
-    throw new Error('Something went wrong with price feeds!');
-  }
 
   const cumulativeUSDVolumes = React.useMemo(() => {
     if (cumulativeRelayChainNativeTokenVolumes === undefined || cumulativeGovernanceTokenVolumes === undefined) return;
@@ -54,12 +51,16 @@ const LockedCollateralsCard = (): JSX.Element => {
           {
             cumulativeVolumes: cumulativeRelayChainNativeTokenVolumes,
             tokenPriceInUSD: relayChainNativeTokenPriceInUSD
-          },
-          {
-            cumulativeVolumes: cumulativeGovernanceTokenVolumes,
-            tokenPriceInUSD: governanceTokenPriceInUSD
           }
         ];
+
+        // Includes governance token data only if the price is available.
+        if (governanceTokenPriceInUSD !== undefined) {
+          collaterals.push({
+            cumulativeVolumes: cumulativeGovernanceTokenVolumes,
+            tokenPriceInUSD: governanceTokenPriceInUSD
+          });
+        }
 
         let sumValueInUSD = 0;
         for (const collateral of collaterals) {


### PR DESCRIPTION
Fixing Locked Collateral Card component to work on Interlay. The governance token data will be used only when the price is available.

before
![image](https://user-images.githubusercontent.com/47864599/174619324-f7642837-aab7-45e4-b83d-4335dfe47e21.png)
after
![image](https://user-images.githubusercontent.com/47864599/174619386-ba4e86ee-5ce8-45c3-8adb-7bcc578ce306.png)
