### PR TITLE
fix: add specific node version to Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,8 @@ jobs:
     # Job steps
     steps:
       - uses: actions/checkout@v1
+        with:
+          node-version: "16"
       - name: Install dependencies
         run: yarn
         # 👇 Adds Chromatic as a step in the workflow


### PR DESCRIPTION
Update the workflow to specify a node version. This fixes the build issue with Chromatic.