### PR TITLE
fix: get thresholds for supported collaterals only

### DIFF
--- a/src/config/vaults.ts
+++ b/src/config/vaults.ts
@@ -8,7 +8,7 @@ let VAULT_GOVERNANCE: GovernanceIdLiteral;
 
 switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
   case POLKADOT: {
-    VAULT_COLLATERAL = [CurrencyIdLiteral.DOT, CurrencyIdLiteral.INTR];
+    VAULT_COLLATERAL = [CurrencyIdLiteral.DOT];
     VAULT_WRAPPED = CurrencyIdLiteral.INTERBTC;
     VAULT_GOVERNANCE = CurrencyIdLiteral.INTR;
     break;

--- a/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
@@ -29,6 +29,7 @@ import {
   RELAY_CHAIN_NATIVE_TOKEN,
   RELAY_CHAIN_NATIVE_TOKEN_SYMBOL
 } from '@/config/relay-chains';
+import { VAULT_COLLATERAL } from '@/config/vaults';
 import * as constants from '@/constants';
 import SectionTitle from '@/parts/SectionTitle';
 import genericFetcher, { GENERIC_FETCHER } from '@/services/fetchers/generic-fetcher';
@@ -37,9 +38,7 @@ import { BTCToCollateralTokenRate } from '@/types/currency';
 import { PAGES, URL_PARAMETERS } from '@/utils/constants/links';
 import { getColorShade } from '@/utils/helpers/colors';
 import { getCollateralization, getVaultStatusLabel } from '@/utils/helpers/vaults';
-
-import { VAULT_COLLATERAL } from '../../../../../config/vaults';
-import { useGetCollateralThresholds } from '../../../../../utils/hooks/api/use-get-collateral-thresholds';
+import { useGetCollateralThresholds } from '@/utils/hooks/api/use-get-collateral-thresholds';
 
 interface CollateralizationCellProps {
   settledCollateralization: Big | undefined;

--- a/src/pages/Dashboard/sub-pages/Vaults/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/config/relay-chains';
 import PageTitle from '@/parts/PageTitle';
 import TimerIncrement from '@/parts/TimerIncrement';
+import { KUSAMA } from '@/utils/constants/relay-chain-names';
 import { getTokenPrice } from '@/utils/helpers/prices';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
 
@@ -27,6 +28,7 @@ const Vaults = (): JSX.Element => {
   const relayChainNativeTokenPriceInUSD = getTokenPrice(prices, RELAY_CHAIN_NATIVE_TOKEN_SYMBOL)?.usd;
   const governanceTokenPriceInUSD = getTokenPrice(prices, GOVERNANCE_TOKEN_SYMBOL)?.usd;
 
+  // TODO: Refactor to use vault config as a source for supported collateral currencies
   const collaterals = React.useMemo(
     () => [
       {
@@ -34,11 +36,15 @@ const Vaults = (): JSX.Element => {
         collateralTokenSymbol: RELAY_CHAIN_NATIVE_TOKEN_SYMBOL,
         collateralTokenPriceInUSD: relayChainNativeTokenPriceInUSD
       },
-      {
-        collateralToken: GOVERNANCE_TOKEN as CollateralToken,
-        collateralTokenSymbol: GOVERNANCE_TOKEN_SYMBOL,
-        collateralTokenPriceInUSD: governanceTokenPriceInUSD
-      }
+      ...(process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA
+        ? [
+            {
+              collateralToken: GOVERNANCE_TOKEN as CollateralToken,
+              collateralTokenSymbol: GOVERNANCE_TOKEN_SYMBOL,
+              collateralTokenPriceInUSD: governanceTokenPriceInUSD
+            }
+          ]
+        : [])
     ],
     [relayChainNativeTokenPriceInUSD, governanceTokenPriceInUSD]
   );

--- a/src/utils/hooks/api/use-get-collateral-thresholds.tsx
+++ b/src/utils/hooks/api/use-get-collateral-thresholds.tsx
@@ -7,7 +7,7 @@ import {
 import Big from 'big.js';
 import { useQuery, UseQueryResult } from 'react-query';
 
-import { VAULT_COLLATERAL } from '../../../config/vaults';
+import { VAULT_COLLATERAL } from '@/config/vaults';
 
 // TODO: Refactor with currencies update
 type AllCollateralThresholds = { [currencySymbol in CollateralIdLiteral]: CollateralThresholds };

--- a/src/utils/hooks/api/use-get-collateral-thresholds.tsx
+++ b/src/utils/hooks/api/use-get-collateral-thresholds.tsx
@@ -1,0 +1,56 @@
+import {
+  CollateralCurrency,
+  CollateralIdLiteral,
+  CollateralUnit,
+  currencyIdLiteralToMonetaryCurrency
+} from '@interlay/interbtc-api';
+import Big from 'big.js';
+import { useQuery, UseQueryResult } from 'react-query';
+
+import { VAULT_COLLATERAL } from '../../../config/vaults';
+
+// TODO: Refactor with currencies update
+type AllCollateralThresholds = { [currencySymbol in CollateralIdLiteral]: CollateralThresholds };
+
+type CollateralThresholds = {
+  liquidationThreshold: Big;
+  secureThreshold: Big;
+};
+
+const getThresholds = async (collateralCurrencyLiteral: CollateralIdLiteral): Promise<CollateralThresholds> => {
+  try {
+    // TODO: Need to refactor this after currency updates are merged.
+    const currency = currencyIdLiteralToMonetaryCurrency<CollateralUnit>(
+      window.bridge.api,
+      collateralCurrencyLiteral
+    ) as CollateralCurrency;
+
+    const liquidationThreshold = await window.bridge.vaults.getLiquidationCollateralThreshold(currency);
+    const secureThreshold = await window.bridge.vaults.getSecureCollateralThreshold(currency);
+
+    return { liquidationThreshold, secureThreshold };
+  } catch {
+    throw new Error(`useGetCollateralThresholds: error getting thresholds for currency ${collateralCurrencyLiteral}.`);
+  }
+};
+
+const getAllThresholds = async (): Promise<AllCollateralThresholds> => {
+  const collateralIdLiterals = VAULT_COLLATERAL;
+  const allThresholds = await Promise.all(
+    collateralIdLiterals.map((collateralIdLiteral) => getThresholds(collateralIdLiteral))
+  );
+  // TODO: handle types properly
+  return allThresholds.reduce(
+    (result, thresholds, index) => ({
+      ...result,
+      [collateralIdLiterals[index]]: thresholds
+    }),
+    {}
+  ) as AllCollateralThresholds;
+};
+
+const useGetCollateralThresholds = (bridgeLoaded: boolean): UseQueryResult<AllCollateralThresholds> => {
+  return useQuery({ queryKey: 'getAllThresholds', queryFn: getAllThresholds, enabled: bridgeLoaded });
+};
+
+export { useGetCollateralThresholds };


### PR DESCRIPTION
Fix to get threshold limits only for supported collateral threshold currencies in the VaultTable.