### PR TITLE
refactor: colour variant for at risk vaults

### DIFF
--- a/src/component-library/VaultCard/VaultCard.stories.tsx
+++ b/src/component-library/VaultCard/VaultCard.stories.tsx
@@ -11,10 +11,22 @@ Default.args = {
   pendingRequests: 3,
   apy: '16.23',
   collateralScore: '115.45',
-  link: '#'
+  link: '#',
+  atRisk: false
 };
 
-export { Default };
+const AtRisk = Template.bind({});
+AtRisk.args = {
+  collateralSymbol: 'DOT',
+  wrappedSymbol: 'BTC',
+  pendingRequests: 3,
+  apy: '16.23',
+  collateralScore: '115.45',
+  link: '#',
+  atRisk: true
+};
+
+export { AtRisk, Default };
 
 export default {
   title: 'Components/VaultCard',

--- a/src/component-library/VaultCard/VaultCard.style.tsx
+++ b/src/component-library/VaultCard/VaultCard.style.tsx
@@ -2,6 +2,10 @@ import styled from 'styled-components';
 
 import { theme } from '../theme';
 
+interface CollateralScoreProps {
+  $atRisk: boolean;
+}
+
 export const Card = styled.div`
   box-shadow: ${theme.boxShadow.default};
   color: ${theme.colors.textSecondary};
@@ -55,6 +59,10 @@ export const DlItem = styled.div`
   &:last-of-type {
     margin-bottom: 0;
   }
+`;
+
+export const CollateralScore = styled.dd<CollateralScoreProps>`
+  color: ${(props) => (props.$atRisk ? theme.colors.warn : theme.colors.textTertiary)};
 `;
 
 export const CTAWrapper = styled.div`

--- a/src/component-library/VaultCard/VaultCard.tsx
+++ b/src/component-library/VaultCard/VaultCard.tsx
@@ -1,7 +1,16 @@
 import { CoinPair } from '../CoinPair';
 import { CTALink } from '../CTA';
 import { Tokens } from '../types';
-import { Card, CardBody, CardHeader, CardTitle, CTAWrapper, DlItem, StyledDl } from './VaultCard.style';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  CollateralScore,
+  CTAWrapper,
+  DlItem,
+  StyledDl
+} from './VaultCard.style';
 
 interface VaultCardProps {
   collateralSymbol: Tokens;
@@ -10,6 +19,7 @@ interface VaultCardProps {
   apy: string;
   collateralScore: string;
   link: string;
+  atRisk: boolean;
 }
 
 const VaultCard = ({
@@ -18,7 +28,8 @@ const VaultCard = ({
   pendingRequests,
   apy,
   collateralScore,
-  link
+  link,
+  atRisk
 }: VaultCardProps): JSX.Element => (
   <Card>
     <CardHeader>
@@ -42,7 +53,9 @@ const VaultCard = ({
         </DlItem>
         <DlItem>
           <dt>Collateralization</dt>
-          <dd>{collateralScore === '∞' ? collateralScore : `${collateralScore}%`}</dd>
+          <CollateralScore $atRisk={atRisk}>
+            {collateralScore === '∞' ? collateralScore : `${collateralScore}%`}
+          </CollateralScore>
         </DlItem>
       </StyledDl>
       <CTAWrapper>

--- a/src/component-library/theme/theme.base.css
+++ b/src/component-library/theme/theme.base.css
@@ -44,6 +44,8 @@
   --colors-neutral-light-grey-50: #9999997f;
   --colors-neutral-black: #000000;
 
+  --colors-shared-red: #cb5458;
+
   --text-xs: 0.75rem;
   --text-s: 0.875rem;
   --text-base: 1rem;

--- a/src/component-library/theme/theme.ts
+++ b/src/component-library/theme/theme.ts
@@ -12,7 +12,8 @@ const theme = {
     textPrimary: 'var(--colors-text-primary)',
     textSecondary: 'var(--colors-text-secondary)',
     textTertiary: 'var(--colors-text-tertiary)',
-    bgPrimary: 'var(--colors-bg-primary)'
+    bgPrimary: 'var(--colors-bg-primary)',
+    warn: `var(--colors-shared-red)`
   },
   font: {
     primary: 'var(--fonts-primary)'

--- a/src/pages/Vaults/index.tsx
+++ b/src/pages/Vaults/index.tsx
@@ -42,6 +42,7 @@ const VaultOverview = (): JSX.Element => {
                 apy={safeRoundTwoDecimals(vault.apy.toString())}
                 collateralScore={safeRoundTwoDecimals(vault.collateralization?.mul(100).toString(), '∞')}
                 link={`${accountAddress}/${vault.collateralId}/${vault.wrappedId}`}
+                atRisk={vault.vaultAtRisk}
               />
             </GridItem>
           ))}


### PR DESCRIPTION
This makes the collateral score red for at risk vaults, as in the original design. Jay is working on a more accessible solution, but this is a quick change to bring the implementation into line with the original designs. Current implementation of the dashboard flags that a vault is at risk in the info box, but doesn't indicate which one.

<img width="528" alt="Screenshot 2022-07-27 at 10 12 49" src="https://user-images.githubusercontent.com/40243778/181209997-9be0f816-6e84-4210-a36a-f827d076770c.png">

