### PR TITLE
fix: handle offline oracle for issue and redeem

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -119,6 +119,7 @@
   "not_enough_vault_capacity": "None vault has enough capacity.",
   "view_all_transactions_on_subscan": "View all transactions on Subscan",
   "collateral": "Collateral",
+  "error_oracle_offline": "You can't {{action}} {{wrappedTokenSymbol}} at the moment because oracle is offline.",
   "redeem_page": {
     "withdraw": "Withdraw",
     "sorry_redeem_failed": "Sorry, your redeem request has failed",

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -269,7 +269,7 @@ const IssueForm = (): JSX.Element | null => {
         return 'Invalid BTC amount input!';
       }
 
-      if (btcToGovernanceTokenRate.toBig().eq(0)) {
+      if (isOracleOffline) {
         return t('error_oracle_offline', { action: 'issue', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL });
       }
 
@@ -344,6 +344,9 @@ const IssueForm = (): JSX.Element | null => {
     const wrappedTokenAmount = parsedBTCAmount.sub(bridgeFee);
     const accountSet = !!address;
     const isSelectVaultCheckboxDisabled = wrappedTokenAmount.gt(requestLimits.singleVaultMaxIssuable);
+
+    // `btcToGovernanceTokenRate` has 0 value only if oracle call fails
+    const isOracleOffline = btcToGovernanceTokenRate.toBig().eq(0);
 
     return (
       <>

--- a/src/pages/Bridge/IssueForm/index.tsx
+++ b/src/pages/Bridge/IssueForm/index.tsx
@@ -144,7 +144,12 @@ const IssueForm = (): JSX.Element | null => {
     (async () => {
       try {
         setStatus(STATUSES.PENDING);
-        const [theFeeRate, theDepositRate, theDustValue, theBtcToGovernanceToken] = await Promise.all([
+        const [
+          theFeeRateResult,
+          theDepositRateResult,
+          theDustValueResult,
+          theBtcToGovernanceTokenResult
+        ] = await Promise.allSettled([
           // Loading this data is not strictly required as long as the constantly set values did
           // not change. However, you will not see the correct value for the security deposit.
           window.bridge.fee.getIssueFee(),
@@ -154,16 +159,38 @@ const IssueForm = (): JSX.Element | null => {
         ]);
         setStatus(STATUSES.RESOLVED);
 
-        setFeeRate(theFeeRate);
-        setDepositRate(theDepositRate);
-        setDustValue(theDustValue);
-        setBTCToGovernanceTokenRate(theBtcToGovernanceToken);
+        if (theFeeRateResult.status === 'rejected') {
+          throw new Error(theFeeRateResult.reason);
+        }
+
+        if (theDepositRateResult.status === 'rejected') {
+          throw new Error(theDepositRateResult.reason);
+        }
+
+        if (theDustValueResult.status === 'rejected') {
+          throw new Error(theDustValueResult.reason);
+        }
+
+        if (theBtcToGovernanceTokenResult.status === 'rejected') {
+          setError(BTC_AMOUNT, {
+            type: 'validate',
+            message: t('error_oracle_offline', { action: 'issue', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL })
+          });
+        }
+
+        if (theBtcToGovernanceTokenResult.status === 'fulfilled') {
+          setBTCToGovernanceTokenRate(theBtcToGovernanceTokenResult.value);
+        }
+
+        setFeeRate(theFeeRateResult.value);
+        setDepositRate(theDepositRateResult.value);
+        setDustValue(theDustValueResult.value);
       } catch (error) {
         setStatus(STATUSES.REJECTED);
         handleError(error);
       }
     })();
-  }, [bridgeLoaded, dispatch, handleError]);
+  }, [bridgeLoaded, dispatch, handleError, setError, t]);
 
   React.useEffect(() => {
     // deselect checkbox when required btcAmount exceeds capacity
@@ -240,6 +267,10 @@ const IssueForm = (): JSX.Element | null => {
 
       if (btcAmount === undefined) {
         return 'Invalid BTC amount input!';
+      }
+
+      if (btcToGovernanceTokenRate.toBig().eq(0)) {
+        return t('error_oracle_offline', { action: 'issue', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL });
       }
 
       return undefined;

--- a/src/pages/Bridge/RedeemForm/index.tsx
+++ b/src/pages/Bridge/RedeemForm/index.tsx
@@ -306,7 +306,7 @@ const RedeemForm = (): JSX.Element | null => {
         return 'Input value is too high!';
       }
 
-      if (btcToDotRate.toBig().eq(0)) {
+      if (isOracleOffline) {
         return t('error_oracle_offline', { action: 'redeem', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL });
       }
 
@@ -337,6 +337,9 @@ const RedeemForm = (): JSX.Element | null => {
       getTokenPrice(prices, ForeignAssetIdLiteral.BTC)?.usd
     );
     const accountSet = !!address;
+
+    // `btcToDotRate` has 0 value only if oracle call fails
+    const isOracleOffline = btcToDotRate.toBig().eq(0);
 
     return (
       <>

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -75,7 +75,8 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
     formState: { errors },
     watch,
     trigger,
-    setValue
+    setValue,
+    setError
   } = useForm<RequestIssueFormData>({
     mode: 'onChange'
   });
@@ -150,18 +151,23 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
         if (theDustValue.status === 'fulfilled') {
           setDustValue(theDustValue.value);
         }
-        if (theBtcToGovernanceToken.status === 'fulfilled') {
-          setBTCToGovernanceTokenRate(theBtcToGovernanceToken.value);
-        }
         if (issuableAmount.status === 'fulfilled') {
           setVaultCapacity(issuableAmount.value);
+        }
+        if (theBtcToGovernanceToken.status === 'fulfilled') {
+          setBTCToGovernanceTokenRate(theBtcToGovernanceToken.value);
+        } else {
+          setError(WRAPPED_TOKEN_AMOUNT, {
+            type: 'validate',
+            message: t('error_oracle_offline', { action: 'issue', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL })
+          });
         }
       } catch (error) {
         setStatus(STATUSES.REJECTED);
         handleError(error);
       }
     })();
-  }, [collateralIdLiteral, bridgeLoaded, handleError, vaultAccountId]);
+  }, [collateralIdLiteral, bridgeLoaded, handleError, vaultAccountId, setError, t]);
 
   if (
     status === STATUSES.IDLE ||
@@ -237,6 +243,10 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
 
     if (btcAmount === undefined) {
       return 'Invalid BTC amount input!';
+    }
+
+    if (btcToGovernanceTokenRate.toBig().eq(0)) {
+      return t('error_oracle_offline', { action: 'issue', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL });
     }
 
     return undefined;

--- a/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
+++ b/src/pages/Vaults/Vault/RequestIssueModal/index.tsx
@@ -245,7 +245,7 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
       return 'Invalid BTC amount input!';
     }
 
-    if (btcToGovernanceTokenRate.toBig().eq(0)) {
+    if (isOracleOffline) {
       return t('error_oracle_offline', { action: 'issue', wrappedTokenSymbol: WRAPPED_TOKEN_SYMBOL });
     }
 
@@ -269,6 +269,9 @@ const RequestIssueModal = ({ onClose, open, collateralIdLiteral, vaultAddress }:
   const bridgeFee = parsedBTCAmount.mul(feeRate);
   const securityDeposit = btcToGovernanceTokenRate.toCounter(parsedBTCAmount).mul(depositRate);
   const wrappedTokenAmount = parsedBTCAmount.sub(bridgeFee);
+
+  // `btcToGovernanceTokenRate` has 0 value only if oracle call is unsuccessful
+  const isOracleOffline = btcToGovernanceTokenRate.toBig().eq(0);
 
   return (
     <>


### PR DESCRIPTION
Handling the oracle being offline. Instead of throwing an error on rejection, informative error message is displayed under the BTC and wrapped BTC amount input element in the Issue and Redeem pages, respectively.
![image](https://user-images.githubusercontent.com/47864599/182624899-44a0ebee-a5d3-4b2d-879b-6a2a3f3c89ff.png)
