### PR TITLE
Refactor/governance token balance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -321,7 +321,9 @@ const App = (): JSX.Element => {
   }, [dispatch, bridgeLoaded, address, wrappedTokenBalance, wrappedTokenTransferableBalance]);
 
   const queryClient = useQueryClient();
+  // ray test touch <
   const governanceTokenBalanceQueryKey = useGovernanceTokenBalanceQueryKey();
+  // ray test touch >
 
   // Subscribes to governance token balance
   React.useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,9 @@ import { ACCOUNT_ID_TYPE_NAME } from '@/config/general';
 import { APP_NAME, GOVERNANCE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN } from '@/config/relay-chains';
 import InterlayHelmet from '@/parts/InterlayHelmet';
 import Layout from '@/parts/Layout';
+// ray test touch <
 import { useGovernanceTokenBalanceQueryKey } from '@/services/hooks/use-token-balance';
+// ray test touch >
 import { BitcoinNetwork } from '@/types/bitcoin';
 import { COLLATERAL_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { PAGES } from '@/utils/constants/links';
@@ -330,7 +332,9 @@ const App = (): JSX.Element => {
     if (!bridgeLoaded) return;
     if (!address) return;
     if (!queryClient) return;
+    // ray test touch <
     if (!governanceTokenBalanceQueryKey) return;
+    // ray test touch >
 
     (async () => {
       try {
@@ -339,7 +343,9 @@ const App = (): JSX.Element => {
           address,
           // TODO: it looks like the callback is called just before the balance is updated (not after)
           () => {
+            // ray test touch <
             queryClient.invalidateQueries(governanceTokenBalanceQueryKey);
+            // ray test touch >
           }
         );
         // Unsubscribe if previous subscription is alive
@@ -359,7 +365,9 @@ const App = (): JSX.Element => {
         unsubscribeGovernanceTokenBalance.current = null;
       }
     };
+    // ray test touch <
   }, [bridgeLoaded, address, queryClient, governanceTokenBalanceQueryKey]);
+  // ray test touch >
 
   // Color schemes according to Interlay vs. Kintsugi
   React.useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,9 +36,7 @@ import { ACCOUNT_ID_TYPE_NAME } from '@/config/general';
 import { APP_NAME, GOVERNANCE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN } from '@/config/relay-chains';
 import InterlayHelmet from '@/parts/InterlayHelmet';
 import Layout from '@/parts/Layout';
-// ray test touch <
 import { useGovernanceTokenBalanceInvalidate } from '@/services/hooks/use-token-balance';
-// ray test touch >
 import { BitcoinNetwork } from '@/types/bitcoin';
 import { COLLATERAL_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { PAGES } from '@/utils/constants/links';
@@ -321,17 +319,13 @@ const App = (): JSX.Element => {
     };
   }, [dispatch, bridgeLoaded, address, wrappedTokenBalance, wrappedTokenTransferableBalance]);
 
-  // ray test touch <
   const governanceTokenBalanceInvalidate = useGovernanceTokenBalanceInvalidate();
-  // ray test touch >
 
   // Subscribes to governance token balance
   React.useEffect(() => {
     if (!bridgeLoaded) return;
     if (!address) return;
-    // ray test touch <
     if (!governanceTokenBalanceInvalidate) return;
-    // ray test touch >
 
     (async () => {
       try {
@@ -340,9 +334,7 @@ const App = (): JSX.Element => {
           address,
           // TODO: it looks like the callback is called just before the balance is updated (not after)
           () => {
-            // ray test touch <
             governanceTokenBalanceInvalidate();
-            // ray test touch >
           }
         );
         // Unsubscribe if previous subscription is alive
@@ -362,9 +354,7 @@ const App = (): JSX.Element => {
         unsubscribeGovernanceTokenBalance.current = null;
       }
     };
-    // ray test touch <
   }, [bridgeLoaded, address, governanceTokenBalanceInvalidate]);
-  // ray test touch >
 
   // Color schemes according to Interlay vs. Kintsugi
   React.useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,8 +27,10 @@ import {
   setInstalledExtensionAction,
   updateCollateralTokenBalanceAction,
   updateCollateralTokenTransferableBalanceAction,
+  // ray test touch <
   updateGovernanceTokenBalanceAction,
   updateGovernanceTokenTransferableBalanceAction,
+  // ray test touch >
   updateWrappedTokenBalanceAction,
   updateWrappedTokenTransferableBalanceAction
 } from '@/common/actions/general.actions';
@@ -45,6 +47,7 @@ import { PAGES } from '@/utils/constants/links';
 import { KUSAMA, POLKADOT } from '@/utils/constants/relay-chain-names';
 import STATUSES from '@/utils/constants/statuses';
 import { CLASS_NAMES } from '@/utils/constants/styles';
+
 
 import * as constants from './constants';
 
@@ -68,8 +71,10 @@ const App = (): JSX.Element => {
     wrappedTokenTransferableBalance,
     collateralTokenBalance,
     collateralTokenTransferableBalance,
+    // ray test touch <
     governanceTokenBalance,
     governanceTokenTransferableBalance
+    // ray test touch >
   } = useSelector((state: StoreType) => state.general);
   // eslint-disable-next-line max-len
   const [bridgeStatus, setBridgeStatus] = React.useState(STATUSES.IDLE); // TODO: `bridgeLoaded` should be based on enum instead of boolean
@@ -77,7 +82,9 @@ const App = (): JSX.Element => {
 
   const unsubscribeCollateralTokenBalance = React.useRef<UnsubscriptionRef>(null);
   const unsubscribeWrappedTokenBalance = React.useRef<UnsubscriptionRef>(null);
+  // ray test touch <
   const unsubscribeGovernanceTokenBalance = React.useRef<UnsubscriptionRef>(null);
+  // ray test touch >
 
   // Loads the main bridge API - connection to the bridge
   const loadBridge = React.useCallback(async (): Promise<void> => {
@@ -323,6 +330,7 @@ const App = (): JSX.Element => {
     };
   }, [dispatch, bridgeLoaded, address, wrappedTokenBalance, wrappedTokenTransferableBalance]);
 
+  // ray test touch <
   // Subscribes to governance token balance
   React.useEffect(() => {
     if (!dispatch) return;
@@ -361,6 +369,7 @@ const App = (): JSX.Element => {
       }
     };
   }, [dispatch, bridgeLoaded, address, governanceTokenBalance, governanceTokenTransferableBalance]);
+  // ray test touch >
 
   // Color schemes according to Interlay vs. Kintsugi
   React.useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,7 +330,7 @@ const App = (): JSX.Element => {
     };
   }, [dispatch, bridgeLoaded, address, wrappedTokenBalance, wrappedTokenTransferableBalance]);
 
-  // ray test touch <
+  // ray test touch <<
   // Subscribes to governance token balance
   React.useEffect(() => {
     if (!dispatch) return;
@@ -369,7 +369,7 @@ const App = (): JSX.Element => {
       }
     };
   }, [dispatch, bridgeLoaded, address, governanceTokenBalance, governanceTokenTransferableBalance]);
-  // ray test touch >
+  // ray test touch >>
 
   // Color schemes according to Interlay vs. Kintsugi
   React.useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import { Keyring } from '@polkadot/api';
 import { web3Accounts, web3Enable, web3FromAddress } from '@polkadot/extension-dapp';
 import * as React from 'react';
 import { withErrorBoundary } from 'react-error-boundary';
-import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { toast, ToastContainer } from 'react-toastify';
@@ -38,7 +37,7 @@ import { APP_NAME, GOVERNANCE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN, WRAPPED_TOKEN } f
 import InterlayHelmet from '@/parts/InterlayHelmet';
 import Layout from '@/parts/Layout';
 // ray test touch <
-import { useGovernanceTokenBalanceQueryKey } from '@/services/hooks/use-token-balance';
+import { useGovernanceTokenBalanceInvalidate } from '@/services/hooks/use-token-balance';
 // ray test touch >
 import { BitcoinNetwork } from '@/types/bitcoin';
 import { COLLATERAL_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
@@ -322,18 +321,16 @@ const App = (): JSX.Element => {
     };
   }, [dispatch, bridgeLoaded, address, wrappedTokenBalance, wrappedTokenTransferableBalance]);
 
-  const queryClient = useQueryClient();
   // ray test touch <
-  const governanceTokenBalanceQueryKey = useGovernanceTokenBalanceQueryKey();
+  const governanceTokenBalanceInvalidate = useGovernanceTokenBalanceInvalidate();
   // ray test touch >
 
   // Subscribes to governance token balance
   React.useEffect(() => {
     if (!bridgeLoaded) return;
     if (!address) return;
-    if (!queryClient) return;
     // ray test touch <
-    if (!governanceTokenBalanceQueryKey) return;
+    if (!governanceTokenBalanceInvalidate) return;
     // ray test touch >
 
     (async () => {
@@ -344,7 +341,7 @@ const App = (): JSX.Element => {
           // TODO: it looks like the callback is called just before the balance is updated (not after)
           () => {
             // ray test touch <
-            queryClient.invalidateQueries(governanceTokenBalanceQueryKey);
+            governanceTokenBalanceInvalidate();
             // ray test touch >
           }
         );
@@ -366,7 +363,7 @@ const App = (): JSX.Element => {
       }
     };
     // ray test touch <
-  }, [bridgeLoaded, address, queryClient, governanceTokenBalanceQueryKey]);
+  }, [bridgeLoaded, address, governanceTokenBalanceInvalidate]);
   // ray test touch >
 
   // Color schemes according to Interlay vs. Kintsugi

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,6 @@ import { KUSAMA, POLKADOT } from '@/utils/constants/relay-chain-names';
 import STATUSES from '@/utils/constants/statuses';
 import { CLASS_NAMES } from '@/utils/constants/styles';
 
-
 import * as constants from './constants';
 
 const Bridge = React.lazy(() => import(/* webpackChunkName: 'bridge' */ '@/pages/Bridge'));
@@ -332,7 +331,6 @@ const App = (): JSX.Element => {
     };
   }, [dispatch, bridgeLoaded, address, wrappedTokenBalance, wrappedTokenTransferableBalance]);
 
-  // ray test touch <<
   const queryClient = useQueryClient();
   const governanceTokenBalanceQueryKey = useGovernanceTokenBalanceQueryKey();
 
