### PR TITLE
feat: text components

### DIFF
--- a/src/component-library/Text/Em/Em.stories.tsx
+++ b/src/component-library/Text/Em/Em.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { Em, EmProps } from '.';
+
+const Template: Story<EmProps> = (args) => <Em {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary emphasis'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary emphasis'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary emphasis'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/Em',
+  component: Em
+} as Meta;

--- a/src/component-library/Text/Em/Em.style.tsx
+++ b/src/component-library/Text/Em/Em.style.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import { BaseTextProps, resolveTextColor } from '..';
+
+const EmText = styled.em<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-style: italic;
+`;
+
+export { EmText };

--- a/src/component-library/Text/Em/Em.tsx
+++ b/src/component-library/Text/Em/Em.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { EmText } from './Em.style';
+
+interface EmProps extends BaseTextProps {
+  children: ReactNode;
+}
+
+const Em = ({ color, children }: EmProps): JSX.Element => <EmText color={color}>{children}</EmText>;
+
+export { Em };
+export type { EmProps };

--- a/src/component-library/Text/Em/Em.tsx
+++ b/src/component-library/Text/Em/Em.tsx
@@ -9,5 +9,7 @@ interface EmProps extends BaseTextProps {
 
 const Em = ({ color, children }: EmProps): JSX.Element => <EmText color={color}>{children}</EmText>;
 
+Em.displayName = 'Em';
+
 export { Em };
 export type { EmProps };

--- a/src/component-library/Text/Em/index.tsx
+++ b/src/component-library/Text/Em/index.tsx
@@ -1,0 +1,2 @@
+export { Em } from './Em';
+export type { EmProps } from './Em';

--- a/src/component-library/Text/H1/H1.stories.tsx
+++ b/src/component-library/Text/H1/H1.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { H1, H1Props } from '.';
+
+const Template: Story<H1Props> = (args) => <H1 {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary heading 1'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary heading 1'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary heading 1'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/H1',
+  component: H1
+} as Meta;

--- a/src/component-library/Text/H1/H1.style.tsx
+++ b/src/component-library/Text/H1/H1.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const H1Text = styled.h1<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-size: ${theme.text.xl5};
+`;
+
+export { H1Text };

