### PR TITLE
Tom/vault theft status

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -32,14 +32,14 @@ REACT_APP_HYDRA_URL="https://api-dev-kintsugi.interlay.io/graphql/graphql"
 
 REACT_APP_BITCOIN_NETWORK="testnet"
 REACT_APP_DEFAULT_ACCOUNT_SEED="//Alice"
-REACT_APP_PARACHAIN_URL="wss://api-dev.interlay.io/parachain"
-REACT_APP_FAUCET_URL="https://api-dev.interlay.io/faucet"
-REACT_APP_STATS_SERVER_URL="https://api-dev.interlay.io/stats"
-REACT_APP_RELAY_CHAIN_URL="" // TODO: what is the polkadot relaychain URL?
+REACT_APP_PARACHAIN_URL="wss://staging.interlay-dev.interlay.io/parachain"
+REACT_APP_FAUCET_URL="https://staging.interlay-dev.interlay.io/faucet"
+REACT_APP_STATS_SERVER_URL="https://staging.interlay-dev.interlay.io/stats"
+REACT_APP_RELAY_CHAIN_URL="wss://staging.interlay-dev.interlay.io/relaychain"
 REACT_APP_PARACHAIN_ID="2032"
 REACT_APP_RELAY_CHAIN_NAME="polkadot"
 DOCKER_RELAY_CHAIN_CURRENCY="DOT"
-REACT_APP_HYDRA_URL="https://api-dev.interlay.io/graphql/graphql"
+REACT_APP_HYDRA_URL="https://staging.interlay-dev.interlay.io/graphql/graphql"
 
 /* PRODUCTION */
 

--- a/src/pages/Vaults/Vault/VaultStatusStatPanel/index.tsx
+++ b/src/pages/Vaults/Vault/VaultStatusStatPanel/index.tsx
@@ -1,4 +1,4 @@
-import { VaultExt } from '@interlay/interbtc-api';
+import { CurrencyIdLiteral, VaultExt } from '@interlay/interbtc-api';
 import { BitcoinUnit } from '@interlay/monetary-js';
 import { AccountId } from '@polkadot/types/interfaces';
 import Big from 'big.js';
@@ -13,29 +13,25 @@ import { RELAY_CHAIN_NATIVE_TOKEN } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useCurrentActiveBlockNumber from '@/services/hooks/use-current-active-block-number';
 import { BTCToCollateralTokenRate } from '@/types/currency';
-import { COLLATERAL_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { getVaultStatusLabel } from '@/utils/helpers/vaults';
 
 import StatPanel from '../StatPanel';
 
 interface Props {
   vaultAccountId: AccountId | undefined; // TODO: should remove `undefined` later on when the loading is properly handled
+  collateralId: CurrencyIdLiteral | undefined;
 }
 
-const VaultStatusStatPanel = ({ vaultAccountId }: Props): JSX.Element => {
+const VaultStatusStatPanel = ({ vaultAccountId, collateralId }: Props): JSX.Element => {
   const { t } = useTranslation();
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
   const { isIdle: vaultExtIdle, isLoading: vaultExtLoading, data: vaultExt, error: vaultExtError } = useQuery<
     VaultExt<BitcoinUnit>,
     Error
-  >(
-    [GENERIC_FETCHER, 'vaults', 'get', vaultAccountId, COLLATERAL_TOKEN_ID_LITERAL],
-    genericFetcher<VaultExt<BitcoinUnit>>(),
-    {
-      enabled: !!bridgeLoaded && !!vaultAccountId
-    }
-  );
+  >([GENERIC_FETCHER, 'vaults', 'get', vaultAccountId, collateralId], genericFetcher<VaultExt<BitcoinUnit>>(), {
+    enabled: !!bridgeLoaded && !!vaultAccountId && !!collateralId
+  });
   useErrorHandler(vaultExtError);
 
   const {

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -271,7 +271,7 @@ const Vault = (): JSX.Element => {
             {vaultItems.map((item) => (
               <StatPanel key={item.title} label={item.title} value={item.value} />
             ))}
-            <VaultStatusStatPanel vaultAccountId={vaultAccountId} />
+            <VaultStatusStatPanel collateralId={collateralCurrencyValues?.id} vaultAccountId={vaultAccountId} />
           </div>
         </div>
         {/* Check interaction with the vault */}


### PR DESCRIPTION
This fixes the bug with the incorrect vault status. The stats panel was making a separate call to get the vaults, with the collateral ID hardcoded.

We shouldn't need to make this additional api call, but with the vault dashboard work coming in next sprint it's best to leave as is for now, as we'll be refactoring it very shortly.

I've also updated the Interlay dev environment variables as these were out of date.  