### PR TITLE
fix(Modal): styles and accessibility

### DIFF
--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -23,6 +23,7 @@ const ModalOverlay = styled.div`
   position: absolute;
   width: 100vw;
   height: 100vh;
+  background: ${theme.overlay.bg};
 `;
 
 const ModalContent = styled.div<ModalContentProps>`
@@ -32,7 +33,7 @@ const ModalContent = styled.div<ModalContentProps>`
   max-width: 32em;
   margin: 1.5em;
   background: ${theme.colors.bgPrimary};
-  padding: ${theme.spacing.spacing4};
+  padding: ${theme.spacing.spacing8};
   border-radius: ${theme.rounded.md};
   color: ${theme.colors.textPrimary};
   transition: opacity ${theme.transition.duration}ms ease-out;
@@ -42,13 +43,14 @@ const ModalContent = styled.div<ModalContentProps>`
 `;
 
 const CloseIcon = styled.button`
+  display: inline-flex;
   position: absolute;
   top: 0.5em;
   right: 0.5em;
   background: none;
   color: inherit;
   border: none;
-  padding: 0;
+  padding: ${theme.spacing.spacing1};
   font: inherit;
   cursor: pointer;
   outline: inherit;

--- a/src/component-library/Modal/Modal.tsx
+++ b/src/component-library/Modal/Modal.tsx
@@ -13,6 +13,7 @@ interface ModalProps {
   initialFocusRef?: MutableRefObject<HTMLElement | null>;
 }
 
+// TODO: we have missing relevant behaviours for a Modal. Could be rewritten with react-aria.
 const Modal = ({ open, onClose, children, initialFocusRef }: ModalProps): JSX.Element | null => {
   const { shouldRender, transitionTrigger } = useMountTransition(open, theme.transition.duration);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -39,10 +40,10 @@ const Modal = ({ open, onClose, children, initialFocusRef }: ModalProps): JSX.El
 
   return open || shouldRender ? (
     <Portal>
-      <ModalContainer>
+      <ModalContainer role='dialog'>
         <ModalOverlay onClick={onClose} />
         <ModalContent transitionTrigger={transitionTrigger}>
-          <CloseIcon onClick={onClose} ref={closeButtonRef}>
+          <CloseIcon aria-label='Dismiss' onClick={onClose} ref={closeButtonRef}>
             <Icon variant='close' />
           </CloseIcon>
           {children}

--- a/src/component-library/theme/theme.ts
+++ b/src/component-library/theme/theme.ts
@@ -136,6 +136,9 @@ const theme = {
       color: 'var(--colors-indeterminate-color)',
       bg: 'var(--colors-indeterminate-bg)'
     }
+  },
+  overlay: {
+    bg: 'var(--colors-neutral-black-20)'
   }
 };
 


### PR DESCRIPTION
- close button miss aria-label and small size (hard to click on mobile)
- modal content wrapper `role` missing
- standardise modal padding according to Jay designs
- add missing overlay


In the future we need to improve styles and maybe implement `react-aria` and `react-stately` because there are some missing features