--- a/src/component-library/Text/H1/H1.tsx
+++ b/src/component-library/Text/H1/H1.tsx
@@ -9,5 +9,7 @@ interface H1Props extends BaseTextProps {
 
 const H1 = ({ color, children }: H1Props): JSX.Element => <H1Text color={color}>{children}</H1Text>;
 
+H1.displayName = 'H1';
+
 export { H1 };
 export type { H1Props };

--- a/src/component-library/Text/H1/H1.tsx
+++ b/src/component-library/Text/H1/H1.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { H1Text } from './H1.style';
+
+interface H1Props extends BaseTextProps {
+  children: ReactNode;
+}
+
+const H1 = ({ color, children }: H1Props): JSX.Element => <H1Text color={color}>{children}</H1Text>;
+
+export { H1 };
+export type { H1Props };

--- a/src/component-library/Text/H1/index.tsx
+++ b/src/component-library/Text/H1/index.tsx
@@ -1,0 +1,2 @@
+export { H1 } from './H1';
+export type { H1Props } from './H1';

--- a/src/component-library/Text/H2/H2.stories.tsx
+++ b/src/component-library/Text/H2/H2.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { H2, H2Props } from '.';
+
+const Template: Story<H2Props> = (args) => <H2 {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary heading 2'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary heading 2'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary heading 2'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/H2',
+  component: H2
+} as Meta;

--- a/src/component-library/Text/H2/H2.style.tsx
+++ b/src/component-library/Text/H2/H2.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const H2Text = styled.h2<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-size: ${theme.text.xl4};
+`;
+
+export { H2Text };

--- a/src/component-library/Text/H2/H2.tsx
+++ b/src/component-library/Text/H2/H2.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { H2Text } from './H2.style';
+
+interface H2Props extends BaseTextProps {
+  children: ReactNode;
+}
+
+const H2 = ({ color, children }: H2Props): JSX.Element => <H2Text color={color}>{children}</H2Text>;
+
+export { H2 };
+export type { H2Props };

--- a/src/component-library/Text/H2/H2.tsx
+++ b/src/component-library/Text/H2/H2.tsx
@@ -9,5 +9,7 @@ interface H2Props extends BaseTextProps {
 
 const H2 = ({ color, children }: H2Props): JSX.Element => <H2Text color={color}>{children}</H2Text>;
 
+H2.displayName = 'H2';
+
 export { H2 };
 export type { H2Props };

--- a/src/component-library/Text/H2/index.tsx
+++ b/src/component-library/Text/H2/index.tsx
@@ -1,0 +1,2 @@
+export { H2 } from './H2';
+export type { H2Props } from './H2';

--- a/src/component-library/Text/H3/H3.stories.tsx
+++ b/src/component-library/Text/H3/H3.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { H3, H3Props } from '.';
+
+const Template: Story<H3Props> = (args) => <H3 {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary heading 3'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary heading 3'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary heading 3'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/H3',
+  component: H3
+} as Meta;

--- a/src/component-library/Text/H3/H3.style.tsx
+++ b/src/component-library/Text/H3/H3.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const H3Text = styled.h3<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-size: ${theme.text.xl3};
+`;
+
+export { H3Text };

--- a/src/component-library/Text/H3/H3.tsx
+++ b/src/component-library/Text/H3/H3.tsx
@@ -9,5 +9,7 @@ interface H3Props extends BaseTextProps {
 
 const H3 = ({ color, children }: H3Props): JSX.Element => <H3Text color={color}>{children}</H3Text>;
 
+H3.displayName = 'H3';
+
 export { H3 };
 export type { H3Props };

--- a/src/component-library/Text/H3/H3.tsx
+++ b/src/component-library/Text/H3/H3.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { H3Text } from './H3.style';
+
+interface H3Props extends BaseTextProps {
+  children: ReactNode;
+}
+
+const H3 = ({ color, children }: H3Props): JSX.Element => <H3Text color={color}>{children}</H3Text>;
+
+export { H3 };
+export type { H3Props };

--- a/src/component-library/Text/H3/index.tsx
+++ b/src/component-library/Text/H3/index.tsx
@@ -1,0 +1,2 @@
+export { H3 } from './H3';
+export type { H3Props } from './H3';

--- a/src/component-library/Text/H4/H4.stories.tsx
+++ b/src/component-library/Text/H4/H4.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { H4, H4Props } from '.';
+
+const Template: Story<H4Props> = (args) => <H4 {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary heading 4'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary heading 4'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary heading 4'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/H4',
+  component: H4
+} as Meta;

--- a/src/component-library/Text/H4/H4.style.tsx
+++ b/src/component-library/Text/H4/H4.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const H4Text = styled.h4<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-size: ${theme.text.xl2};
+`;
+
+export { H4Text };

--- a/src/component-library/Text/H4/H4.tsx
+++ b/src/component-library/Text/H4/H4.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { H4Text } from './H4.style';
+
+interface H4Props extends BaseTextProps {
+  children: ReactNode;
+}
+
+const H4 = ({ color, children }: H4Props): JSX.Element => <H4Text color={color}>{children}</H4Text>;
+
+export { H4 };
+export type { H4Props };

--- a/src/component-library/Text/H4/H4.tsx
+++ b/src/component-library/Text/H4/H4.tsx
@@ -9,5 +9,7 @@ interface H4Props extends BaseTextProps {
 
 const H4 = ({ color, children }: H4Props): JSX.Element => <H4Text color={color}>{children}</H4Text>;
 
+H4.displayName = 'H4';
+
 export { H4 };
 export type { H4Props };

--- a/src/component-library/Text/H4/index.tsx
+++ b/src/component-library/Text/H4/index.tsx
@@ -1,0 +1,2 @@
+export { H4 } from './H4';
+export type { H4Props } from './H4';

--- a/src/component-library/Text/H5/H5.stories.tsx
+++ b/src/component-library/Text/H5/H5.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { H5, H5Props } from '.';
+
+const Template: Story<H5Props> = (args) => <H5 {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary heading 5'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary heading 5'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary heading 5'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/H5',
+  component: H5
+} as Meta;

--- a/src/component-library/Text/H5/H5.style.tsx
+++ b/src/component-library/Text/H5/H5.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const H5Text = styled.h5<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-size: ${theme.text.xl};
+`;
+
+export { H5Text };

--- a/src/component-library/Text/H5/H5.tsx
+++ b/src/component-library/Text/H5/H5.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { H5Text } from './H5.style';
+
+interface H5Props extends BaseTextProps {
+  children: ReactNode;
+}
+
+const H5 = ({ color, children }: H5Props): JSX.Element => <H5Text color={color}>{children}</H5Text>;
+
+export { H5 };
+export type { H5Props };

--- a/src/component-library/Text/H5/H5.tsx
+++ b/src/component-library/Text/H5/H5.tsx
@@ -9,5 +9,7 @@ interface H5Props extends BaseTextProps {
 
 const H5 = ({ color, children }: H5Props): JSX.Element => <H5Text color={color}>{children}</H5Text>;
 
+H5.displayName = 'H5';
+
 export { H5 };
 export type { H5Props };

--- a/src/component-library/Text/H5/index.tsx
+++ b/src/component-library/Text/H5/index.tsx
@@ -1,0 +1,2 @@
+export { H5 } from './H5';
+export type { H5Props } from './H5';

--- a/src/component-library/Text/H6/H6.stories.tsx
+++ b/src/component-library/Text/H6/H6.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { H6, H6Props } from '.';
+
+const Template: Story<H6Props> = (args) => <H6 {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary heading 6'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary heading 6'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary heading 6'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/H6',
+  component: H6
+} as Meta;

--- a/src/component-library/Text/H6/H6.style.tsx
+++ b/src/component-library/Text/H6/H6.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const H6Text = styled.h6<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-size: ${theme.text.lg};
+`;
+
+export { H6Text };

--- a/src/component-library/Text/H6/H6.tsx
+++ b/src/component-library/Text/H6/H6.tsx
@@ -9,5 +9,7 @@ interface H6Props extends BaseTextProps {
 
 const H6 = ({ color, children }: H6Props): JSX.Element => <H6Text color={color}>{children}</H6Text>;
 
+H6.displayName = 'H6';
+
 export { H6 };
 export type { H6Props };

--- a/src/component-library/Text/H6/H6.tsx
+++ b/src/component-library/Text/H6/H6.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { H6Text } from './H6.style';
+
+interface H6Props extends BaseTextProps {
+  children: ReactNode;
+}
+
+const H6 = ({ color, children }: H6Props): JSX.Element => <H6Text color={color}>{children}</H6Text>;
+
+export { H6 };
+export type { H6Props };

--- a/src/component-library/Text/H6/index.tsx
+++ b/src/component-library/Text/H6/index.tsx
@@ -1,0 +1,2 @@
+export { H6 } from './H6';
+export type { H6Props } from './H6';

--- a/src/component-library/Text/P/P.stories.tsx
+++ b/src/component-library/Text/P/P.stories.tsx
@@ -1,0 +1,33 @@
+import { Story, Meta } from '@storybook/react';
+
+import { P, PProps } from '.';
+
+const Template: Story<PProps> = (args) => <P {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children:
+    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus maiores cumque quidem voluptate odit explicabo asperiores itaque tenetur illum iusto possimus quae, sequi natus corporis voluptas cupiditate ipsa eius officiis?'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children:
+    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus maiores cumque quidem voluptate odit explicabo asperiores itaque tenetur illum iusto possimus quae, sequi natus corporis voluptas cupiditate ipsa eius officiis?'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children:
+    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Doloribus maiores cumque quidem voluptate odit explicabo asperiores itaque tenetur illum iusto possimus quae, sequi natus corporis voluptas cupiditate ipsa eius officiis?'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/P',
+  component: P
+} as Meta;

--- a/src/component-library/Text/P/P.style.tsx
+++ b/src/component-library/Text/P/P.style.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+import { BaseTextProps, resolveTextColor } from '..';
+import { theme } from '../..';
+
+const ParagraphText = styled.p<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  line-height: ${theme.lineHeight.base};
+  font-size: ${theme.text.base};
+`;
+
+export { ParagraphText };

--- a/src/component-library/Text/P/P.tsx
+++ b/src/component-library/Text/P/P.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { ParagraphText } from './P.style';
+
+interface PProps extends BaseTextProps {
+  children: ReactNode;
+}
+
+const P = ({ color, children }: PProps): JSX.Element => <ParagraphText color={color}>{children}</ParagraphText>;
+
+export { P };
+export type { PProps };

--- a/src/component-library/Text/P/P.tsx
+++ b/src/component-library/Text/P/P.tsx
@@ -9,5 +9,7 @@ interface PProps extends BaseTextProps {
 
 const P = ({ color, children }: PProps): JSX.Element => <ParagraphText color={color}>{children}</ParagraphText>;
 
+P.displayName = 'P';
+
 export { P };
 export type { PProps };

--- a/src/component-library/Text/P/index.tsx
+++ b/src/component-library/Text/P/index.tsx
@@ -1,0 +1,2 @@
+export { P } from './P';
+export type { PProps } from './P';

--- a/src/component-library/Text/Strong/Strong.stories.tsx
+++ b/src/component-library/Text/Strong/Strong.stories.tsx
@@ -1,0 +1,30 @@
+import { Story, Meta } from '@storybook/react';
+
+import { Strong, StrongProps } from '.';
+
+const Template: Story<StrongProps> = (args) => <Strong {...args} />;
+
+const Primary = Template.bind({});
+Primary.args = {
+  color: 'primary',
+  children: 'Primary strong'
+};
+
+const Secondary = Template.bind({});
+Secondary.args = {
+  color: 'secondary',
+  children: 'Secondary strong'
+};
+
+const Tertiary = Template.bind({});
+Tertiary.args = {
+  color: 'tertiary',
+  children: 'Tertiary strong'
+};
+
+export { Primary, Secondary, Tertiary };
+
+export default {
+  title: 'Text/Strong',
+  component: Strong
+} as Meta;

--- a/src/component-library/Text/Strong/Strong.style.tsx
+++ b/src/component-library/Text/Strong/Strong.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { theme } from '../..';
+import { BaseTextProps, resolveTextColor } from '..';
+
+const StrongText = styled.strong<BaseTextProps>`
+  color: ${({ color }) => resolveTextColor(color)};
+  font-weight: ${theme.fontWeight.bold};
+`;
+
+export { StrongText };

--- a/src/component-library/Text/Strong/Strong.tsx
+++ b/src/component-library/Text/Strong/Strong.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+import { BaseTextProps } from '..';
+import { StrongText } from './Strong.style';
+
+interface StrongProps extends BaseTextProps {
+  children: ReactNode;
+}
+
+const Strong = ({ color, children }: StrongProps): JSX.Element => <StrongText color={color}>{children}</StrongText>;
+
+export { Strong };
+export type { StrongProps };

--- a/src/component-library/Text/Strong/Strong.tsx
+++ b/src/component-library/Text/Strong/Strong.tsx
@@ -9,5 +9,7 @@ interface StrongProps extends BaseTextProps {
 
 const Strong = ({ color, children }: StrongProps): JSX.Element => <StrongText color={color}>{children}</StrongText>;
 
+Strong.displayName = 'Strong';
+
 export { Strong };
 export type { StrongProps };

--- a/src/component-library/Text/Strong/index.tsx
+++ b/src/component-library/Text/Strong/index.tsx
@@ -1,0 +1,2 @@
+export { Strong } from './Strong';
+export type { StrongProps } from './Strong';

--- a/src/component-library/Text/index.tsx
+++ b/src/component-library/Text/index.tsx
@@ -1,0 +1,30 @@
+export { resolveTextColor } from './utils';
+
+export type { TextColor, BaseTextProps } from './types';
+
+export { Strong } from './Strong';
+export type { StrongProps } from './Strong';
+
+export { Em } from './Em';
+export type { EmProps } from './Em';
+
+export { P } from './P';
+export type { PProps } from './P';
+
+export { H1 } from './H1';
+export type { H1Props } from './H1';
+
+export { H2 } from './H2';
+export type { H2Props } from './H2';
+
+export { H3 } from './H3';
+export type { H3Props } from './H3';
+
+export { H4 } from './H4';
+export type { H4Props } from './H4';
+
+export { H5 } from './H5';
+export type { H5Props } from './H5';
+
+export { H6 } from './H6';
+export type { H6Props } from './H6';

--- a/src/component-library/Text/types.ts
+++ b/src/component-library/Text/types.ts
@@ -1,0 +1,7 @@
+type TextColor = 'primary' | 'secondary' | 'tertiary';
+
+interface BaseTextProps {
+    color?: TextColor
+}
+
+export type { TextColor, BaseTextProps };

--- a/src/component-library/Text/utils.ts
+++ b/src/component-library/Text/utils.ts
@@ -1,0 +1,17 @@
+import { theme } from "..";
+import { TextColor } from "./types";
+
+const resolveTextColor = (color: TextColor | undefined): string => {
+    switch (color) {
+        case 'primary':
+            return theme.colors.textPrimary;
+        case 'secondary':
+            return theme.colors.textSecondary;
+        case 'tertiary':
+            return theme.colors.textTertiary;
+        default:
+            return theme.colors.textPrimary;
+    }
+}
+
+export { resolveTextColor };

--- a/src/component-library/index.tsx
+++ b/src/component-library/index.tsx
@@ -44,3 +44,6 @@ export type { NumberInputProps } from './NumberInput';
 
 export { TokenField } from './TokenField';
 export type { TokenFieldProps } from './TokenField';
+
+export { Strong, Em, P, H1, H2, H3, H4, H5, H6 } from './Text';
+export type { StrongProps, EmProps, PProps, H1Props, H2Props, H3Props, H4Props, H5Props, H6Props } from './Text';


### PR DESCRIPTION
Adding text components to component library: `Strong`, `Em`, `P`, `H1`, `H2`, `H3`, `H4`, `H5`, `H6`. Each component accepts optional `color` property to allow control over the text color. 

This PR is quite big because it contains some boilerplate - to render stories, also the heading components are very similar. I added 3 story variations for primary, secondary and tertiary color. These can be removed if needed. Is there a story count limitation on Chromatic @tomjeatt?

Note: the heading sizes are subject to change - they are set accordingly to sizes defined in the theme and will be updated once we have the final values :)