### PR TITLE
feature: Dl component

### DIFF
--- a/src/component-library/Text/Dl/Dl.stories.tsx
+++ b/src/component-library/Text/Dl/Dl.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, Story } from '@storybook/react';
+
+import { Dl, DlProps } from '.';
+
+const Template: Story<DlProps> = (args) => <Dl {...args} />;
+
+const Default = Template.bind({});
+Default.args = {
+  listItems: [
+    { term: 'Item', definition: 'Definition' },
+    { term: 'Item', definition: 'Definition' },
+    { term: 'Item', definition: 'Definition' },
+    { term: 'Item', definition: 'Definition' }
+  ]
+};
+
+export { Default };
+
+export default {
+  title: 'Text/Dl',
+  component: Dl
+} as Meta;

--- a/src/component-library/Text/Dl/Dl.style.tsx
+++ b/src/component-library/Text/Dl/Dl.style.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+import { theme } from '../../theme';
+import { BaseTextProps } from '../types';
+
+const DefinitionList = styled.dl<BaseTextProps>`
+  display: flex;
+  font-size: ${theme.text.s};
+`;
+
+const ListItem = styled.div`
+  border-right: 1px solid ${theme.colors.textTertiary};
+  display: flex;
+  margin-right: ${theme.spacing.spacing10};
+  padding-right: ${theme.spacing.spacing10};
+
+  &:last-of-type {
+    border-right: none;
+  }
+`;
+
+const Dt = styled.dt`
+  color: ${theme.colors.textTertiary};
+  margin-right: ${theme.spacing.spacing2};
+`;
+
+const Dd = styled.dd`
+  color: ${theme.colors.textPrimary};
+`;
+
+export { Dd, DefinitionList, Dt, ListItem };

--- a/src/component-library/Text/Dl/Dl.tsx
+++ b/src/component-library/Text/Dl/Dl.tsx
@@ -1,0 +1,29 @@
+import { BaseTextProps } from '../types';
+import { Dd, DefinitionList, Dt, ListItem } from './Dl.style';
+
+type DlItem = {
+  term: string;
+  definition: string;
+};
+
+interface DlProps extends BaseTextProps {
+  listItems: Array<DlItem>;
+}
+
+const Dl = ({ listItems }: DlProps): JSX.Element => {
+  return (
+    <DefinitionList>
+      {listItems.map((listItem) => (
+        <ListItem key={listItem.term}>
+          <Dt>{listItem.term}:</Dt>
+          <Dd>{listItem.definition}</Dd>
+        </ListItem>
+      ))}
+    </DefinitionList>
+  );
+};
+
+Dl.displayName = 'P';
+
+export { Dl };
+export type { DlProps };

--- a/src/component-library/Text/Dl/index.tsx
+++ b/src/component-library/Text/Dl/index.tsx
@@ -1,0 +1,2 @@
+export type { DlProps } from './Dl';
+export { Dl } from './Dl';

--- a/src/component-library/Text/index.tsx
+++ b/src/component-library/Text/index.tsx
@@ -1,3 +1,5 @@
+export type { DlProps } from './Dl';
+export { Dl } from './Dl';
 export type { EmProps } from './Em';
 export { Em } from './Em';
 export type { H1Props } from './H1';

--- a/src/component-library/index.tsx
+++ b/src/component-library/index.tsx
@@ -20,8 +20,19 @@ export type { StackProps } from './Stack';
 export { Stack } from './Stack';
 export type { TableProps } from './Table';
 export { Table } from './Table';
-export type { EmProps, H1Props, H2Props, H3Props, H4Props, H5Props, H6Props, PProps, StrongProps } from './Text';
-export { Em, H1, H2, H3, H4, H5, H6, P, Strong } from './Text';
+export type {
+  DlProps,
+  EmProps,
+  H1Props,
+  H2Props,
+  H3Props,
+  H4Props,
+  H5Props,
+  H6Props,
+  PProps,
+  StrongProps
+} from './Text';
+export { Dl, Em, H1, H2, H3, H4, H5, H6, P, Strong } from './Text';
 export type { ComponentLibraryTheme } from './theme';
 export { theme } from './theme';
 export type { TokenBalanceProps } from './TokenBalance';


### PR DESCRIPTION
Add a definition list component. This is a text component which is needed for the updated vault dashboard header. This is the only use case at the moment, so there are no variants but it can be extended as and when necessary.

<img width="732" alt="Screenshot 2022-07-26 at 11 59 52" src="https://user-images.githubusercontent.com/40243778/180990815-3b24892a-67b9-4f98-a45c-438e460dbb38.png">

<img width="694" alt="Screenshot 2022-07-26 at 12 00 09" src="https://user-images.githubusercontent.com/40243778/180990817-e3b85b17-85ee-4095-8949-3c3c0c6fc836.png">

