### PR TITLE
fix: show APR instead of APY

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -46,7 +46,7 @@
   "update": "Update",
   "collateralization": "Collateralization",
   "fees_earned": "Fees earned",
-  "apy": "APY",
+  "apy": "APR",
   "here": "here",
   "refresh_page.": "Once you create a new account please refresh the page.",
   "btc_relay_status": "BTC Relay Status:",

--- a/src/component-library/VaultCard/VaultCard.tsx
+++ b/src/component-library/VaultCard/VaultCard.tsx
@@ -48,7 +48,7 @@ const VaultCard = ({
       </StyledDl>
       <StyledDl>
         <DlItem>
-          <dt>Current APY</dt>
+          <dt>Current APR</dt>
           <dd>≈{apy}%</dd>
         </DlItem>
         <DlItem>

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -832,9 +832,9 @@ const Staking = (): JSX.Element => {
               />
             )}
             <InformationUI
-              label='Estimated APY'
+              label='Estimated APR'
               value={renderEstimatedAPYLabel()}
-              tooltip={`The APY may change as the amount of total ${VOTE_GOVERNANCE_TOKEN_SYMBOL} changes.`}
+              tooltip={`The APR may change as the amount of total ${VOTE_GOVERNANCE_TOKEN_SYMBOL} changes.`}
             />
             <InformationUI
               label={`Estimated ${GOVERNANCE_TOKEN_SYMBOL} Rewards`}


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Quick replace of only the places where we display "APY", still need to change variable names etc..