### PR TITLE
chore: bump react-hook-form and resolve breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^17.0.1",
     "react-error-boundary": "^3.1.3",
     "react-helmet-async": "^1.2.2",
-    "react-hook-form": "^6.8.4",
+    "react-hook-form": "^7.33.1",
     "react-i18next": "^11.7.4",
     "react-icons": "^3.10.0",
     "react-paginate": "^7.1.3",

--- a/src/pages/Bridge/BurnForm/index.tsx
+++ b/src/pages/Bridge/BurnForm/index.tsx
@@ -141,7 +141,7 @@ const BurnForm = (): JSX.Element | null => {
       }
     };
 
-    const validateForm = (value: number): string | undefined => {
+    const validateForm = (value: string): string | undefined => {
       // TODO: should use wrapped token amount type (e.g. InterBtcAmount or KBtcAmount)
       const bitcoinAmountValue = BitcoinAmount.from.BTC(value);
 
@@ -209,9 +209,8 @@ const BurnForm = (): JSX.Element | null => {
           />
           <TokenField
             id={WRAPPED_TOKEN_AMOUNT}
-            name={WRAPPED_TOKEN_AMOUNT}
             label={WRAPPED_TOKEN_SYMBOL}
-            ref={register({
+            {...register(WRAPPED_TOKEN_AMOUNT, {
               required: {
                 value: true,
                 message: t('burn_page.please_enter_the_amount')

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -310,10 +310,9 @@ const IssueForm = (): JSX.Element | null => {
           <div>
             <TokenField
               id={BTC_AMOUNT}
-              name={BTC_AMOUNT}
               label='BTC'
               min={0}
-              ref={register({
+              {...register(BTC_AMOUNT, {
                 required: {
                   value: true,
                   message: t('issue_page.enter_valid_amount')

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -337,10 +337,9 @@ const RedeemForm = (): JSX.Element | null => {
           </FormTitle>
           <TokenField
             id={WRAPPED_TOKEN_AMOUNT}
-            name={WRAPPED_TOKEN_AMOUNT}
             label={WRAPPED_TOKEN_SYMBOL}
             min={0}
-            ref={register({
+            {...register(WRAPPED_TOKEN_AMOUNT, {
               required: {
                 value: true,
                 message: t('redeem_page.please_enter_amount')
@@ -354,11 +353,10 @@ const RedeemForm = (): JSX.Element | null => {
           <ParachainStatusInfo status={parachainStatus} />
           <TextField
             id={BTC_ADDRESS}
-            name={BTC_ADDRESS}
             type='text'
             label='BTC Address'
             placeholder={t('enter_btc_address')}
-            ref={register({
+            {...register(BTC_ADDRESS, {
               required: {
                 value: true,
                 message: t('redeem_page.enter_btc')

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -759,10 +759,9 @@ const Staking = (): JSX.Element => {
               />
               <TokenField
                 id={LOCKING_AMOUNT}
-                name={LOCKING_AMOUNT}
                 label={GOVERNANCE_TOKEN_SYMBOL}
                 min={0}
-                ref={register({
+                {...register(LOCKING_AMOUNT, {
                   required: {
                     value: extendLockTimeSet ? false : true,
                     message: 'This field is required!'
@@ -777,9 +776,8 @@ const Staking = (): JSX.Element => {
             </div>
             <LockTimeField
               id={LOCK_TIME}
-              name={LOCK_TIME}
               min={0}
-              ref={register({
+              {...register(LOCK_TIME, {
                 required: {
                   value: votingBalanceGreaterThanZero ? false : true,
                   message: 'This field is required!'

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -129,13 +129,13 @@ const CrossChainTransferForm = (): JSX.Element => {
     setApproxUsdValue(usd);
   };
 
-  const validateRelayChainTransferAmount = (value: number): string | undefined => {
+  const validateRelayChainTransferAmount = (value: string): string | undefined => {
     const transferAmount = newMonetaryAmount(value, RELAY_CHAIN_NATIVE_TOKEN, true);
 
     return relayChainBalance?.lt(transferAmount) ? t('insufficient_funds') : undefined;
   };
 
-  const validateParachainTransferAmount = (value: number): string | undefined => {
+  const validateParachainTransferAmount = (value: string): string | undefined => {
     const transferAmount = newMonetaryAmount(value, RELAY_CHAIN_NATIVE_TOKEN, true);
 
     // TODO: this api check won't be necessary when the api call is moved out of
@@ -278,10 +278,9 @@ const CrossChainTransferForm = (): JSX.Element => {
             onClick={handleClickBalance}
           />
           <TokenField
-            onChange={(e) => handleUpdateUsdAmount(e.target.value)}
             id={TRANSFER_AMOUNT}
-            name={TRANSFER_AMOUNT}
-            ref={register({
+            {...register(TRANSFER_AMOUNT, {
+              onChange: (e) => handleUpdateUsdAmount(e.target.value),
               required: {
                 value: true,
                 message: t('transfer_page.cross_chain_transfer_form.please_enter_amount')

--- a/src/pages/Transfer/TransferForm/index.tsx
+++ b/src/pages/Transfer/TransferForm/index.tsx
@@ -53,6 +53,7 @@ const TransferForm = (): JSX.Element => {
 
   const onSubmit = async (data: TransferFormData) => {
     if (!activeToken) return;
+    if (data[TRANSFER_AMOUNT] === undefined) return;
 
     try {
       setSubmitStatus(STATUSES.PENDING);
@@ -70,7 +71,7 @@ const TransferForm = (): JSX.Element => {
   };
 
   const validateTransferAmount = React.useCallback(
-    (value: number): string | undefined => {
+    (value: string): string | undefined => {
       if (!activeToken) return;
 
       const balance = newMonetaryAmount(
@@ -103,7 +104,7 @@ const TransferForm = (): JSX.Element => {
     setActiveToken(token);
   };
 
-  const handleClickBalance = () => setValue(TRANSFER_AMOUNT, activeToken?.transferableBalance);
+  const handleClickBalance = () => setValue(TRANSFER_AMOUNT, activeToken?.transferableBalance || '');
 
   React.useEffect(() => {
     setAccountSet(!!address);
@@ -145,8 +146,7 @@ const TransferForm = (): JSX.Element => {
             <Tokens variant='formField' showBalances={false} callbackFunction={handleTokenChange} />
             <TokenAmountField
               id={TRANSFER_AMOUNT}
-              name={TRANSFER_AMOUNT}
-              ref={register({
+              {...register(TRANSFER_AMOUNT, {
                 required: {
                   value: true,
                   message: t('redeem_page.please_enter_amount')
@@ -161,11 +161,10 @@ const TransferForm = (): JSX.Element => {
         <div>
           <TextField
             id={RECIPIENT_ADDRESS}
-            name={RECIPIENT_ADDRESS}
             type='text'
             label={t('recipient')}
             placeholder={t('recipient_account')}
-            ref={register({
+            {...register(RECIPIENT_ADDRESS, {
               required: {
                 value: true,
                 message: t('enter_recipient_address')

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -67,7 +67,14 @@ const extraRequiredCollateralTokenAmount = newMonetaryAmount(
 
 // TODO: share form with bridge page
 const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }: Props): JSX.Element => {
-  const { register, handleSubmit, errors, watch, trigger, setValue } = useForm<RequestIssueFormData>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+    trigger,
+    setValue
+  } = useForm<RequestIssueFormData>({
     mode: 'onChange'
   });
   const btcAmount = watch(WRAPPED_TOKEN_AMOUNT) || '0';
@@ -258,10 +265,9 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
             <div>
               <TokenField
                 id={WRAPPED_TOKEN_AMOUNT}
-                name={WRAPPED_TOKEN_AMOUNT}
                 label='BTC'
                 min={0}
-                ref={register({
+                {...register(WRAPPED_TOKEN_AMOUNT, {
                   required: {
                     value: true,
                     message: t('issue_page.enter_valid_amount')

--- a/src/pages/Vaults/Vault/RequestRedeemModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestRedeemModal/index.tsx
@@ -35,7 +35,11 @@ interface Props {
 
 // TODO: share form with bridge page
 const RequestRedeemModal = ({ onClose, open, collateralCurrency, vaultAddress }: Props): JSX.Element => {
-  const { register, handleSubmit, errors } = useForm<RequestRedeemFormData>();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<RequestRedeemFormData>();
   const lockedBtc = useSelector((state: StoreType) => state.vault.lockedBTC);
   const [isRequestPending, setRequestPending] = React.useState(false);
   const { t } = useTranslation();
@@ -97,9 +101,8 @@ const RequestRedeemModal = ({ onClose, open, collateralCurrency, vaultAddress }:
           <p>{t('vault.redeem_amount')}</p>
           <div>
             <NumberInput
-              name={WRAPPED_TOKEN_AMOUNT}
               min={0}
-              ref={register({
+              {...register(WRAPPED_TOKEN_AMOUNT, {
                 required: {
                   value: true,
                   message: t('Amount is required!')
@@ -113,10 +116,9 @@ const RequestRedeemModal = ({ onClose, open, collateralCurrency, vaultAddress }:
           <div>
             <TextField
               id={BTC_ADDRESS}
-              name={BTC_ADDRESS}
               type='text'
               placeholder={t('enter_btc_address')}
-              ref={register({
+              {...register(BTC_ADDRESS, {
                 required: {
                   value: true,
                   message: t('redeem_page.enter_btc')

--- a/src/pages/Vaults/Vault/RequestReplacementModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestReplacementModal/index.tsx
@@ -34,7 +34,11 @@ interface Props {
 }
 
 const RequestReplacementModal = ({ onClose, open, collateralCurrency, vaultAddress }: Props): JSX.Element => {
-  const { register, handleSubmit, errors } = useForm<RequestReplacementFormData>();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<RequestReplacementFormData>();
   const lockedCollateral = useSelector((state: StoreType) => state.vault.collateral);
   const lockedBtc = useSelector((state: StoreType) => state.vault.lockedBTC);
   const [isRequestPending, setRequestPending] = React.useState(false);
@@ -65,7 +69,7 @@ const RequestReplacementModal = ({ onClose, open, collateralCurrency, vaultAddre
     setRequestPending(false);
   });
 
-  const validateAmount = (value: string): string | undefined => {
+  const validateAmount = (value: number): string | undefined => {
     const wrappedTokenAmount = BitcoinAmount.from.BTC(value);
     if (wrappedTokenAmount.lte(BitcoinAmount.zero)) {
       return t('Amount must be greater than zero!');
@@ -97,9 +101,8 @@ const RequestReplacementModal = ({ onClose, open, collateralCurrency, vaultAddre
           <p>{t('vault.replace_amount')}</p>
           <div>
             <NumberInput
-              name={AMOUNT}
               min={0}
-              ref={register({
+              {...register(AMOUNT, {
                 required: {
                   value: true,
                   message: t('Amount is required!')

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -323,10 +323,9 @@ const UpdateCollateralModal = ({
             </label>
             <TokenField
               id={COLLATERAL_TOKEN_AMOUNT}
-              name={COLLATERAL_TOKEN_AMOUNT}
               label={collateralCurrency.id}
               min={0}
-              ref={register({
+              {...register(COLLATERAL_TOKEN_AMOUNT, {
                 required: {
                   value: true,
                   message: t('vault.collateral_is_required')

--- a/yarn.lock
+++ b/yarn.lock
@@ -15016,10 +15016,10 @@ react-helmet-async@^1.2.2:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^6.8.4:
-  version "6.15.8"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.8.tgz#725c139d308c431c4611e4b9d85a49f01cfc0e7a"
-  integrity sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==
+react-hook-form@^7.33.1:
+  version "7.33.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.33.1.tgz#8c4410e3420788d3b804d62cc4c142915c2e46d0"
+  integrity sha512-ydTfTxEJdvgjCZBj5DDXRc58oTEfnFupEwwTAQ9FSKzykEJkX+3CiAkGtAMiZG7IPWHuzgT6AOBfogiKhUvKgg==
 
 react-i18next@^11.7.4:
   version "11.16.1"


### PR DESCRIPTION
This PR upgrades react hook form to version 7, which included some breaking changes. There were some issues using the resolver (required for schema validation) with version 6, so better to bump the dependencies now.