### PR TITLE
refactor: change displayed active block numbers to absolute parachain block numbers

### DIFF
--- a/src/components/IssueUI/IssueRequestStatusUI/CompletedIssueRequest/index.tsx
+++ b/src/components/IssueUI/IssueRequestStatusUI/CompletedIssueRequest/index.tsx
@@ -32,7 +32,7 @@ const CompletedIssueRequest = ({ request }: Props): JSX.Element => {
       </p>
       <Ring48 className={getColorShade('green', 'ring')}>
         <Ring48Title>{t('issue_page.in_parachain_block')}</Ring48Title>
-        <Ring48Value className={getColorShade('green')}>{request.execution.height.active}</Ring48Value>
+        <Ring48Value className={getColorShade('green')}>{request.execution.height.absolute}</Ring48Value>
       </Ring48>
       <ExternalLink className='text-sm' href={getPolkadotLink(request.execution.height.absolute)}>
         {t('issue_page.view_parachain_block')}

--- a/src/components/IssueUI/index.tsx
+++ b/src/components/IssueUI/index.tsx
@@ -137,7 +137,7 @@ const IssueUI = ({ issue }: Props): JSX.Element => {
             >
               {t('issue_page.parachain_block')}
             </span>
-            <span className='font-medium'>{issue.request.height.active}</span>
+            <span className='font-medium'>{issue.request.height.absolute}</span>
           </div>
           <div className={clsx('flex', 'justify-between')}>
             <span

--- a/src/components/RedeemUI/RedeemRequestStatusUI/CompletedRedeemRequest/index.tsx
+++ b/src/components/RedeemUI/RedeemRequestStatusUI/CompletedRedeemRequest/index.tsx
@@ -28,7 +28,7 @@ const CompletedRedeemRequest = ({ redeem }: Props): JSX.Element => {
       </p>
       <Ring48 className={getColorShade('green', 'ring')}>
         <Ring48Title>{t('issue_page.in_parachain_block')}</Ring48Title>
-        <Ring48Value className={getColorShade('green')}>{redeem.request.height.active}</Ring48Value>
+        <Ring48Value className={getColorShade('green')}>{redeem.request.height.absolute}</Ring48Value>
       </Ring48>
       <ExternalLink className='text-sm' href={getPolkadotLink(redeem.request.height.absolute)}>
         {t('issue_page.view_parachain_block')}

--- a/src/components/RedeemUI/index.tsx
+++ b/src/components/RedeemUI/index.tsx
@@ -136,7 +136,7 @@ const RedeemUI = ({ redeem, onClose }: Props): JSX.Element => {
             >
               {t('issue_page.parachain_block')}
             </span>
-            <span className='font-medium'>{redeem.request.height.active}</span>
+            <span className='font-medium'>{redeem.request.height.absolute}</span>
           </div>
           <div className={clsx('flex', 'justify-between')}>
             <span

--- a/src/pages/Dashboard/sub-pages/IssueRequests/IssueRequestsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/IssueRequests/IssueRequestsTable/index.tsx
@@ -73,11 +73,11 @@ const IssueRequestsTable = (): JSX.Element => {
         Cell: function FormattedCell({ row: { original: issue } }: any) {
           let height;
           if (issue.execution) {
-            height = issue.execution.height.active;
+            height = issue.execution.height.absolute;
           } else if (issue.cancellation) {
-            height = issue.cancellation.height.active;
+            height = issue.cancellation.height.absolute;
           } else {
-            height = issue.request.height.active;
+            height = issue.request.height.absolute;
           }
 
           return <>{height}</>;

--- a/src/pages/Dashboard/sub-pages/RedeemRequests/RedeemRequestsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/RedeemRequests/RedeemRequestsTable/index.tsx
@@ -73,11 +73,11 @@ const RedeemRequestsTable = (): JSX.Element => {
         Cell: function FormattedCell({ row: { original: redeem } }: any) {
           let height;
           if (redeem.execution) {
-            height = redeem.execution.height.active;
+            height = redeem.execution.height.absolute;
           } else if (redeem.cancellation) {
-            height = redeem.cancellation.height.active;
+            height = redeem.cancellation.height.absolute;
           } else {
-            height = redeem.request.height.active;
+            height = redeem.request.height.absolute;
           }
 
           return <>{height}</>;

--- a/src/pages/Vaults/Vault/VaultIssueRequestsTable/index.tsx
+++ b/src/pages/Vaults/Vault/VaultIssueRequestsTable/index.tsx
@@ -124,7 +124,7 @@ const VaultIssueRequestsTable = ({ vaultAddress, collateralId }: Props): JSX.Ele
         classNames: ['text-right'],
         // TODO: should type properly (`Relay`)
         Cell: function FormattedCell({ row: { original: issue } }: any) {
-          return <>{issue.request.height.active}</>;
+          return <>{issue.request.height.absolute}</>;
         }
       },
       {
@@ -151,11 +151,11 @@ const VaultIssueRequestsTable = ({ vaultAddress, collateralId }: Props): JSX.Ele
         Cell: function FormattedCell({ row: { original: issue } }: any) {
           let height;
           if (issue.execution) {
-            height = issue.execution.height.active;
+            height = issue.execution.height.absolute;
           } else if (issue.cancellation) {
-            height = issue.cancellation.height.active;
+            height = issue.cancellation.height.absolute;
           } else {
-            height = issue.request.height.active;
+            height = issue.request.height.absolute;
           }
 
           return <>{height}</>;

--- a/src/pages/Vaults/Vault/VaultRedeemRequestsTable/index.tsx
+++ b/src/pages/Vaults/Vault/VaultRedeemRequestsTable/index.tsx
@@ -127,7 +127,7 @@ const VaultRedeemRequestsTable = ({ vaultAddress, collateralId }: Props): JSX.El
         classNames: ['text-right'],
         // TODO: should type properly (`Relay`)
         Cell: function FormattedCell({ row: { original: redeem } }: any) {
-          return <>{redeem.request.height.active}</>;
+          return <>{redeem.request.height.absolute}</>;
         }
       },
       {
@@ -154,11 +154,11 @@ const VaultRedeemRequestsTable = ({ vaultAddress, collateralId }: Props): JSX.El
         Cell: function FormattedCell({ row: { original: issue } }: any) {
           let height;
           if (issue.execution) {
-            height = issue.execution.height.active;
+            height = issue.execution.height.absolute;
           } else if (issue.cancellation) {
-            height = issue.cancellation.height.active;
+            height = issue.cancellation.height.absolute;
           } else {
-            height = issue.request.height.active;
+            height = issue.request.height.absolute;
           }
 
           return <>{height}</>;


### PR DESCRIPTION
Changing the displayed block numbers from active block numbers to absolute parachain block numbers.

Diff: **Creation Block** and **Last Update Block** columns

Before
![image](https://user-images.githubusercontent.com/47864599/183934713-af8602c6-25a9-45e6-a3e3-cafbfaab51cf.png)

After
![image](https://user-images.githubusercontent.com/47864599/183934501-a6a41daa-89f1-41e9-9fdd-e5b59ff95adb.png)
