### PR TITLE
Tom/cta bug fix

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,8 @@ import '../src/componentLibrary/theme/theme.interlay.css';
 import '../src/componentLibrary/theme/theme.kintsugi.css';
 import './sb-preview.css';
 import { withThemes } from 'storybook-addon-themes/react';
+import { addDecorator } from "@storybook/react";
+import { MemoryRouter } from "react-router-dom";
 
 const parameters = {
   backgrounds: { disable: true },
@@ -22,6 +24,8 @@ const parameters = {
     Decorator: withThemes 
   },
 };
+
+addDecorator(story => <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>);
 
 export {
   parameters

--- a/src/componentLibrary/CTA/CTALink.tsx
+++ b/src/componentLibrary/CTA/CTALink.tsx
@@ -1,7 +1,8 @@
 import { forwardRef } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
 import { PrimaryCTA, SecondaryCTA } from './CTA.style';
 
-interface CTALinkProps extends React.ComponentPropsWithRef<'a'> {
+interface CTALinkProps extends LinkProps {
   fullWidth?: boolean;
   variant: 'primary' | 'secondary';
 }
@@ -10,11 +11,11 @@ interface CTALinkProps extends React.ComponentPropsWithRef<'a'> {
 const CTALink = forwardRef<HTMLAnchorElement, CTALinkProps>(
   ({ variant, fullWidth = false, className, href, children, ...rest }, ref): JSX.Element =>
     variant === 'primary' ? (
-      <PrimaryCTA as='a' fullWidth={fullWidth} ref={ref} href={href} className={className} {...rest}>
+      <PrimaryCTA as={Link} fullWidth={fullWidth} ref={ref} href={href} className={className} {...rest}>
         {children}
       </PrimaryCTA>
     ) : (
-      <SecondaryCTA as='a' fullWidth={fullWidth} ref={ref} href={href} className={className} {...rest}>
+      <SecondaryCTA as={Link} fullWidth={fullWidth} ref={ref} href={href} className={className} {...rest}>
         {children}
       </SecondaryCTA>
     )

--- a/src/componentLibrary/CTA/CTALink.tsx
+++ b/src/componentLibrary/CTA/CTALink.tsx
@@ -9,13 +9,13 @@ interface CTALinkProps extends LinkProps {
 
 // TODO: Does this need to be changed to a React Router link component?
 const CTALink = forwardRef<HTMLAnchorElement, CTALinkProps>(
-  ({ variant, fullWidth = false, className, href, children, ...rest }, ref): JSX.Element =>
+  ({ variant, fullWidth = false, className, children, ...rest }, ref): JSX.Element =>
     variant === 'primary' ? (
-      <PrimaryCTA as={Link} fullWidth={fullWidth} ref={ref} href={href} className={className} {...rest}>
+      <PrimaryCTA as={Link} fullWidth={fullWidth} ref={ref} className={className} {...rest}>
         {children}
       </PrimaryCTA>
     ) : (
-      <SecondaryCTA as={Link} fullWidth={fullWidth} ref={ref} href={href} className={className} {...rest}>
+      <SecondaryCTA as={Link} fullWidth={fullWidth} ref={ref} className={className} {...rest}>
         {children}
       </SecondaryCTA>
     )

--- a/src/componentLibrary/VaultCard/VaultCard.tsx
+++ b/src/componentLibrary/VaultCard/VaultCard.tsx
@@ -45,7 +45,7 @@ const VaultCard = ({
         </DlItem>
       </StyledDl>
       <CTAWrapper>
-        <CTALink href={link} variant='primary' fullWidth={false}>
+        <CTALink to={link} variant='primary' fullWidth={false}>
           View
         </CTALink>
       </CTAWrapper>


### PR DESCRIPTION
CTALink component renders a router link instead of an anchor tag, which prevents the application re-rendering unnecessarily.