@@ -341,27 +339,25 @@ const App = (): JSX.Element => {
     if (!dispatch) return;
     if (!bridgeLoaded) return;
     if (!address) return;
-    // ray test touch <<<
     if (!queryClient) return;
     if (!governanceTokenBalanceQueryKey) return;
-    // ray test touch >>>
 
     (async () => {
       try {
         const unsubscribe = await window.bridge.tokens.subscribeToBalance(
           GOVERNANCE_TOKEN,
           address,
+          // TODO: it looks like the callback is called just before the balance is updated
           (_: string, balance: ChainBalance<GovernanceUnit>) => {
-            // ray test touch <<<
             queryClient.invalidateQueries(governanceTokenBalanceQueryKey);
-            console.log('ray : ***** subscribe');
-            // ray test touch >>>
+            // ray test touch <<
             if (!balance.free.eq(governanceTokenBalance)) {
               dispatch(updateGovernanceTokenBalanceAction(balance.free));
             }
             if (!balance.transferable.eq(governanceTokenTransferableBalance)) {
               dispatch(updateGovernanceTokenTransferableBalanceAction(balance.transferable));
             }
+            // ray test touch >>
           }
         );
         // Unsubscribe if previous subscription is alive
@@ -387,12 +383,9 @@ const App = (): JSX.Element => {
     address,
     governanceTokenBalance,
     governanceTokenTransferableBalance,
-    // ray test touch <<
     queryClient,
     governanceTokenBalanceQueryKey
-    // ray test touch >>
   ]);
-  // ray test touch >>
 
   // Color schemes according to Interlay vs. Kintsugi
   React.useEffect(() => {

--- a/src/common/actions/general.actions.ts
+++ b/src/common/actions/general.actions.ts
@@ -21,16 +21,20 @@ import {
   UPDATE_BALANCE_POLKA_BTC,
   UPDATE_COLLATERAL_TOKEN_BALANCE,
   UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE,
+  // ray test touch <
   UPDATE_GOVERNANCE_TOKEN_BALANCE,
   UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
+  // ray test touch >
   UPDATE_HEIGHTS,
   UPDATE_TOTALS,
   UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE,
   UpdateBalancePolkaBTC,
   UpdateCollateralTokenBalance,
   UpdateCollateralTokenTransferableBalance,
+  // ray test touch <
   UpdateGovernanceTokenBalance,
   UpdateGovernanceTokenTransferableBalance,
+  // ray test touch >
   UpdateHeights,
   UpdateTotals,
   UpdateWrappedTokenTransferableBalance
@@ -83,19 +87,23 @@ export const updateCollateralTokenTransferableBalanceAction = (
   collateralTokenTransferableBalance
 });
 
+// ray test touch <
 export const updateGovernanceTokenBalanceAction = (
   governanceTokenBalance: GovernanceTokenMonetaryAmount
 ): UpdateGovernanceTokenBalance => ({
   type: UPDATE_GOVERNANCE_TOKEN_BALANCE,
   governanceTokenBalance
 });
+// ray test touch >
 
+// ray test touch <
 export const updateGovernanceTokenTransferableBalanceAction = (
   governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount
 ): UpdateGovernanceTokenTransferableBalance => ({
   type: UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
   governanceTokenTransferableBalance
 });
+// ray test touch >
 
 export const initGeneralDataAction = (
   totalWrappedTokenAmount: BitcoinAmount,

--- a/src/common/actions/general.actions.ts
+++ b/src/common/actions/general.actions.ts
@@ -21,20 +21,12 @@ import {
   UPDATE_BALANCE_POLKA_BTC,
   UPDATE_COLLATERAL_TOKEN_BALANCE,
   UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE,
-  // ray test touch <
-  UPDATE_GOVERNANCE_TOKEN_BALANCE,
-  UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
-  // ray test touch >
   UPDATE_HEIGHTS,
   UPDATE_TOTALS,
   UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE,
   UpdateBalancePolkaBTC,
   UpdateCollateralTokenBalance,
   UpdateCollateralTokenTransferableBalance,
-  // ray test touch <
-  UpdateGovernanceTokenBalance,
-  UpdateGovernanceTokenTransferableBalance,
-  // ray test touch >
   UpdateHeights,
   UpdateTotals,
   UpdateWrappedTokenTransferableBalance
@@ -86,24 +78,6 @@ export const updateCollateralTokenTransferableBalanceAction = (
   type: UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE,
   collateralTokenTransferableBalance
 });
-
-// ray test touch <
-export const updateGovernanceTokenBalanceAction = (
-  governanceTokenBalance: GovernanceTokenMonetaryAmount
-): UpdateGovernanceTokenBalance => ({
-  type: UPDATE_GOVERNANCE_TOKEN_BALANCE,
-  governanceTokenBalance
-});
-// ray test touch >
-
-// ray test touch <
-export const updateGovernanceTokenTransferableBalanceAction = (
-  governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount
-): UpdateGovernanceTokenTransferableBalance => ({
-  type: UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
-  governanceTokenTransferableBalance
-});
-// ray test touch >
 
 export const initGeneralDataAction = (
   totalWrappedTokenAmount: BitcoinAmount,

--- a/src/common/reducers/general.reducer.ts
+++ b/src/common/reducers/general.reducer.ts
@@ -14,8 +14,10 @@ import {
   UPDATE_BALANCE_POLKA_BTC,
   UPDATE_COLLATERAL_TOKEN_BALANCE,
   UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE,
+  // ray test touch <
   UPDATE_GOVERNANCE_TOKEN_BALANCE,
   UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
+  // ray test touch >
   UPDATE_HEIGHTS,
   UPDATE_TOTALS,
   UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE
@@ -34,8 +36,10 @@ const initialState = {
   wrappedTokenTransferableBalance: BitcoinAmount.zero,
   collateralTokenBalance: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
   collateralTokenTransferableBalance: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
+  // ray test touch <
   governanceTokenBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
   governanceTokenTransferableBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
+  // ray test touch >
   extensions: [],
   btcRelayHeight: 0,
   bitcoinHeight: 0,
@@ -77,10 +81,12 @@ export const generalReducer = (state: GeneralState = initialState, action: Gener
       return { ...state, collateralTokenBalance: action.collateralTokenBalance };
     case UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE:
       return { ...state, collateralTokenTransferableBalance: action.collateralTokenTransferableBalance };
+    // ray test touch <
     case UPDATE_GOVERNANCE_TOKEN_BALANCE:
       return { ...state, governanceTokenBalance: action.governanceTokenBalance };
     case UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE:
       return { ...state, governanceTokenTransferableBalance: action.governanceTokenTransferableBalance };
+    // ray test touch >
     case UPDATE_BALANCE_POLKA_BTC:
       return { ...state, wrappedTokenBalance: action.wrappedTokenBalance };
     case UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE:

--- a/src/common/reducers/general.reducer.ts
+++ b/src/common/reducers/general.reducer.ts
@@ -1,7 +1,7 @@
 import { newMonetaryAmount } from '@interlay/interbtc-api';
 import { BitcoinAmount } from '@interlay/monetary-js';
 
-import { GOVERNANCE_TOKEN, RELAY_CHAIN_NATIVE_TOKEN } from '@/config/relay-chains';
+import { RELAY_CHAIN_NATIVE_TOKEN } from '@/config/relay-chains';
 
 import {
   CHANGE_ADDRESS,
@@ -14,10 +14,6 @@ import {
   UPDATE_BALANCE_POLKA_BTC,
   UPDATE_COLLATERAL_TOKEN_BALANCE,
   UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE,
-  // ray test touch <
-  UPDATE_GOVERNANCE_TOKEN_BALANCE,
-  UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE,
-  // ray test touch >
   UPDATE_HEIGHTS,
   UPDATE_TOTALS,
   UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE
@@ -36,10 +32,6 @@ const initialState = {
   wrappedTokenTransferableBalance: BitcoinAmount.zero,
   collateralTokenBalance: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
   collateralTokenTransferableBalance: newMonetaryAmount(0, RELAY_CHAIN_NATIVE_TOKEN),
-  // ray test touch <
-  governanceTokenBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
-  governanceTokenTransferableBalance: newMonetaryAmount(0, GOVERNANCE_TOKEN),
-  // ray test touch >
   extensions: [],
   btcRelayHeight: 0,
   bitcoinHeight: 0,
@@ -81,12 +73,6 @@ export const generalReducer = (state: GeneralState = initialState, action: Gener
       return { ...state, collateralTokenBalance: action.collateralTokenBalance };
     case UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE:
       return { ...state, collateralTokenTransferableBalance: action.collateralTokenTransferableBalance };
-    // ray test touch <
-    case UPDATE_GOVERNANCE_TOKEN_BALANCE:
-      return { ...state, governanceTokenBalance: action.governanceTokenBalance };
-    case UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE:
-      return { ...state, governanceTokenTransferableBalance: action.governanceTokenTransferableBalance };
-    // ray test touch >
     case UPDATE_BALANCE_POLKA_BTC:
       return { ...state, wrappedTokenBalance: action.wrappedTokenBalance };
     case UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE:

--- a/src/common/types/actions.types.ts
+++ b/src/common/types/actions.types.ts
@@ -16,8 +16,10 @@ export const UPDATE_BALANCE_POLKA_BTC = 'UPDATE_BALANCE_POLKA_BTC';
 export const UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE = 'UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE';
 export const UPDATE_COLLATERAL_TOKEN_BALANCE = 'UPDATE_COLLATERAL_TOKEN_BALANCE';
 export const UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE = 'UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE';
+// ray test touch <
 export const UPDATE_GOVERNANCE_TOKEN_BALANCE = 'UPDATE_GOVERNANCE_TOKEN_BALANCE';
 export const UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE = 'UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE';
+// ray test touch >
 export const SET_INSTALLED_EXTENSION = 'SET_INSTALLED_EXTENSION';
 export const SHOW_ACCOUNT_MODAL = 'SHOW_ACCOUNT_MODAL';
 export const UPDATE_HEIGHTS = 'UPDATE_HEIGHTS';
@@ -90,6 +92,7 @@ export interface UpdateCollateralTokenTransferableBalance {
   collateralTokenTransferableBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
 }
 
+// ray test touch <
 export interface UpdateGovernanceTokenBalance {
   type: typeof UPDATE_GOVERNANCE_TOKEN_BALANCE;
   governanceTokenBalance: GovernanceTokenMonetaryAmount;
@@ -99,6 +102,7 @@ export interface UpdateGovernanceTokenTransferableBalance {
   type: typeof UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE;
   governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount;
 }
+// ray test touch >
 
 export interface SetInstalledExtension {
   type: typeof SET_INSTALLED_EXTENSION;

--- a/src/common/types/actions.types.ts
+++ b/src/common/types/actions.types.ts
@@ -16,10 +16,6 @@ export const UPDATE_BALANCE_POLKA_BTC = 'UPDATE_BALANCE_POLKA_BTC';
 export const UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE = 'UPDATE_WRAPPED_TOKEN_TRANSFERABLE_BALANCE';
 export const UPDATE_COLLATERAL_TOKEN_BALANCE = 'UPDATE_COLLATERAL_TOKEN_BALANCE';
 export const UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE = 'UPDATE_COLLATERAL_TOKEN_TRANSFERABLE_BALANCE';
-// ray test touch <
-export const UPDATE_GOVERNANCE_TOKEN_BALANCE = 'UPDATE_GOVERNANCE_TOKEN_BALANCE';
-export const UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE = 'UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE';
-// ray test touch >
 export const SET_INSTALLED_EXTENSION = 'SET_INSTALLED_EXTENSION';
 export const SHOW_ACCOUNT_MODAL = 'SHOW_ACCOUNT_MODAL';
 export const UPDATE_HEIGHTS = 'UPDATE_HEIGHTS';
@@ -92,18 +88,6 @@ export interface UpdateCollateralTokenTransferableBalance {
   collateralTokenTransferableBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
 }
 
-// ray test touch <
-export interface UpdateGovernanceTokenBalance {
-  type: typeof UPDATE_GOVERNANCE_TOKEN_BALANCE;
-  governanceTokenBalance: GovernanceTokenMonetaryAmount;
-}
-
-export interface UpdateGovernanceTokenTransferableBalance {
-  type: typeof UPDATE_GOVERNANCE_TOKEN_TRANSFERABLE_BALANCE;
-  governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount;
-}
-// ray test touch >
-
 export interface SetInstalledExtension {
   type: typeof SET_INSTALLED_EXTENSION;
   extensions: string[];
@@ -123,8 +107,6 @@ export type GeneralActions =
   | UpdateWrappedTokenTransferableBalance
   | UpdateCollateralTokenBalance
   | UpdateCollateralTokenTransferableBalance
-  | UpdateGovernanceTokenBalance
-  | UpdateGovernanceTokenTransferableBalance
   | SetInstalledExtension
   | ShowAccountModal
   | UpdateHeights

--- a/src/common/types/util.types.ts
+++ b/src/common/types/util.types.ts
@@ -3,8 +3,6 @@ import { BitcoinAmount, Currency, MonetaryAmount } from '@interlay/monetary-js';
 import { u256 } from '@polkadot/types/primitive';
 import { CombinedState, Store } from 'redux';
 
-import { GovernanceTokenMonetaryAmount } from '@/config/relay-chains';
-
 import { rootReducer } from '../reducers/index';
 import { GeneralActions, RedeemActions, VaultActions } from './actions.types';
 import { RedeemState } from './redeem.types';
@@ -72,10 +70,6 @@ export type GeneralState = {
   wrappedTokenTransferableBalance: BitcoinAmount;
   collateralTokenBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
   collateralTokenTransferableBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
-  // ray test touch <
-  governanceTokenBalance: GovernanceTokenMonetaryAmount;
-  governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount;
-  // ray test touch >
   extensions: string[];
   btcRelayHeight: number;
   bitcoinHeight: number;

--- a/src/common/types/util.types.ts
+++ b/src/common/types/util.types.ts
@@ -72,8 +72,10 @@ export type GeneralState = {
   wrappedTokenTransferableBalance: BitcoinAmount;
   collateralTokenBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
   collateralTokenTransferableBalance: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
+  // ray test touch <
   governanceTokenBalance: GovernanceTokenMonetaryAmount;
   governanceTokenTransferableBalance: GovernanceTokenMonetaryAmount;
+  // ray test touch >
   extensions: string[];
   btcRelayHeight: number;
   bitcoinHeight: number;

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useErrorHandler, withErrorBoundary } from 'react-error-boundary';
+import { withErrorBoundary } from 'react-error-boundary';
 import { useSelector } from 'react-redux';
 
 import { StoreType, TokenType } from '@/common/types/util.types';
@@ -67,8 +67,9 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     wrappedTokenTransferableBalance
   } = useSelector((state: StoreType) => state.general);
 
-  const { data: governanceTokenBalance, error: governanceTokenBalanceError } = useGovernanceTokenBalance();
-  useErrorHandler(governanceTokenBalanceError);
+  // ray test touch <
+  const { governanceTokenBalance } = useGovernanceTokenBalance();
+  // ray test touch >
 
   const handleUpdateToken = (tokenType: TokenType) => {
     const token = getTokenOption(tokenType);

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -18,6 +18,7 @@ import {
   WrappedToken,
   WrappedTokenLogoIcon
 } from '@/config/relay-chains';
+import { useGovernanceTokenBalance } from '@/services/hooks/use-token-balance';
 
 import TokenSelector from './TokenSelector';
 
@@ -61,12 +62,26 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     collateralTokenBalance,
     collateralTokenTransferableBalance,
     wrappedTokenBalance,
-    wrappedTokenTransferableBalance,
-    // ray test touch <
-    governanceTokenBalance,
-    governanceTokenTransferableBalance
-    // ray test touch >
+    wrappedTokenTransferableBalance
+    // ray test touch <<
+    // governanceTokenBalance,
+    // governanceTokenTransferableBalance
+    // ray test touch >>
   } = useSelector((state: StoreType) => state.general);
+
+  // ray test touch <<
+  const {
+    // isIdle: governanceTokenBalanceIdle,
+    // isLoading: governanceTokenBalanceLoading,
+    data: governanceTokenBalance
+    // error: governanceTokenBalanceError
+  } = useGovernanceTokenBalance();
+  console.log('ray : ***** governanceTokenBalanceA?.free.toHuman()', governanceTokenBalance?.free.toHuman());
+  console.log(
+    'ray : ***** governanceTokenBalanceA?.transferable.toHuman()',
+    governanceTokenBalance?.transferable.toHuman()
+  );
+  // ray test touch >>
 
   const handleUpdateToken = (tokenType: TokenType) => {
     const token = getTokenOption(tokenType);
@@ -98,8 +113,10 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
       {
         token: GOVERNANCE_TOKEN,
         type: TokenType.GOVERNANCE,
-        balance: displayMonetaryAmount(governanceTokenBalance),
-        transferableBalance: displayMonetaryAmount(governanceTokenTransferableBalance),
+        // ray test touch <<
+        balance: governanceTokenBalance ? displayMonetaryAmount(governanceTokenBalance.free) : '-',
+        transferableBalance: governanceTokenBalance ? displayMonetaryAmount(governanceTokenBalance.transferable) : '-',
+        // ray test touch >>
         icon: <GovernanceTokenLogoIcon height={variant === SELECT_VARIANTS.formField ? 46 : 26} />,
         symbol: GOVERNANCE_TOKEN_SYMBOL
       }
@@ -111,8 +128,10 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     collateralTokenTransferableBalance,
     wrappedTokenBalance,
     wrappedTokenTransferableBalance,
+    // ray test touch <<
     governanceTokenBalance,
-    governanceTokenTransferableBalance,
+    // governanceTokenTransferableBalance,
+    // ray test touch >>
     variant
   ]);
 

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
-// ray test touch <<
 import { useErrorHandler, withErrorBoundary } from 'react-error-boundary';
-// ray test touch >>
 import { useSelector } from 'react-redux';
 
 import { StoreType, TokenType } from '@/common/types/util.types';
 import { displayMonetaryAmount } from '@/common/utils/utils';
-// ray test touch <<
 import ErrorFallback from '@/components/ErrorFallback';
-// ray test touch >>
 import { SELECT_VARIANTS, SelectVariants } from '@/components/Select';
 import {
   CollateralToken,
@@ -72,9 +68,7 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
   } = useSelector((state: StoreType) => state.general);
 
   const { data: governanceTokenBalance, error: governanceTokenBalanceError } = useGovernanceTokenBalance();
-  // ray test touch <<
   useErrorHandler(governanceTokenBalanceError);
-  // ray test touch >>
 
   const handleUpdateToken = (tokenType: TokenType) => {
     const token = getTokenOption(tokenType);
@@ -148,11 +142,9 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
 };
 
 export type { TokenOption };
-// ray test touch <<
 export default withErrorBoundary(Tokens, {
   FallbackComponent: ErrorFallback,
   onReset: () => {
     window.location.reload();
   }
 });
-// ray test touch >>

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
+// ray test touch <<
+import { useErrorHandler, withErrorBoundary } from 'react-error-boundary';
+// ray test touch >>
 import { useSelector } from 'react-redux';
 
 import { StoreType, TokenType } from '@/common/types/util.types';
 import { displayMonetaryAmount } from '@/common/utils/utils';
+// ray test touch <<
+import ErrorFallback from '@/components/ErrorFallback';
+// ray test touch >>
 import { SELECT_VARIANTS, SelectVariants } from '@/components/Select';
 import {
   CollateralToken,
@@ -65,7 +71,10 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     wrappedTokenTransferableBalance
   } = useSelector((state: StoreType) => state.general);
 
-  const { data: governanceTokenBalance } = useGovernanceTokenBalance();
+  const { data: governanceTokenBalance, error: governanceTokenBalanceError } = useGovernanceTokenBalance();
+  // ray test touch <<
+  useErrorHandler(governanceTokenBalanceError);
+  // ray test touch >>
 
   const handleUpdateToken = (tokenType: TokenType) => {
     const token = getTokenOption(tokenType);
@@ -139,4 +148,11 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
 };
 
 export type { TokenOption };
-export default Tokens;
+// ray test touch <<
+export default withErrorBoundary(Tokens, {
+  FallbackComponent: ErrorFallback,
+  onReset: () => {
+    window.location.reload();
+  }
+});
+// ray test touch >>

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -67,9 +67,7 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     wrappedTokenTransferableBalance
   } = useSelector((state: StoreType) => state.general);
 
-  // ray test touch <
   const { governanceTokenBalance } = useGovernanceTokenBalance();
-  // ray test touch >
 
   const handleUpdateToken = (tokenType: TokenType) => {
     const token = getTokenOption(tokenType);

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -62,8 +62,10 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     collateralTokenTransferableBalance,
     wrappedTokenBalance,
     wrappedTokenTransferableBalance,
+    // ray test touch <
     governanceTokenBalance,
     governanceTokenTransferableBalance
+    // ray test touch >
   } = useSelector((state: StoreType) => state.general);
 
   const handleUpdateToken = (tokenType: TokenType) => {

--- a/src/components/Tokens/index.tsx
+++ b/src/components/Tokens/index.tsx
@@ -63,25 +63,9 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     collateralTokenTransferableBalance,
     wrappedTokenBalance,
     wrappedTokenTransferableBalance
-    // ray test touch <<
-    // governanceTokenBalance,
-    // governanceTokenTransferableBalance
-    // ray test touch >>
   } = useSelector((state: StoreType) => state.general);
 
-  // ray test touch <<
-  const {
-    // isIdle: governanceTokenBalanceIdle,
-    // isLoading: governanceTokenBalanceLoading,
-    data: governanceTokenBalance
-    // error: governanceTokenBalanceError
-  } = useGovernanceTokenBalance();
-  console.log('ray : ***** governanceTokenBalanceA?.free.toHuman()', governanceTokenBalance?.free.toHuman());
-  console.log(
-    'ray : ***** governanceTokenBalanceA?.transferable.toHuman()',
-    governanceTokenBalance?.transferable.toHuman()
-  );
-  // ray test touch >>
+  const { data: governanceTokenBalance } = useGovernanceTokenBalance();
 
   const handleUpdateToken = (tokenType: TokenType) => {
     const token = getTokenOption(tokenType);
@@ -113,10 +97,8 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
       {
         token: GOVERNANCE_TOKEN,
         type: TokenType.GOVERNANCE,
-        // ray test touch <<
         balance: governanceTokenBalance ? displayMonetaryAmount(governanceTokenBalance.free) : '-',
         transferableBalance: governanceTokenBalance ? displayMonetaryAmount(governanceTokenBalance.transferable) : '-',
-        // ray test touch >>
         icon: <GovernanceTokenLogoIcon height={variant === SELECT_VARIANTS.formField ? 46 : 26} />,
         symbol: GOVERNANCE_TOKEN_SYMBOL
       }
@@ -128,10 +110,7 @@ const Tokens = ({ variant = 'optionSelector', callbackFunction, showBalances = t
     collateralTokenTransferableBalance,
     wrappedTokenBalance,
     wrappedTokenTransferableBalance,
-    // ray test touch <<
     governanceTokenBalance,
-    // governanceTokenTransferableBalance,
-    // ray test touch >>
     variant
   ]);
 

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -89,12 +89,10 @@ const IssueForm = (): JSX.Element | null => {
 
   // ray test touch <
   const {
-    isIdle: governanceTokenBalanceIdle,
-    isLoading: governanceTokenBalanceLoading,
-    data: governanceTokenBalance,
-    error: governanceTokenBalanceError
+    governanceTokenBalanceIdle,
+    governanceTokenBalanceLoading,
+    governanceTokenBalance
   } = useGovernanceTokenBalance();
-  useErrorHandler(governanceTokenBalanceError);
   // ray test touch >
 
   const {

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -87,13 +87,11 @@ const IssueForm = (): JSX.Element | null => {
     (state: StoreType) => state.general
   );
 
-  // ray test touch <
   const {
     governanceTokenBalanceIdle,
     governanceTokenBalanceLoading,
     governanceTokenBalance
   } = useGovernanceTokenBalance();
-  // ray test touch >
 
   const {
     register,

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -43,9 +43,7 @@ import {
 } from '@/config/relay-chains';
 import ParachainStatusInfo from '@/pages/Bridge/ParachainStatusInfo';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
-// ray test touch <<
 import { useGovernanceTokenBalance } from '@/services/hooks/use-token-balance';
-// ray test touch >>
 import { ForeignAssetIdLiteral } from '@/types/currency';
 import { COLLATERAL_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { KUSAMA, POLKADOT } from '@/utils/constants/relay-chain-names';
@@ -85,18 +83,10 @@ const IssueForm = (): JSX.Element | null => {
 
   const handleError = useErrorHandler();
 
-  const {
-    bridgeLoaded,
-    address,
-    bitcoinHeight,
-    btcRelayHeight,
-    parachainStatus
-    // ray test touch <
-    // governanceTokenBalance
-    // ray test touch >
-  } = useSelector((state: StoreType) => state.general);
+  const { bridgeLoaded, address, bitcoinHeight, btcRelayHeight, parachainStatus } = useSelector(
+    (state: StoreType) => state.general
+  );
 
-  // ray test touch <<
   const {
     isIdle: governanceTokenBalanceIdle,
     isLoading: governanceTokenBalanceLoading,
@@ -104,7 +94,6 @@ const IssueForm = (): JSX.Element | null => {
     error: governanceTokenBalanceError
   } = useGovernanceTokenBalance();
   useErrorHandler(governanceTokenBalanceError);
-  // ray test touch >>
 
   const {
     register,
@@ -203,7 +192,6 @@ const IssueForm = (): JSX.Element | null => {
     }
   }, [selectVaultManually, vault, setError, clearErrors, t, btcAmount, feeRate]);
 
-  // ray test touch <<
   if (
     status === STATUSES.IDLE ||
     status === STATUSES.PENDING ||
@@ -214,15 +202,12 @@ const IssueForm = (): JSX.Element | null => {
   ) {
     return <PrimaryColorEllipsisLoader />;
   }
-  // ray test touch >>
   if (requestLimits === undefined) {
     throw new Error('Something went wrong!');
   }
-  // ray test touch <<
   if (governanceTokenBalance === undefined) {
     throw new Error('Something went wrong!');
   }
-  // ray test touch >>
 
   if (status === STATUSES.RESOLVED) {
     const validateForm = (value: string): string | undefined => {
@@ -231,9 +216,7 @@ const IssueForm = (): JSX.Element | null => {
 
       const securityDeposit = btcToGovernanceTokenRate.toCounter(btcAmount).mul(depositRate);
       const minRequiredGovernanceTokenAmount = extraRequiredCollateralTokenAmount.add(securityDeposit);
-      // ray test touch <<
       if (governanceTokenBalance.free.lte(minRequiredGovernanceTokenAmount)) {
-        // ray test touch >>
         return t('insufficient_funds_governance_token', {
           governanceTokenSymbol: GOVERNANCE_TOKEN_SYMBOL
         });

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -200,10 +200,7 @@ const IssueForm = (): JSX.Element | null => {
   ) {
     return <PrimaryColorEllipsisLoader />;
   }
-  if (requestLimits === undefined) {
-    throw new Error('Something went wrong!');
-  }
-  if (governanceTokenBalance === undefined) {
+  if (requestLimits === undefined || governanceTokenBalance === undefined) {
     throw new Error('Something went wrong!');
   }
 

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -82,9 +82,16 @@ const IssueForm = (): JSX.Element | null => {
 
   const handleError = useErrorHandler();
 
-  const { bridgeLoaded, address, bitcoinHeight, btcRelayHeight, parachainStatus, governanceTokenBalance } = useSelector(
-    (state: StoreType) => state.general
-  );
+  const {
+    bridgeLoaded,
+    address,
+    bitcoinHeight,
+    btcRelayHeight,
+    parachainStatus,
+    // ray test touch <
+    governanceTokenBalance
+    // ray test touch >
+  } = useSelector((state: StoreType) => state.general);
 
   const {
     register,

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -87,6 +87,7 @@ const IssueForm = (): JSX.Element | null => {
     (state: StoreType) => state.general
   );
 
+  // ray test touch <
   const {
     isIdle: governanceTokenBalanceIdle,
     isLoading: governanceTokenBalanceLoading,
@@ -94,6 +95,7 @@ const IssueForm = (): JSX.Element | null => {
     error: governanceTokenBalanceError
   } = useGovernanceTokenBalance();
   useErrorHandler(governanceTokenBalanceError);
+  // ray test touch >
 
   const {
     register,

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -109,6 +109,7 @@ const Staking = (): JSX.Element => {
 
   const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
 
+  // ray test touch <
   const {
     isIdle: governanceTokenBalanceIdle,
     isLoading: governanceTokenBalanceLoading,
@@ -116,6 +117,7 @@ const Staking = (): JSX.Element => {
     error: governanceTokenBalanceError
   } = useGovernanceTokenBalance();
   useErrorHandler(governanceTokenBalanceError);
+  // ray test touch >
 
   const {
     register,

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -38,9 +38,7 @@ import {
   STAKING_TRANSACTION_FEE_RESERVE_FETCHER,
   stakingTransactionFeeReserveFetcher
 } from '@/services/fetchers/staking-transaction-fee-reserve-fetcher';
-// ray test touch <<
 import { useGovernanceTokenBalance } from '@/services/hooks/use-token-balance';
-// ray test touch >>
 import { ZERO_GOVERNANCE_TOKEN_AMOUNT, ZERO_VOTE_GOVERNANCE_TOKEN_AMOUNT } from '@/utils/constants/currency';
 import { YEAR_MONTH_DAY_PATTERN } from '@/utils/constants/date-time';
 import { KUSAMA } from '@/utils/constants/relay-chain-names';
@@ -109,7 +107,6 @@ const Staking = (): JSX.Element => {
   const { t } = useTranslation();
   const prices = useGetPrices();
 
-  // ray test touch <
   const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
 
   const {
@@ -119,7 +116,6 @@ const Staking = (): JSX.Element => {
     error: governanceTokenBalanceError
   } = useGovernanceTokenBalance();
   useErrorHandler(governanceTokenBalanceError);
-  // ray test touch >
 
   const {
     register,
@@ -357,11 +353,8 @@ const Staking = (): JSX.Element => {
 
   const availableBalance = React.useMemo(() => {
     if (
-      // ray test touch <<
       governanceTokenBalanceIdle ||
       governanceTokenBalanceLoading ||
-      // !governanceTokenBalance ||
-      // ray test touch >>
       stakedAmountAndEndBlockIdle ||
       stakedAmountAndEndBlockLoading ||
       transactionFeeReserveIdle ||
@@ -374,13 +367,11 @@ const Staking = (): JSX.Element => {
     if (transactionFeeReserve === undefined) {
       throw new Error('Transaction fee reserve value returned undefined!');
     }
-    // ray test touch <<
     if (governanceTokenBalance === undefined) {
       throw new Error('Governance token balance value returned undefined!');
     }
 
     return governanceTokenBalance.free.sub(stakedAmount).sub(transactionFeeReserve);
-    // ray test touch >>
   }, [
     governanceTokenBalanceIdle,
     governanceTokenBalanceLoading,

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -106,7 +106,9 @@ const Staking = (): JSX.Element => {
   const { t } = useTranslation();
   const prices = useGetPrices();
 
+  // ray test touch <
   const { governanceTokenBalance, bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
+  // ray test touch >
 
   const {
     register,

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -109,13 +109,11 @@ const Staking = (): JSX.Element => {
 
   const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
 
-  // ray test touch <
   const {
     governanceTokenBalanceIdle,
     governanceTokenBalanceLoading,
     governanceTokenBalance
   } = useGovernanceTokenBalance();
-  // ray test touch >
 
   const {
     register,

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -111,12 +111,10 @@ const Staking = (): JSX.Element => {
 
   // ray test touch <
   const {
-    isIdle: governanceTokenBalanceIdle,
-    isLoading: governanceTokenBalanceLoading,
-    data: governanceTokenBalance,
-    error: governanceTokenBalanceError
+    governanceTokenBalanceIdle,
+    governanceTokenBalanceLoading,
+    governanceTokenBalance
   } = useGovernanceTokenBalance();
-  useErrorHandler(governanceTokenBalanceError);
   // ray test touch >
 
   const {

--- a/src/pages/Vaults/Vault/ClaimRewardsButton/index.tsx
+++ b/src/pages/Vaults/Vault/ClaimRewardsButton/index.tsx
@@ -18,8 +18,10 @@ import { CurrencyValues } from '@/types/currency';
 import { ZERO_GOVERNANCE_TOKEN_AMOUNT } from '@/utils/constants/currency';
 
 interface CustomProps {
-  vaultAccountId: AccountId | undefined; // TODO: should remove `undefined` later on when the loading is properly handled
-  collateralToken: CurrencyValues | undefined;
+  // ray test touch <<
+  vaultAccountId: AccountId;
+  // ray test touch >>
+  collateralToken: CurrencyValues;
 }
 
 const ClaimRewardsButton = ({
@@ -37,7 +39,7 @@ const ClaimRewardsButton = ({
     error: governanceTokenRewardError,
     refetch: governanceTokenRewardRefetch
   } = useQuery<GovernanceTokenMonetaryAmount, Error>(
-    [GENERIC_FETCHER, 'vaults', 'getGovernanceReward', vaultAccountId, collateralToken?.id, GOVERNANCE_TOKEN_SYMBOL],
+    [GENERIC_FETCHER, 'vaults', 'getGovernanceReward', vaultAccountId, collateralToken.id, GOVERNANCE_TOKEN_SYMBOL],
     genericFetcher<GovernanceTokenMonetaryAmount>(),
     {
       enabled: !!bridgeLoaded && !!vaultAccountId
@@ -54,7 +56,7 @@ const ClaimRewardsButton = ({
       const vaultId = newVaultId(
         window.bridge.api,
         vaultAccountId.toString(),
-        collateralToken?.currency as CollateralCurrency,
+        collateralToken.currency as CollateralCurrency,
         WRAPPED_TOKEN as WrappedCurrency
       );
 

--- a/src/pages/Vaults/Vault/ClaimRewardsButton/index.tsx
+++ b/src/pages/Vaults/Vault/ClaimRewardsButton/index.tsx
@@ -18,9 +18,7 @@ import { CurrencyValues } from '@/types/currency';
 import { ZERO_GOVERNANCE_TOKEN_AMOUNT } from '@/utils/constants/currency';
 
 interface CustomProps {
-  // ray test touch <<
   vaultAccountId: AccountId;
-  // ray test touch >>
   collateralToken: CurrencyValues;
 }
 

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -30,9 +30,7 @@ import {
   WrappedTokenLogoIcon
 } from '@/config/relay-chains';
 import SubmittedIssueRequestModal from '@/pages/Bridge/IssueForm/SubmittedIssueRequestModal';
-// ray test touch <<
 import { useGovernanceTokenBalance } from '@/services/hooks/use-token-balance';
-// ray test touch >>
 import { ForeignAssetIdLiteral } from '@/types/currency';
 import { KUSAMA, POLKADOT } from '@/utils/constants/relay-chain-names';
 import STATUSES from '@/utils/constants/statuses';
@@ -105,18 +103,10 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
 
   const handleError = useErrorHandler();
 
-  const {
-    bridgeLoaded,
-    address,
-    bitcoinHeight,
-    btcRelayHeight,
-    // ray test touch <<
-    // governanceTokenBalance,
-    // ray test touch >>
-    parachainStatus
-  } = useSelector((state: StoreType) => state.general);
+  const { bridgeLoaded, address, bitcoinHeight, btcRelayHeight, parachainStatus } = useSelector(
+    (state: StoreType) => state.general
+  );
 
-  // ray test touch <<
   const {
     isIdle: governanceTokenBalanceIdle,
     isLoading: governanceTokenBalanceLoading,
@@ -124,7 +114,6 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     error: governanceTokenBalanceError
   } = useGovernanceTokenBalance();
   useErrorHandler(governanceTokenBalanceError);
-  // ray test touch >>
 
   const vaultAccountId = useAccountId(vaultAddress);
 
@@ -176,7 +165,6 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     })();
   }, [collateralIdLiteral, bridgeLoaded, handleError, vaultAccountId]);
 
-  // ray test touch <<
   if (
     status === STATUSES.IDLE ||
     status === STATUSES.PENDING ||
@@ -189,7 +177,6 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
   if (governanceTokenBalance === undefined) {
     throw new Error('Something went wrong!');
   }
-  // ray test touch >>
 
   const onSubmit = async (data: RequestIssueFormData) => {
     try {
@@ -223,9 +210,7 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
 
     const securityDeposit = btcToGovernanceTokenRate.toCounter(btcAmount).mul(depositRate);
     const minRequiredGovernanceTokenAmount = extraRequiredCollateralTokenAmount.add(securityDeposit);
-    // ray test touch <<
     if (governanceTokenBalance.free.lte(minRequiredGovernanceTokenAmount)) {
-      // ray test touch >>
       return t('insufficient_funds_governance_token', {
         governanceTokenSymbol: GOVERNANCE_TOKEN_SYMBOL
       });

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -107,13 +107,11 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     (state: StoreType) => state.general
   );
 
-  // ray test touch <
   const {
     governanceTokenBalanceIdle,
     governanceTokenBalanceLoading,
     governanceTokenBalance
   } = useGovernanceTokenBalance();
-  // ray test touch >
 
   const vaultAccountId = useAccountId(vaultAddress);
 

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -101,9 +101,16 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
 
   const handleError = useErrorHandler();
 
-  const { bridgeLoaded, address, bitcoinHeight, btcRelayHeight, governanceTokenBalance, parachainStatus } = useSelector(
-    (state: StoreType) => state.general
-  );
+  const {
+    bridgeLoaded,
+    address,
+    bitcoinHeight,
+    btcRelayHeight,
+    // ray test touch <
+    governanceTokenBalance,
+    // ray test touch >
+    parachainStatus
+  } = useSelector((state: StoreType) => state.general);
 
   const vaultAccountId = React.useMemo(() => {
     if (!bridgeLoaded) return;

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -109,12 +109,10 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
 
   // ray test touch <
   const {
-    isIdle: governanceTokenBalanceIdle,
-    isLoading: governanceTokenBalanceLoading,
-    data: governanceTokenBalance,
-    error: governanceTokenBalanceError
+    governanceTokenBalanceIdle,
+    governanceTokenBalanceLoading,
+    governanceTokenBalance
   } = useGovernanceTokenBalance();
-  useErrorHandler(governanceTokenBalanceError);
   // ray test touch >
 
   const vaultAccountId = useAccountId(vaultAddress);

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -107,6 +107,7 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     (state: StoreType) => state.general
   );
 
+  // ray test touch <
   const {
     isIdle: governanceTokenBalanceIdle,
     isLoading: governanceTokenBalanceLoading,
@@ -114,6 +115,7 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     error: governanceTokenBalanceError
   } = useGovernanceTokenBalance();
   useErrorHandler(governanceTokenBalanceError);
+  // ray test touch >
 
   const vaultAccountId = useAccountId(vaultAddress);
 

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -1,4 +1,4 @@
-import { CurrencyIdLiteral, GovernanceUnit, Issue, newAccountId, newMonetaryAmount } from '@interlay/interbtc-api';
+import { CurrencyIdLiteral, GovernanceUnit, Issue, newMonetaryAmount } from '@interlay/interbtc-api';
 import { Bitcoin, BitcoinAmount, BitcoinUnit, Currency, ExchangeRate } from '@interlay/monetary-js';
 import Big from 'big.js';
 import clsx from 'clsx';
@@ -35,6 +35,7 @@ import { KUSAMA, POLKADOT } from '@/utils/constants/relay-chain-names';
 import STATUSES from '@/utils/constants/statuses';
 import { getTokenPrice } from '@/utils/helpers/prices';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
+import useAccountId from '@/utils/hooks/use-account-id';
 
 const WRAPPED_TOKEN_AMOUNT = 'amount';
 const BTC_ADDRESS = 'btc-address';
@@ -112,10 +113,13 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     parachainStatus
   } = useSelector((state: StoreType) => state.general);
 
-  const vaultAccountId = React.useMemo(() => {
-    if (!bridgeLoaded) return;
-    return newAccountId(window.bridge.api, vaultAddress);
-  }, [bridgeLoaded, vaultAddress]);
+  // ray test touch <<
+  const vaultAccountId = useAccountId(vaultAddress);
+  // const vaultAccountId = React.useMemo(() => {
+  //   if (!bridgeLoaded) return;
+  //   return newAccountId(window.bridge.api, vaultAddress);
+  // }, [bridgeLoaded, vaultAddress]);
+  // ray test touch >>
 
   React.useEffect(() => {
     if (!bridgeLoaded) return;

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -113,13 +113,7 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     parachainStatus
   } = useSelector((state: StoreType) => state.general);
 
-  // ray test touch <<
   const vaultAccountId = useAccountId(vaultAddress);
-  // const vaultAccountId = React.useMemo(() => {
-  //   if (!bridgeLoaded) return;
-  //   return newAccountId(window.bridge.api, vaultAddress);
-  // }, [bridgeLoaded, vaultAddress]);
-  // ray test touch >>
 
   React.useEffect(() => {
     if (!bridgeLoaded) return;

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -50,7 +50,6 @@ interface Props {
   onClose: () => void;
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
-  vaultAccountId: AccountId;
   hasLockedBTC: boolean;
   collateralCurrency: CurrencyValues;
 }
@@ -60,7 +59,6 @@ const UpdateCollateralModal = ({
   onClose,
   collateralUpdateStatus,
   vaultAddress,
-  vaultAccountId,
   hasLockedBTC,
   collateralCurrency
 }: Props): JSX.Element => {
@@ -106,7 +104,7 @@ const UpdateCollateralModal = ({
     isLoading: collateralBalanceLoading,
     data: collateralBalance,
     error: collateralBalanceError
-  } = useTokenBalance(collateralCurrency.currency, vaultAccountId);
+  } = useTokenBalance(collateralCurrency.currency, vaultAddress);
   useErrorHandler(collateralBalanceError);
 
   const collateralTokenAmount = newMonetaryAmount(

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -28,6 +28,7 @@ import InterlayModal, { InterlayModalInnerWrapper, InterlayModalTitle } from '@/
 import { ACCOUNT_ID_TYPE_NAME } from '@/config/general';
 import { RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
+import useTokenBalance from '@/services/hooks/use-token-balance';
 import { CurrencyValues } from '@/types/currency';
 import STATUSES from '@/utils/constants/statuses';
 import { getTokenPrice } from '@/utils/helpers/prices';
@@ -101,24 +102,25 @@ const UpdateCollateralModal = ({
   useErrorHandler(requiredCollateralTokenAmountError);
 
   // ray test touch <
+  // const {
+  //   isIdle: collateralBalanceIdle,
+  //   isLoading: collateralBalanceLoading,
+  //   data: collateralBalance,
+  //   error: collateralBalanceError
+  // } = useQuery<ChainBalance<CollateralUnit>, Error>(
+  //   [GENERIC_FETCHER, 'tokens', 'balance', collateralCurrency.currency, vaultAccountId],
+  //   genericFetcher<ChainBalance<CollateralUnit>>(),
+  //   {
+  //     enabled: !!bridgeLoaded && !!vaultAccountId
+  //   }
+  // );
   const {
     isIdle: collateralBalanceIdle,
     isLoading: collateralBalanceLoading,
     data: collateralBalance,
     error: collateralBalanceError
-  } = useQuery<ChainBalance<CollateralUnit>, Error>(
-    [GENERIC_FETCHER, 'tokens', 'balance', collateralCurrency.currency, vaultAccountId],
-    genericFetcher<ChainBalance<CollateralUnit>>(),
-    {
-      enabled: !!bridgeLoaded && !!vaultAccountId
-    }
-  );
+  } = useTokenBalance(collateralCurrency.currency, vaultAccountId);
   useErrorHandler(collateralBalanceError);
-  // ray test touch >
-
-  // ray test touch <
-  // const { data: test } = useTokenBalance(collateralCurrency.currency, vaultAccountId);
-  // console.log('ray : ***** test?.transferable.toHuman() => ', test?.transferable.toHuman());
   // ray test touch >
 
   const collateralTokenAmount = newMonetaryAmount(

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -101,19 +101,6 @@ const UpdateCollateralModal = ({
   );
   useErrorHandler(requiredCollateralTokenAmountError);
 
-  // ray test touch <
-  // const {
-  //   isIdle: collateralBalanceIdle,
-  //   isLoading: collateralBalanceLoading,
-  //   data: collateralBalance,
-  //   error: collateralBalanceError
-  // } = useQuery<ChainBalance<CollateralUnit>, Error>(
-  //   [GENERIC_FETCHER, 'tokens', 'balance', collateralCurrency.currency, vaultAccountId],
-  //   genericFetcher<ChainBalance<CollateralUnit>>(),
-  //   {
-  //     enabled: !!bridgeLoaded && !!vaultAccountId
-  //   }
-  // );
   const {
     isIdle: collateralBalanceIdle,
     isLoading: collateralBalanceLoading,
@@ -121,7 +108,6 @@ const UpdateCollateralModal = ({
     error: collateralBalanceError
   } = useTokenBalance(collateralCurrency.currency, vaultAccountId);
   useErrorHandler(collateralBalanceError);
-  // ray test touch >
 
   const collateralTokenAmount = newMonetaryAmount(
     strCollateralTokenAmount,

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -1,4 +1,4 @@
-import { CollateralUnit, CurrencyUnit, newMonetaryAmount, roundTwoDecimals } from '@interlay/interbtc-api';
+import { CollateralUnit, newMonetaryAmount, roundTwoDecimals } from '@interlay/interbtc-api';
 import { Currency, MonetaryAmount } from '@interlay/monetary-js';
 import Big from 'big.js';
 import clsx from 'clsx';
@@ -21,7 +21,9 @@ import InterlayModal, { InterlayModalInnerWrapper, InterlayModalTitle } from '@/
 import { ACCOUNT_ID_TYPE_NAME } from '@/config/general';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useTokenBalance from '@/services/hooks/use-token-balance';
-import { CurrencyValues } from '@/types/currency';
+// ray test touch <<
+import { GenericCurrencyValues } from '@/types/currency';
+// ray test touch >>
 import STATUSES from '@/utils/constants/statuses';
 import { getTokenPrice } from '@/utils/helpers/prices';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
@@ -43,7 +45,9 @@ interface Props {
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
   hasLockedBTC: boolean;
-  collateralCurrency: CurrencyValues;
+  // ray test touch <<
+  collateralCurrency: GenericCurrencyValues<CollateralUnit>;
+  // ray test touch >>
 }
 
 const UpdateCollateralModal = ({
@@ -96,7 +100,9 @@ const UpdateCollateralModal = ({
     isLoading: collateralBalanceLoading,
     data: collateralBalance,
     error: collateralBalanceError
-  } = useTokenBalance(collateralCurrency.currency, vaultAddress);
+    // ray test touch <<
+  } = useTokenBalance<CollateralUnit>(collateralCurrency.currency, vaultAddress);
+  // ray test touch >>
   useErrorHandler(collateralBalanceError);
 
   const collateralTokenAmount = newMonetaryAmount(
@@ -181,9 +187,7 @@ const UpdateCollateralModal = ({
 
     // Collateral update only allowed if above required collateral
     if (collateralUpdateStatus === CollateralUpdateStatus.Withdraw && requiredCollateralTokenAmount) {
-      const maxWithdrawableCollateralTokenAmount = currentTotalCollateralTokenAmount.sub(
-        requiredCollateralTokenAmount
-      ) as MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>;
+      const maxWithdrawableCollateralTokenAmount = currentTotalCollateralTokenAmount.sub(requiredCollateralTokenAmount);
 
       return collateralTokenAmount.gt(maxWithdrawableCollateralTokenAmount)
         ? t('vault.collateral_below_threshold')
@@ -199,7 +203,10 @@ const UpdateCollateralModal = ({
     }
 
     if (
-      collateralTokenAmount.gt(collateralBalance?.transferable as MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>)
+      // ray test touch <<
+      collateralBalance &&
+      collateralTokenAmount.gt(collateralBalance.transferable)
+      // ray test touch >>
     ) {
       return t(`Must be less than ${collateralCurrency.id} balance!`);
     }

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -91,13 +91,11 @@ const UpdateCollateralModal = ({
   );
   useErrorHandler(requiredCollateralTokenAmountError);
 
-  // ray test touch <
   const {
     tokenBalanceIdle: collateralBalanceIdle,
     tokenBalanceLoading: collateralBalanceLoading,
     tokenBalance: collateralBalance
   } = useTokenBalance<CollateralUnit>(collateralCurrency.currency, vaultAddress);
-  // ray test touch >
 
   const collateralTokenAmount = newMonetaryAmount(
     strCollateralTokenAmount,

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -21,9 +21,7 @@ import InterlayModal, { InterlayModalInnerWrapper, InterlayModalTitle } from '@/
 import { ACCOUNT_ID_TYPE_NAME } from '@/config/general';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useTokenBalance from '@/services/hooks/use-token-balance';
-// ray test touch <<
 import { GenericCurrencyValues } from '@/types/currency';
-// ray test touch >>
 import STATUSES from '@/utils/constants/statuses';
 import { getTokenPrice } from '@/utils/helpers/prices';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
@@ -45,9 +43,7 @@ interface Props {
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
   hasLockedBTC: boolean;
-  // ray test touch <<
   collateralCurrency: GenericCurrencyValues<CollateralUnit>;
-  // ray test touch >>
 }
 
 const UpdateCollateralModal = ({
@@ -100,9 +96,7 @@ const UpdateCollateralModal = ({
     isLoading: collateralBalanceLoading,
     data: collateralBalance,
     error: collateralBalanceError
-    // ray test touch <<
   } = useTokenBalance<CollateralUnit>(collateralCurrency.currency, vaultAddress);
-  // ray test touch >>
   useErrorHandler(collateralBalanceError);
 
   const collateralTokenAmount = newMonetaryAmount(
@@ -202,12 +196,7 @@ const UpdateCollateralModal = ({
       return 'Please enter an amount greater than 1 Planck';
     }
 
-    if (
-      // ray test touch <<
-      collateralBalance &&
-      collateralTokenAmount.gt(collateralBalance.transferable)
-      // ray test touch >>
-    ) {
+    if (collateralBalance && collateralTokenAmount.gt(collateralBalance.transferable)) {
       return t(`Must be less than ${collateralCurrency.id} balance!`);
     }
 

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -50,9 +50,7 @@ interface Props {
   onClose: () => void;
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
-  // ray test touch <<
   vaultAccountId: AccountId;
-  // ray test touch >>
   hasLockedBTC: boolean;
   collateralCurrency: CurrencyValues;
 }

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -100,6 +100,7 @@ const UpdateCollateralModal = ({
   );
   useErrorHandler(requiredCollateralTokenAmountError);
 
+  // ray test touch <
   const {
     isIdle: collateralBalanceIdle,
     isLoading: collateralBalanceLoading,
@@ -113,6 +114,12 @@ const UpdateCollateralModal = ({
     }
   );
   useErrorHandler(collateralBalanceError);
+  // ray test touch >
+
+  // ray test touch <
+  // const { data: test } = useTokenBalance(collateralCurrency.currency, vaultAccountId);
+  // console.log('ray : ***** test?.transferable.toHuman() => ', test?.transferable.toHuman());
+  // ray test touch >
 
   const collateralTokenAmount = newMonetaryAmount(
     strCollateralTokenAmount,

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -93,12 +93,10 @@ const UpdateCollateralModal = ({
 
   // ray test touch <
   const {
-    isIdle: collateralBalanceIdle,
-    isLoading: collateralBalanceLoading,
-    data: collateralBalance,
-    error: collateralBalanceError
+    tokenBalanceIdle: collateralBalanceIdle,
+    tokenBalanceLoading: collateralBalanceLoading,
+    tokenBalance: collateralBalance
   } = useTokenBalance<CollateralUnit>(collateralCurrency.currency, vaultAddress);
-  useErrorHandler(collateralBalanceError);
   // ray test touch >
 
   const collateralTokenAmount = newMonetaryAmount(

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -19,7 +19,6 @@ import ErrorFallback from '@/components/ErrorFallback';
 import TokenField from '@/components/TokenField';
 import InterlayModal, { InterlayModalInnerWrapper, InterlayModalTitle } from '@/components/UI/InterlayModal';
 import { ACCOUNT_ID_TYPE_NAME } from '@/config/general';
-import { RELAY_CHAIN_NATIVE_TOKEN_SYMBOL } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useTokenBalance from '@/services/hooks/use-token-balance';
 import { CurrencyValues } from '@/types/currency';
@@ -318,12 +317,10 @@ const UpdateCollateralModal = ({
                 },
                 validate: (value) => validateCollateralTokenAmount(value)
               })}
-              // ray test touch <<
               approxUSD={`≈ $ ${getUsdAmount(
                 collateralTokenAmount,
-                getTokenPrice(prices, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL)?.usd
+                getTokenPrice(prices, collateralCurrency.id)?.usd
               )}`}
-              // ray test touch >>
               error={!!errors[COLLATERAL_TOKEN_AMOUNT]}
               helperText={errors[COLLATERAL_TOKEN_AMOUNT]?.message}
             />

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -50,7 +50,9 @@ interface Props {
   onClose: () => void;
   collateralUpdateStatus: CollateralUpdateStatus;
   vaultAddress: string;
-  vaultAccountId: AccountId | undefined; // TODO: should remove `undefined` later on when the loading is properly handled
+  // ray test touch <<
+  vaultAccountId: AccountId;
+  // ray test touch >>
   hasLockedBTC: boolean;
   collateralCurrency: CurrencyValues;
 }

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -1,12 +1,5 @@
-import {
-  ChainBalance,
-  CollateralUnit,
-  CurrencyUnit,
-  newMonetaryAmount,
-  roundTwoDecimals
-} from '@interlay/interbtc-api';
+import { CollateralUnit, CurrencyUnit, newMonetaryAmount, roundTwoDecimals } from '@interlay/interbtc-api';
 import { Currency, MonetaryAmount } from '@interlay/monetary-js';
-import { AccountId } from '@polkadot/types/interfaces';
 import Big from 'big.js';
 import clsx from 'clsx';
 import * as React from 'react';

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -91,6 +91,7 @@ const UpdateCollateralModal = ({
   );
   useErrorHandler(requiredCollateralTokenAmountError);
 
+  // ray test touch <
   const {
     isIdle: collateralBalanceIdle,
     isLoading: collateralBalanceLoading,
@@ -98,6 +99,7 @@ const UpdateCollateralModal = ({
     error: collateralBalanceError
   } = useTokenBalance<CollateralUnit>(collateralCurrency.currency, vaultAddress);
   useErrorHandler(collateralBalanceError);
+  // ray test touch >
 
   const collateralTokenAmount = newMonetaryAmount(
     strCollateralTokenAmount,

--- a/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
+++ b/src/pages/Vaults/Vault/UpdateCollateralModal/index.tsx
@@ -325,10 +325,12 @@ const UpdateCollateralModal = ({
                 },
                 validate: (value) => validateCollateralTokenAmount(value)
               })}
+              // ray test touch <<
               approxUSD={`≈ $ ${getUsdAmount(
                 collateralTokenAmount,
                 getTokenPrice(prices, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL)?.usd
               )}`}
+              // ray test touch >>
               error={!!errors[COLLATERAL_TOKEN_AMOUNT]}
               helperText={errors[COLLATERAL_TOKEN_AMOUNT]?.message}
             />

--- a/src/pages/Vaults/Vault/VaultStatusStatPanel/index.tsx
+++ b/src/pages/Vaults/Vault/VaultStatusStatPanel/index.tsx
@@ -18,7 +18,7 @@ import { getVaultStatusLabel } from '@/utils/helpers/vaults';
 import StatPanel from '../StatPanel';
 
 interface Props {
-  vaultAccountId: AccountId | undefined; // TODO: should remove `undefined` later on when the loading is properly handled
+  vaultAccountId: AccountId;
   collateralId: CurrencyIdLiteral | undefined;
 }
 

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -327,7 +327,6 @@ const Vault = (): JSX.Element => {
           onClose={handleUpdateCollateralModalClose}
           collateralUpdateStatus={collateralUpdateStatus}
           vaultAddress={selectedVaultAccountAddress}
-          vaultAccountId={vaultAccountId}
           hasLockedBTC={hasLockedBTC}
           collateralCurrency={collateralCurrencyValues}
         />

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -2,7 +2,6 @@ import {
   CollateralCurrency,
   CollateralIdLiteral,
   CurrencyIdLiteral,
-  newAccountId,
   VaultExt,
   VaultStatusExt
 } from '@interlay/interbtc-api';
@@ -35,6 +34,7 @@ import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fet
 import { WRAPPED_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { URL_PARAMETERS } from '@/utils/constants/links';
 import { getCurrency } from '@/utils/helpers/currencies';
+import useAccountId from '@/utils/hooks/use-account-id';
 
 import { VaultsHeader } from '../VaultsHeader';
 import ClaimRewardsButton from './ClaimRewardsButton';
@@ -96,13 +96,14 @@ const Vault = (): JSX.Element => {
   };
 
   // ray test touch <<
-  const vaultAccountId = React.useMemo(() => {
-    // eslint-disable-next-line max-len
-    // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
-    if (!bridgeLoaded) return;
+  const vaultAccountId = useAccountId(selectedVaultAccountAddress);
+  // const vaultAccountId = React.useMemo(() => {
+  //   // eslint-disable-next-line max-len
+  //   // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
+  //   if (!bridgeLoaded) return;
 
-    return newAccountId(window.bridge.api, selectedVaultAccountAddress);
-  }, [bridgeLoaded, selectedVaultAccountAddress]);
+  //   return newAccountId(window.bridge.api, selectedVaultAccountAddress);
+  // }, [bridgeLoaded, selectedVaultAccountAddress]);
   // ray test touch >>
 
   const collateralCurrencyValues = React.useMemo(() => getCurrency(vaultCollateral as CurrencyIdLiteral), [

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -95,16 +95,7 @@ const Vault = (): JSX.Element => {
     setRequestIssueModalOpen(true);
   };
 
-  // ray test touch <<
   const vaultAccountId = useAccountId(selectedVaultAccountAddress);
-  // const vaultAccountId = React.useMemo(() => {
-  //   // eslint-disable-next-line max-len
-  //   // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
-  //   if (!bridgeLoaded) return;
-
-  //   return newAccountId(window.bridge.api, selectedVaultAccountAddress);
-  // }, [bridgeLoaded, selectedVaultAccountAddress]);
-  // ray test touch >>
 
   const collateralCurrencyValues = React.useMemo(() => getCurrency(vaultCollateral as CurrencyIdLiteral), [
     vaultCollateral

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -267,7 +267,9 @@ const Vault = (): JSX.Element => {
             {vaultItems.map((item) => (
               <StatPanel key={item.title} label={item.title} value={item.value} />
             ))}
-            {vaultAccountId && <VaultStatusStatPanel collateralId={collateralCurrencyValues?.id} vaultAccountId={vaultAccountId} />}
+            {vaultAccountId && (
+              <VaultStatusStatPanel collateralId={collateralCurrencyValues?.id} vaultAccountId={vaultAccountId} />
+            )}
           </div>
         </div>
         {/* Check interaction with the vault */}

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -1,9 +1,7 @@
 import {
   CollateralCurrency,
   CollateralIdLiteral,
-  // ray test touch <<
   CollateralUnit,
-  // ray test touch >>
   CurrencyIdLiteral,
   VaultExt,
   VaultStatusExt
@@ -34,9 +32,7 @@ import { GOVERNANCE_TOKEN_SYMBOL, GovernanceTokenMonetaryAmount, WRAPPED_TOKEN_S
 import MainContainer from '@/parts/MainContainer';
 import SectionTitle from '@/parts/SectionTitle';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
-// ray test touch <<
 import { GenericCurrencyValues } from '@/types/currency';
-// ray test touch >>
 import { WRAPPED_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { URL_PARAMETERS } from '@/utils/constants/links';
 import { getCurrency } from '@/utils/helpers/currencies';

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -1,6 +1,9 @@
 import {
   CollateralCurrency,
   CollateralIdLiteral,
+  // ray test touch <<
+  CollateralUnit,
+  // ray test touch >>
   CurrencyIdLiteral,
   VaultExt,
   VaultStatusExt
@@ -31,6 +34,9 @@ import { GOVERNANCE_TOKEN_SYMBOL, GovernanceTokenMonetaryAmount, WRAPPED_TOKEN_S
 import MainContainer from '@/parts/MainContainer';
 import SectionTitle from '@/parts/SectionTitle';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
+// ray test touch <<
+import { GenericCurrencyValues } from '@/types/currency';
+// ray test touch >>
 import { WRAPPED_TOKEN_ID_LITERAL } from '@/utils/constants/currency';
 import { URL_PARAMETERS } from '@/utils/constants/links';
 import { getCurrency } from '@/utils/helpers/currencies';
@@ -320,7 +326,7 @@ const Vault = (): JSX.Element => {
           collateralUpdateStatus={collateralUpdateStatus}
           vaultAddress={selectedVaultAccountAddress}
           hasLockedBTC={hasLockedBTC}
-          collateralCurrency={collateralCurrencyValues}
+          collateralCurrency={collateralCurrencyValues as GenericCurrencyValues<CollateralUnit>}
         />
       )}
       <RequestReplacementModal

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -285,11 +285,9 @@ const Vault = (): JSX.Element => {
             <InterlayDefaultContainedButton onClick={handleWithdrawCollateralModalOpen}>
               {t('vault.withdraw_collateral')}
             </InterlayDefaultContainedButton>
-            {/* ray test touch << */}
             {vaultAccountId && collateralCurrencyValues && (
               <ClaimRewardsButton vaultAccountId={vaultAccountId} collateralToken={collateralCurrencyValues} />
             )}
-            {/* ray test touch >> */}
             <InterlayTooltip label={issueButtonTooltip}>
               {/* Button wrapped in div to enable tooltip on disabled button. */}
               <div className='grid'>

--- a/src/pages/Vaults/Vault/index.tsx
+++ b/src/pages/Vaults/Vault/index.tsx
@@ -95,6 +95,7 @@ const Vault = (): JSX.Element => {
     setRequestIssueModalOpen(true);
   };
 
+  // ray test touch <<
   const vaultAccountId = React.useMemo(() => {
     // eslint-disable-next-line max-len
     // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
@@ -102,6 +103,7 @@ const Vault = (): JSX.Element => {
 
     return newAccountId(window.bridge.api, selectedVaultAccountAddress);
   }, [bridgeLoaded, selectedVaultAccountAddress]);
+  // ray test touch >>
 
   const collateralCurrencyValues = React.useMemo(() => getCurrency(vaultCollateral as CurrencyIdLiteral), [
     vaultCollateral
@@ -271,7 +273,7 @@ const Vault = (): JSX.Element => {
             {vaultItems.map((item) => (
               <StatPanel key={item.title} label={item.title} value={item.value} />
             ))}
-            <VaultStatusStatPanel collateralId={collateralCurrencyValues?.id} vaultAccountId={vaultAccountId} />
+            {vaultAccountId && <VaultStatusStatPanel collateralId={collateralCurrencyValues?.id} vaultAccountId={vaultAccountId} />}
           </div>
         </div>
         {/* Check interaction with the vault */}
@@ -283,7 +285,11 @@ const Vault = (): JSX.Element => {
             <InterlayDefaultContainedButton onClick={handleWithdrawCollateralModalOpen}>
               {t('vault.withdraw_collateral')}
             </InterlayDefaultContainedButton>
-            <ClaimRewardsButton vaultAccountId={vaultAccountId} collateralToken={collateralCurrencyValues} />
+            {/* ray test touch << */}
+            {vaultAccountId && collateralCurrencyValues && (
+              <ClaimRewardsButton vaultAccountId={vaultAccountId} collateralToken={collateralCurrencyValues} />
+            )}
+            {/* ray test touch >> */}
             <InterlayTooltip label={issueButtonTooltip}>
               {/* Button wrapped in div to enable tooltip on disabled button. */}
               <div className='grid'>
@@ -314,7 +320,7 @@ const Vault = (): JSX.Element => {
         />
         <ReplaceTable vaultAddress={selectedVaultAccountAddress} collateralId={collateralCurrencyValues?.id} />
       </MainContainer>
-      {collateralCurrencyValues && collateralUpdateStatus !== CollateralUpdateStatus.Close && (
+      {collateralCurrencyValues && collateralUpdateStatus !== CollateralUpdateStatus.Close && vaultAccountId && (
         <UpdateCollateralModal
           open={
             collateralUpdateStatus === CollateralUpdateStatus.Deposit ||

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -42,12 +42,8 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => 
 
 const useGovernanceTokenBalanceFetcher = (
   accountAddress?: string
-): [string, string, string, GovernanceToken, AccountId] => {
+): [string, string, string, GovernanceToken, AccountId | undefined] => {
   const accountId = useAccountId(accountAddress);
-
-  if (accountId === undefined) {
-    throw new Error('Something went wrong!');
-  }
 
   return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
 };

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -3,22 +3,31 @@ import { useSelector } from 'react-redux';
 import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
 
-import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
+// ray test touch <<
+import { GOVERNANCE_TOKEN } from 'config/relay-chains';
+// ray test touch >>
 import useAccountId from 'utils/hooks/use-account-id';
+import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
 import { StoreType } from 'common/types/util.types';
+
+// ray test touch <<
+type ChainTokenBalance = ChainBalance<CurrencyUnit>;
+
+type UseTokenBalance = UseQueryResult<ChainTokenBalance, Error>;
+// ray test touch >>
 
 // `D` stands for Decimals
 const useTokenBalance = <D extends CurrencyUnit>(
   token: Currency<D>,
   accountAddress: string | undefined
-): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
+): UseTokenBalance => {
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
   const accountId = useAccountId(accountAddress);
 
-  return useQuery<ChainBalance<CurrencyUnit>, Error>(
+  return useQuery<ChainTokenBalance, Error>(
     [GENERIC_FETCHER, 'tokens', 'balance', token, accountId],
-    genericFetcher<ChainBalance<CurrencyUnit>>(),
+    genericFetcher<ChainTokenBalance>(),
     {
       enabled: !!bridgeLoaded && !!accountId
     }
@@ -26,7 +35,11 @@ const useTokenBalance = <D extends CurrencyUnit>(
 };
 
 // ray test touch <<
-// const useGovernanceTokenBalance = () => {};
+const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => {
+  return useTokenBalance(GOVERNANCE_TOKEN, accountAddress);
+};
+
+export { useGovernanceTokenBalance };
 // ray test touch >>
 
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,14 +1,14 @@
+import { ChainBalance, CurrencyUnit } from '@interlay/interbtc-api';
+import { Currency } from '@interlay/monetary-js';
+import { AccountId } from '@polkadot/types/interfaces';
 import * as React from 'react';
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
-import { AccountId } from '@polkadot/types/interfaces';
-import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
-import { Currency } from '@interlay/monetary-js';
 
-import { GOVERNANCE_TOKEN, GovernanceToken } from 'config/relay-chains';
-import useAccountId from 'utils/hooks/use-account-id';
-import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
-import { StoreType } from 'common/types/util.types';
+import { StoreType } from '@/common/types/util.types';
+import { GOVERNANCE_TOKEN, GovernanceToken } from '@/config/relay-chains';
+import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
+import useAccountId from '@/utils/hooks/use-account-id';
 
 type ChainTokenBalance = ChainBalance<CurrencyUnit>;
 

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -10,12 +10,6 @@ import { GOVERNANCE_TOKEN, GovernanceToken } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useAccountId from '@/utils/hooks/use-account-id';
 
-// ray test touch <<
-// type ChainTokenBalance = ChainBalance<CurrencyUnit>;
-// type UseTokenBalance = UseQueryResult<ChainTokenBalance, Error>;
-// ray test touch >>
-
-// `D` stands for Decimals
 const useTokenBalance = <T extends CurrencyUnit>(
   token: Currency<T>,
   accountAddress: string | undefined
@@ -34,9 +28,7 @@ const useTokenBalance = <T extends CurrencyUnit>(
 };
 
 const useGovernanceTokenBalance = (accountAddress?: string): UseQueryResult<ChainBalance<GovernanceUnit>, Error> => {
-  // ray test touch <<
   return useTokenBalance<GovernanceUnit>(GOVERNANCE_TOKEN, accountAddress);
-  // ray test touch >>
 };
 
 const useGovernanceTokenBalanceQueryKey = (

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -2,9 +2,7 @@ import { ChainBalance, CurrencyUnit, GovernanceUnit } from '@interlay/interbtc-a
 import { Currency } from '@interlay/monetary-js';
 import { AccountId } from '@polkadot/types/interfaces';
 import * as React from 'react';
-// ray test touch <
 import { useErrorHandler } from 'react-error-boundary';
-// ray test touch >
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 
@@ -13,13 +11,11 @@ import { GOVERNANCE_TOKEN, GovernanceToken } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useAccountId from '@/utils/hooks/use-account-id';
 
-// ray test touch <
 interface UseTokenBalance<T extends CurrencyUnit> {
   tokenBalanceIdle: UseQueryResult<ChainBalance<T>, Error>['isIdle'];
   tokenBalanceLoading: UseQueryResult<ChainBalance<T>, Error>['isLoading'];
   tokenBalance: UseQueryResult<ChainBalance<T>, Error>['data'];
 }
-// ray test touch >
 
 const useTokenBalance = <T extends CurrencyUnit>(
   token: Currency<T>,
@@ -29,7 +25,6 @@ const useTokenBalance = <T extends CurrencyUnit>(
 
   const accountId = useAccountId(accountAddress);
 
-  // ray test touch <
   const {
     isIdle: tokenBalanceIdle,
     isLoading: tokenBalanceLoading,
@@ -49,19 +44,15 @@ const useTokenBalance = <T extends CurrencyUnit>(
     tokenBalanceLoading,
     tokenBalance
   };
-  // ray test touch >
 };
 
-// ray test touch <
 interface UseGovernanceTokenBalance {
   governanceTokenBalanceIdle: UseQueryResult<ChainBalance<GovernanceUnit>, Error>['isIdle'];
   governanceTokenBalanceLoading: UseQueryResult<ChainBalance<GovernanceUnit>, Error>['isLoading'];
   governanceTokenBalance: UseQueryResult<ChainBalance<GovernanceUnit>, Error>['data'];
 }
-// ray test touch >
 
 const useGovernanceTokenBalance = (accountAddress?: string): UseGovernanceTokenBalance => {
-  // ray test touch <
   const {
     tokenBalanceIdle: governanceTokenBalanceIdle,
     tokenBalanceLoading: governanceTokenBalanceLoading,
@@ -73,7 +64,6 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseGovernanceTokenB
     governanceTokenBalanceLoading,
     governanceTokenBalance
   };
-  // ray test touch >
 };
 
 const useGovernanceTokenBalanceQueryKey = (

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,0 +1,27 @@
+// ray test touch <
+import { useQuery, UseQueryResult } from 'react-query';
+import { useSelector } from 'react-redux';
+import { AccountId } from '@polkadot/types/interfaces';
+import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
+import { Currency } from '@interlay/monetary-js';
+
+import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
+import { StoreType } from 'common/types/util.types';
+
+const useTokenBalance = <Decimals extends CurrencyUnit>(
+  token: Currency<Decimals>,
+  accountId: AccountId | undefined
+): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
+  const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
+
+  return useQuery<ChainBalance<CurrencyUnit>, Error>(
+    [GENERIC_FETCHER, 'tokens', 'balance', token, accountId],
+    genericFetcher<ChainBalance<CurrencyUnit>>(),
+    {
+      enabled: !!bridgeLoaded && !!accountId
+    }
+  );
+};
+
+export default useTokenBalance;
+// ray test touch >

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,3 +1,6 @@
+// ray test touch <<
+import * as React from 'react';
+// ray test touch >>
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 import { AccountId } from '@polkadot/types/interfaces';
@@ -42,10 +45,14 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => 
 
 const useGovernanceTokenBalanceQueryKey = (
   accountAddress?: string
-): [string, string, string, GovernanceToken, AccountId | undefined] => {
+): [string, string, string, GovernanceToken, AccountId] | undefined => {
   const accountId = useAccountId(accountAddress);
 
-  return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
+  return React.useMemo(() => {
+    if (!accountId) return;
+
+    return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
+  }, [accountId]);
 };
 
 export { useGovernanceTokenBalance, useGovernanceTokenBalanceQueryKey };

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -14,9 +14,7 @@ const useTokenBalance = <D extends CurrencyUnit>(
 ): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
-  // ray test touch <<
   const accountId = useAccountId(accountAddress);
-  // ray test touch >>
 
   return useQuery<ChainBalance<CurrencyUnit>, Error>(
     [GENERIC_FETCHER, 'tokens', 'balance', token, accountId],

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
-import { CurrencyUnit, ChainBalance, newAccountId } from '@interlay/interbtc-api';
+import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
 
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
+import useAccountId from 'utils/hooks/use-account-id';
 import { StoreType } from 'common/types/util.types';
 
 // `D` stands for Decimals
@@ -12,18 +12,10 @@ const useTokenBalance = <D extends CurrencyUnit>(
   token: Currency<D>,
   accountAddress: string | undefined
 ): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
-  const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
+  const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
   // ray test touch <<
-  // TODO: useAccountId
-  const accountId = React.useMemo(() => {
-    // eslint-disable-next-line max-len
-    // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
-    if (!bridgeLoaded) return;
-    if (!address) return;
-
-    return newAccountId(window.bridge.api, accountAddress || address);
-  }, [bridgeLoaded, accountAddress, address]);
+  const accountId = useAccountId(accountAddress);
   // ray test touch >>
 
   return useQuery<ChainBalance<CurrencyUnit>, Error>(

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,4 +1,4 @@
-import { ChainBalance, CurrencyUnit } from '@interlay/interbtc-api';
+import { ChainBalance, CurrencyUnit, GovernanceUnit } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
 import { AccountId } from '@polkadot/types/interfaces';
 import * as React from 'react';
@@ -10,30 +10,33 @@ import { GOVERNANCE_TOKEN, GovernanceToken } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useAccountId from '@/utils/hooks/use-account-id';
 
-type ChainTokenBalance = ChainBalance<CurrencyUnit>;
-
-type UseTokenBalance = UseQueryResult<ChainTokenBalance, Error>;
+// ray test touch <<
+// type ChainTokenBalance = ChainBalance<CurrencyUnit>;
+// type UseTokenBalance = UseQueryResult<ChainTokenBalance, Error>;
+// ray test touch >>
 
 // `D` stands for Decimals
-const useTokenBalance = <D extends CurrencyUnit>(
-  token: Currency<D>,
+const useTokenBalance = <T extends CurrencyUnit>(
+  token: Currency<T>,
   accountAddress: string | undefined
-): UseTokenBalance => {
+): UseQueryResult<ChainBalance<T>, Error> => {
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
 
   const accountId = useAccountId(accountAddress);
 
-  return useQuery<ChainTokenBalance, Error>(
+  return useQuery<ChainBalance<T>, Error>(
     [GENERIC_FETCHER, 'tokens', 'balance', token, accountId],
-    genericFetcher<ChainTokenBalance>(),
+    genericFetcher<ChainBalance<T>>(),
     {
       enabled: !!bridgeLoaded && !!accountId
     }
   );
 };
 
-const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => {
-  return useTokenBalance(GOVERNANCE_TOKEN, accountAddress);
+const useGovernanceTokenBalance = (accountAddress?: string): UseQueryResult<ChainBalance<GovernanceUnit>, Error> => {
+  // ray test touch <<
+  return useTokenBalance<GovernanceUnit>(GOVERNANCE_TOKEN, accountAddress);
+  // ray test touch >>
 };
 
 const useGovernanceTokenBalanceQueryKey = (

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -64,7 +64,6 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseGovernanceTokenB
   };
 };
 
-// ray test touch <
 const useGovernanceTokenBalanceInvalidate = (accountAddress?: string): (() => void) | undefined => {
   const accountId = useAccountId(accountAddress);
 
@@ -76,7 +75,6 @@ const useGovernanceTokenBalanceInvalidate = (accountAddress?: string): (() => vo
       }
     : undefined;
 };
-// ray test touch >
 
 // MEMO: should wrap components with `withErrorBoundary` from `react-error-boundary` where these hooks are placed for nearest error handling
 export { useGovernanceTokenBalance, useGovernanceTokenBalanceInvalidate };

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,24 +1,18 @@
-// ray test touch <<
 import * as React from 'react';
-// ray test touch >>
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 import { AccountId } from '@polkadot/types/interfaces';
 import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
 
-// ray test touch <<
 import { GOVERNANCE_TOKEN, GovernanceToken } from 'config/relay-chains';
-// ray test touch >>
 import useAccountId from 'utils/hooks/use-account-id';
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
 import { StoreType } from 'common/types/util.types';
 
-// ray test touch <<
 type ChainTokenBalance = ChainBalance<CurrencyUnit>;
 
 type UseTokenBalance = UseQueryResult<ChainTokenBalance, Error>;
-// ray test touch >>
 
 // `D` stands for Decimals
 const useTokenBalance = <D extends CurrencyUnit>(
@@ -38,7 +32,6 @@ const useTokenBalance = <D extends CurrencyUnit>(
   );
 };
 
-// ray test touch <<
 const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => {
   return useTokenBalance(GOVERNANCE_TOKEN, accountAddress);
 };
@@ -56,6 +49,5 @@ const useGovernanceTokenBalanceQueryKey = (
 };
 
 export { useGovernanceTokenBalance, useGovernanceTokenBalanceQueryKey };
-// ray test touch >>
 
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,10 +1,11 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
+import { AccountId } from '@polkadot/types/interfaces';
 import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
 
 // ray test touch <<
-import { GOVERNANCE_TOKEN } from 'config/relay-chains';
+import { GOVERNANCE_TOKEN, GovernanceToken } from 'config/relay-chains';
 // ray test touch >>
 import useAccountId from 'utils/hooks/use-account-id';
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
@@ -39,7 +40,19 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => 
   return useTokenBalance(GOVERNANCE_TOKEN, accountAddress);
 };
 
-export { useGovernanceTokenBalance };
+const useGovernanceTokenBalanceFetcher = (
+  accountAddress?: string
+): [string, string, string, GovernanceToken, AccountId] => {
+  const accountId = useAccountId(accountAddress);
+
+  if (accountId === undefined) {
+    throw new Error('Something went wrong!');
+  }
+
+  return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
+};
+
+export { useGovernanceTokenBalance, useGovernanceTokenBalanceFetcher };
 // ray test touch >>
 
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,6 +1,4 @@
-// ray test touch <<
 import * as React from 'react';
-// ray test touch >>
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 import { CurrencyUnit, ChainBalance, newAccountId } from '@interlay/interbtc-api';
@@ -12,9 +10,7 @@ import { StoreType } from 'common/types/util.types';
 // `D` stands for Decimals
 const useTokenBalance = <D extends CurrencyUnit>(
   token: Currency<D>,
-  // ray test touch <<
   accountAddress: string | undefined
-  // ray test touch >>
 ): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
   const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
 
@@ -39,8 +35,8 @@ const useTokenBalance = <D extends CurrencyUnit>(
   );
 };
 
-// ray test touch <
+// ray test touch <<
 // const useGovernanceTokenBalance = () => {};
-// ray test touch >
+// ray test touch >>
 
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -23,4 +23,8 @@ const useTokenBalance = <D extends CurrencyUnit>(
   );
 };
 
+// ray test touch <
+// const useGovernanceTokenBalance = () => {};
+// ray test touch >
+
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,13 +1,11 @@
 import { ChainBalance, CurrencyUnit, GovernanceUnit } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
-import { AccountId } from '@polkadot/types/interfaces';
-import * as React from 'react';
 import { useErrorHandler } from 'react-error-boundary';
-import { useQuery, UseQueryResult } from 'react-query';
+import { useQuery, useQueryClient, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 
 import { StoreType } from '@/common/types/util.types';
-import { GOVERNANCE_TOKEN, GovernanceToken } from '@/config/relay-chains';
+import { GOVERNANCE_TOKEN } from '@/config/relay-chains';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
 import useAccountId from '@/utils/hooks/use-account-id';
 
@@ -67,20 +65,20 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseGovernanceTokenB
 };
 
 // ray test touch <
-const useGovernanceTokenBalanceQueryKey = (
-  accountAddress?: string
-): [string, string, string, GovernanceToken, AccountId] | undefined => {
+const useGovernanceTokenBalanceInvalidate = (accountAddress?: string): (() => void) | undefined => {
   const accountId = useAccountId(accountAddress);
 
-  return React.useMemo(() => {
-    if (!accountId) return;
+  const queryClient = useQueryClient();
 
-    return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
-  }, [accountId]);
+  return accountId
+    ? () => {
+        queryClient.invalidateQueries([GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId]);
+      }
+    : undefined;
 };
 // ray test touch >
 
 // MEMO: should wrap components with `withErrorBoundary` from `react-error-boundary` where these hooks are placed for nearest error handling
-export { useGovernanceTokenBalance, useGovernanceTokenBalanceQueryKey };
+export { useGovernanceTokenBalance, useGovernanceTokenBalanceInvalidate };
 
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,7 +1,9 @@
+// ray test touch <<
+import * as React from 'react';
+// ray test touch >>
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
-import { AccountId } from '@polkadot/types/interfaces';
-import { CurrencyUnit, ChainBalance } from '@interlay/interbtc-api';
+import { CurrencyUnit, ChainBalance, newAccountId } from '@interlay/interbtc-api';
 import { Currency } from '@interlay/monetary-js';
 
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
@@ -10,9 +12,23 @@ import { StoreType } from 'common/types/util.types';
 // `D` stands for Decimals
 const useTokenBalance = <D extends CurrencyUnit>(
   token: Currency<D>,
-  accountId: AccountId | undefined
+  // ray test touch <<
+  accountAddress: string | undefined
+  // ray test touch >>
 ): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
-  const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
+  const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
+
+  // ray test touch <<
+  // TODO: useAccountId
+  const accountId = React.useMemo(() => {
+    // eslint-disable-next-line max-len
+    // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
+    if (!bridgeLoaded) return;
+    if (!address) return;
+
+    return newAccountId(window.bridge.api, accountAddress || address);
+  }, [bridgeLoaded, accountAddress, address]);
+  // ray test touch >>
 
   return useQuery<ChainBalance<CurrencyUnit>, Error>(
     [GENERIC_FETCHER, 'tokens', 'balance', token, accountId],

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -40,7 +40,7 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseTokenBalance => 
   return useTokenBalance(GOVERNANCE_TOKEN, accountAddress);
 };
 
-const useGovernanceTokenBalanceFetcher = (
+const useGovernanceTokenBalanceQueryKey = (
   accountAddress?: string
 ): [string, string, string, GovernanceToken, AccountId | undefined] => {
   const accountId = useAccountId(accountAddress);
@@ -48,7 +48,7 @@ const useGovernanceTokenBalanceFetcher = (
   return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
 };
 
-export { useGovernanceTokenBalance, useGovernanceTokenBalanceFetcher };
+export { useGovernanceTokenBalance, useGovernanceTokenBalanceQueryKey };
 // ray test touch >>
 
 export default useTokenBalance;

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -1,4 +1,3 @@
-// ray test touch <
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 import { AccountId } from '@polkadot/types/interfaces';
@@ -8,8 +7,9 @@ import { Currency } from '@interlay/monetary-js';
 import genericFetcher, { GENERIC_FETCHER } from 'services/fetchers/generic-fetcher';
 import { StoreType } from 'common/types/util.types';
 
-const useTokenBalance = <Decimals extends CurrencyUnit>(
-  token: Currency<Decimals>,
+// `D` stands for Decimals
+const useTokenBalance = <D extends CurrencyUnit>(
+  token: Currency<D>,
   accountId: AccountId | undefined
 ): UseQueryResult<ChainBalance<CurrencyUnit>, Error> => {
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
@@ -24,4 +24,3 @@ const useTokenBalance = <Decimals extends CurrencyUnit>(
 };
 
 export default useTokenBalance;
-// ray test touch >

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -18,6 +18,7 @@ const useTokenBalance = <T extends CurrencyUnit>(
 
   const accountId = useAccountId(accountAddress);
 
+  // ray test touch <
   return useQuery<ChainBalance<T>, Error>(
     [GENERIC_FETCHER, 'tokens', 'balance', token, accountId],
     genericFetcher<ChainBalance<T>>(),
@@ -25,10 +26,13 @@ const useTokenBalance = <T extends CurrencyUnit>(
       enabled: !!bridgeLoaded && !!accountId
     }
   );
+  // ray test touch >
 };
 
 const useGovernanceTokenBalance = (accountAddress?: string): UseQueryResult<ChainBalance<GovernanceUnit>, Error> => {
+  // ray test touch <
   return useTokenBalance<GovernanceUnit>(GOVERNANCE_TOKEN, accountAddress);
+  // ray test touch >
 };
 
 const useGovernanceTokenBalanceQueryKey = (

--- a/src/services/hooks/use-token-balance.ts
+++ b/src/services/hooks/use-token-balance.ts
@@ -66,6 +66,7 @@ const useGovernanceTokenBalance = (accountAddress?: string): UseGovernanceTokenB
   };
 };
 
+// ray test touch <
 const useGovernanceTokenBalanceQueryKey = (
   accountAddress?: string
 ): [string, string, string, GovernanceToken, AccountId] | undefined => {
@@ -77,6 +78,7 @@ const useGovernanceTokenBalanceQueryKey = (
     return [GENERIC_FETCHER, 'tokens', 'balance', GOVERNANCE_TOKEN, accountId];
   }, [accountId]);
 };
+// ray test touch >
 
 // MEMO: should wrap components with `withErrorBoundary` from `react-error-boundary` where these hooks are placed for nearest error handling
 export { useGovernanceTokenBalance, useGovernanceTokenBalanceQueryKey };

--- a/src/types/currency.ts
+++ b/src/types/currency.ts
@@ -3,14 +3,12 @@ import { Bitcoin, BitcoinUnit, Currency, ExchangeRate } from '@interlay/monetary
 
 type BTCToCollateralTokenRate = ExchangeRate<Bitcoin, BitcoinUnit, Currency<CollateralUnit>, CollateralUnit>;
 
-// ray test touch <<
 interface GenericCurrencyValues<T extends CurrencyUnit> {
   currency: Currency<T>;
   id: CurrencyIdLiteral;
 }
 
 type CurrencyValues = GenericCurrencyValues<CurrencyUnit>;
-// ray test touch >>
 
 // Note: this may be moved to the lib if used more widely, or removed altogether
 // if `CurrencyIdLiteral` is extended to support aUSD
@@ -20,7 +18,5 @@ enum ForeignAssetIdLiteral {
 
 type Currencies = Array<CurrencyValues>;
 
-// ray test touch <<
 export type { BTCToCollateralTokenRate, Currencies, CurrencyValues, GenericCurrencyValues };
-// ray test touch >>
 export { ForeignAssetIdLiteral };

--- a/src/types/currency.ts
+++ b/src/types/currency.ts
@@ -3,10 +3,14 @@ import { Bitcoin, BitcoinUnit, Currency, ExchangeRate } from '@interlay/monetary
 
 type BTCToCollateralTokenRate = ExchangeRate<Bitcoin, BitcoinUnit, Currency<CollateralUnit>, CollateralUnit>;
 
-type CurrencyValues = {
-  currency: Currency<CurrencyUnit>;
+// ray test touch <<
+interface GenericCurrencyValues<T extends CurrencyUnit> {
+  currency: Currency<T>;
   id: CurrencyIdLiteral;
-};
+}
+
+type CurrencyValues = GenericCurrencyValues<CurrencyUnit>;
+// ray test touch >>
 
 // Note: this may be moved to the lib if used more widely, or removed altogether
 // if `CurrencyIdLiteral` is extended to support aUSD
@@ -16,5 +20,7 @@ enum ForeignAssetIdLiteral {
 
 type Currencies = Array<CurrencyValues>;
 
-export type { BTCToCollateralTokenRate, Currencies, CurrencyValues };
+// ray test touch <<
+export type { BTCToCollateralTokenRate, Currencies, CurrencyValues, GenericCurrencyValues };
+// ray test touch >>
 export { ForeignAssetIdLiteral };

--- a/src/utils/hooks/use-account-id.ts
+++ b/src/utils/hooks/use-account-id.ts
@@ -6,7 +6,7 @@ import { newAccountId } from '@interlay/interbtc-api';
 
 import { StoreType } from 'common/types/util.types';
 
-const useAccountId = (accountAddress: string | undefined): AccountId | undefined => {
+const useAccountId = (accountAddress?: string): AccountId | undefined => {
   const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
 
   return React.useMemo(() => {

--- a/src/utils/hooks/use-account-id.ts
+++ b/src/utils/hooks/use-account-id.ts
@@ -1,4 +1,3 @@
-// ray test touch <<
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { AccountId } from '@polkadot/types/interfaces';
@@ -20,4 +19,3 @@ const useAccountId = (accountAddress?: string): AccountId | undefined => {
 };
 
 export default useAccountId;
-// ray test touch >>

--- a/src/utils/hooks/use-account-id.ts
+++ b/src/utils/hooks/use-account-id.ts
@@ -1,9 +1,9 @@
+import { newAccountId } from '@interlay/interbtc-api';
+import { AccountId } from '@polkadot/types/interfaces';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
-import { AccountId } from '@polkadot/types/interfaces';
-import { newAccountId } from '@interlay/interbtc-api';
 
-import { StoreType } from 'common/types/util.types';
+import { StoreType } from '@/common/types/util.types';
 
 const useAccountId = (accountAddress?: string): AccountId | undefined => {
   const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);

--- a/src/utils/hooks/use-account-id.ts
+++ b/src/utils/hooks/use-account-id.ts
@@ -1,0 +1,23 @@
+// ray test touch <<
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { AccountId } from '@polkadot/types/interfaces';
+import { newAccountId } from '@interlay/interbtc-api';
+
+import { StoreType } from 'common/types/util.types';
+
+const useAccountId = (accountAddress: string | undefined): AccountId | undefined => {
+  const { bridgeLoaded, address } = useSelector((state: StoreType) => state.general);
+
+  return React.useMemo(() => {
+    // eslint-disable-next-line max-len
+    // TODO: should correct loading procedure according to https://kentcdodds.com/blog/application-state-management-with-react
+    if (!bridgeLoaded) return;
+    if (!address) return;
+
+    return newAccountId(window.bridge.api, accountAddress || address);
+  }, [bridgeLoaded, accountAddress, address]);
+};
+
+export default useAccountId;
+// ray test touch >>


### PR DESCRIPTION
- Implement:
  * `useGovernanceTokenBalance`
  * `useTokenBalance`
- Replace governance token balance management by redux with the above hooks.
- Drop governance token balance management by redux.
