### PR TITLE
fix(bridge): redeem error mismatch

### DIFF
--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -263,14 +263,22 @@ const RedeemForm = (): JSX.Element | null => {
 
     const validateForm = (value: string): string | undefined => {
       const parsedValue = BitcoinAmount.from.BTC(value);
-      const minValue = dustValue.add(currentInclusionFee).add(redeemFee);
+
       if (parsedValue.gt(wrappedTokenBalance)) {
         return `${t('redeem_page.current_balance')}${displayMonetaryAmount(wrappedTokenBalance)}`;
-      } else if (parsedValue.gte(maxRedeemableCapacity)) {
+      }
+
+      if (parsedValue.gte(maxRedeemableCapacity)) {
         return `${t('redeem_page.request_exceeds_capacity', {
           maxRedeemableAmount: `${displayMonetaryAmount(maxRedeemableCapacity)} BTC`
         })}`;
-      } else if (parsedValue.lte(minValue)) {
+      }
+
+      const parsedWrappedTokenAmount = BitcoinAmount.from.BTC(value);
+      const theRedeemFee = parsedWrappedTokenAmount.mul(redeemFeeRate);
+      const minValue = dustValue.add(currentInclusionFee).add(theRedeemFee);
+
+      if (parsedValue.lte(minValue)) {
         return `${t('redeem_page.amount_greater_dust_inclusion')}${displayMonetaryAmount(minValue)} BTC).`;
       }
 


### PR DESCRIPTION
This PR solves this [ticket](https://www.notion.so/interlay/Sim-o-0a0076c888bc49d7a980bf372acf0aef?p=4080fb4cfc264c21a135d5e7f6b3315b).

The problem was that the `validateForm` function is called `onChange` of the Input. The `redeemFee` calculation needs the current input value, meaning that it has a direct dependency to it. When calling `validateForm`, this function was using the most recent input value, while the `redeemFee` was still using the previous input value. Thus, creating a state sync issue. The quickest and simpler solution  was bring the calculation inside `validateForm` in order to use the most recent input value instead.

Here is a [video](https://www.loom.com/share/83220d693e974559adabd846a50b795b) of the end result.