### PR TITLE
fix: use transient props to resolve react error

### DIFF
--- a/src/componentLibrary/CTA/CTA.style.tsx
+++ b/src/componentLibrary/CTA/CTA.style.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { theme } from 'componentLibrary';
 
 interface CTAProps {
-  fullWidth: boolean;
+  $fullWidth: boolean;
 }
 
 const BaseCTA = styled.button<CTAProps>`
@@ -16,7 +16,7 @@ const BaseCTA = styled.button<CTAProps>`
   line-height: ${theme.lineHeight.base};
   padding: ${theme.spacing.spacing3} ${theme.spacing.spacing10};
   text-decoration: none;
-  width: ${(props) => (props.fullWidth ? '100%' : 'auto')};
+  width: ${(props) => (props.$fullWidth ? '100%' : 'auto')};
   opacity: ${(props) => (props.disabled ? '50%' : '100%')};
 `;
 

--- a/src/componentLibrary/CTA/CTA.tsx
+++ b/src/componentLibrary/CTA/CTA.tsx
@@ -12,7 +12,7 @@ const CTA = forwardRef<HTMLButtonElement, CTAProps>(
     variant === 'primary' ? (
       <PrimaryCTA
         as='button'
-        fullWidth={fullWidth}
+        $fullWidth={fullWidth}
         disabled={disabled}
         ref={ref}
         onClick={onClick}
@@ -24,7 +24,7 @@ const CTA = forwardRef<HTMLButtonElement, CTAProps>(
     ) : (
       <SecondaryCTA
         as='button'
-        fullWidth={fullWidth}
+        $fullWidth={fullWidth}
         disabled={disabled}
         ref={ref}
         onClick={onClick}

--- a/src/componentLibrary/CTA/CTALink.tsx
+++ b/src/componentLibrary/CTA/CTALink.tsx
@@ -11,11 +11,11 @@ interface CTALinkProps extends LinkProps {
 const CTALink = forwardRef<HTMLAnchorElement, CTALinkProps>(
   ({ variant, fullWidth = false, className, children, ...rest }, ref): JSX.Element =>
     variant === 'primary' ? (
-      <PrimaryCTA as={Link} fullWidth={fullWidth} ref={ref} className={className} {...rest}>
+      <PrimaryCTA as={Link} $fullWidth={fullWidth} ref={ref} className={className} {...rest}>
         {children}
       </PrimaryCTA>
     ) : (
-      <SecondaryCTA as={Link} fullWidth={fullWidth} ref={ref} className={className} {...rest}>
+      <SecondaryCTA as={Link} $fullWidth={fullWidth} ref={ref} className={className} {...rest}>
         {children}
       </SecondaryCTA>
     )


### PR DESCRIPTION
This fixes a React error by using transient props to avoid custom props being passed down to the dom element