### PR TITLE
Vault dashboard issue requests modal

### DIFF
--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
@@ -37,7 +37,7 @@ const StyledTable = styled(Table)`
   text-align: left;
   margin-top: ${theme.spacing.spacing4};
 
-  /* TODO: better solution for this */
+  /* TODO: better solution for this. Require UX input on hover state */
   tr:hover {
     cursor: pointer;
   }

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
@@ -9,6 +9,14 @@ const StyledWrapper = styled(Card)`
   align-items: center;
 `;
 
+const StyledLink = styled.div`
+  color: hotpink;
+  cursor: pointer;
+  &:hover {
+    color: deepskyblue;
+  }
+`;
+
 const StyledStack = styled(Stack)`
   width: 100%;
   text-align: right;
@@ -61,6 +69,7 @@ const StyledTableWrapper = styled.div`
 
 export {
   StyledDate,
+  StyledLink,
   StyledRequest,
   StyledRequestCell,
   StyledStack,

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
@@ -9,14 +9,6 @@ const StyledWrapper = styled(Card)`
   align-items: center;
 `;
 
-const StyledLink = styled.div`
-  color: hotpink;
-  cursor: pointer;
-  &:hover {
-    color: deepskyblue;
-  }
-`;
-
 const StyledStack = styled(Stack)`
   width: 100%;
   text-align: right;
@@ -69,7 +61,6 @@ const StyledTableWrapper = styled.div`
 
 export {
   StyledDate,
-  StyledLink,
   StyledRequest,
   StyledRequestCell,
   StyledStack,

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
@@ -36,6 +36,11 @@ const StyledStatus = styled.div`
 const StyledTable = styled(Table)`
   text-align: left;
   margin-top: ${theme.spacing.spacing4};
+
+  /* TODO: better solution for this */
+  tr:hover {
+    cursor: pointer;
+  }
 `;
 
 const StyledRequestCell = styled.div`

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.styles.tsx
@@ -37,7 +37,8 @@ const StyledTable = styled(Table)`
   text-align: left;
   margin-top: ${theme.spacing.spacing4};
 
-  /* TODO: better solution for this. Require UX input on hover state */
+  /* TODO: better solution for this. Require UX input on hover state.
+  Should be handled in the component, not the application. */
   tr:hover {
     cursor: pointer;
   }

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
@@ -21,7 +21,6 @@ const tabKeys = ['all', 'pending', 'issue', 'redeem', 'replace'] as const;
 const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
   const { t } = useTranslation();
   const titleId = useId();
-
   const [filteredTransactionData, setFilteredTransactiondata] = useState<Array<TransactionTableData>>(
     props.transactions
   );

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
@@ -3,6 +3,7 @@ import { HTMLAttributes, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { CTALink, TabsItem } from '@/component-library';
+import IssueRequestModal from '@/pages/Transactions/IssueRequestsTable/IssueRequestModal';
 import { PAGES } from '@/utils/constants/links';
 
 import { StyledStack, StyledTableWrapper, StyledTabs, StyledTitle, StyledWrapper } from './TransactionHistory.styles';
@@ -25,6 +26,13 @@ const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
     props.transactions
   );
   const [tab, setTab] = useState<string>('all');
+  const [selectedIssueRequest, setSelectedIssueRequest] = useState('');
+
+  console.log('selectedIssueRequest', selectedIssueRequest);
+
+  const handleIssueModalClose = () => {
+    setSelectedIssueRequest('');
+  };
 
   useEffect(() => {
     if (tab === 'all') {
@@ -38,7 +46,7 @@ const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
 
   const table = (
     <StyledTableWrapper>
-      <TransactionTable aria-labelledby={titleId} data={filteredTransactionData} />
+      <TransactionTable callBack={setSelectedIssueRequest} aria-labelledby={titleId} data={filteredTransactionData} />
     </StyledTableWrapper>
   );
 
@@ -61,6 +69,13 @@ const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
           </CTALink>
         </StyledStack>
       </StyledWrapper>
+      {selectedIssueRequest && (
+        <IssueRequestModal
+          open={!!selectedIssueRequest}
+          onClose={handleIssueModalClose}
+          request={selectedIssueRequest}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
@@ -22,10 +22,10 @@ const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
   const { t } = useTranslation();
   const titleId = useId();
 
-  const [tab, setTab] = useState<string>('all');
   const [filteredTransactionData, setFilteredTransactiondata] = useState<Array<TransactionTableData>>(
     props.transactions
   );
+  const [tab, setTab] = useState<string>('all');
 
   useEffect(() => {
     if (tab === 'all') {

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionHistory.tsx
@@ -3,7 +3,6 @@ import { HTMLAttributes, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { CTALink, TabsItem } from '@/component-library';
-import IssueRequestModal from '@/pages/Transactions/IssueRequestsTable/IssueRequestModal';
 import { PAGES } from '@/utils/constants/links';
 
 import { StyledStack, StyledTableWrapper, StyledTabs, StyledTitle, StyledWrapper } from './TransactionHistory.styles';
@@ -22,17 +21,11 @@ const tabKeys = ['all', 'pending', 'issue', 'redeem', 'replace'] as const;
 const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
   const { t } = useTranslation();
   const titleId = useId();
+
+  const [tab, setTab] = useState<string>('all');
   const [filteredTransactionData, setFilteredTransactiondata] = useState<Array<TransactionTableData>>(
     props.transactions
   );
-  const [tab, setTab] = useState<string>('all');
-  const [selectedIssueRequest, setSelectedIssueRequest] = useState('');
-
-  console.log('selectedIssueRequest', selectedIssueRequest);
-
-  const handleIssueModalClose = () => {
-    setSelectedIssueRequest('');
-  };
 
   useEffect(() => {
     if (tab === 'all') {
@@ -46,7 +39,7 @@ const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
 
   const table = (
     <StyledTableWrapper>
-      <TransactionTable callBack={setSelectedIssueRequest} aria-labelledby={titleId} data={filteredTransactionData} />
+      <TransactionTable aria-labelledby={titleId} data={filteredTransactionData} />
     </StyledTableWrapper>
   );
 
@@ -69,13 +62,6 @@ const TransactionHistory = (props: TransactionHistoryProps): JSX.Element => {
           </CTALink>
         </StyledStack>
       </StyledWrapper>
-      {selectedIssueRequest && (
-        <IssueRequestModal
-          open={!!selectedIssueRequest}
-          onClose={handleIssueModalClose}
-          request={selectedIssueRequest}
-        />
-      )}
     </>
   );
 };

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionStatusTag.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionStatusTag.tsx
@@ -5,12 +5,13 @@ import { Status } from '@/component-library/utils/prop-types';
 
 import { StatusTag, StatusTagProps } from '../StatusTag';
 
-type TransactionStatus = 'pending' | 'completed' | 'cancelled' | 'retried';
+type TransactionStatus = 'pending' | 'cancelled' | 'completed' | 'confirmed' | 'retried';
 
 const transactionStatus: Record<TransactionStatus, Status> = {
   pending: 'warning',
-  completed: 'success',
   cancelled: 'error',
+  completed: 'success',
+  confirmed: 'warning',
   retried: 'error'
 } as const;
 

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionStatusTag.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionStatusTag.tsx
@@ -13,7 +13,7 @@ const transactionStatus: Record<TransactionStatus, Status> = {
   completed: 'success',
   confirmed: 'warning',
   received: 'success',
-  retried: 'error'
+  retried: 'success'
 } as const;
 
 type Props = {

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionStatusTag.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionStatusTag.tsx
@@ -5,13 +5,14 @@ import { Status } from '@/component-library/utils/prop-types';
 
 import { StatusTag, StatusTagProps } from '../StatusTag';
 
-type TransactionStatus = 'pending' | 'cancelled' | 'completed' | 'confirmed' | 'retried';
+type TransactionStatus = 'pending' | 'cancelled' | 'completed' | 'confirmed' | 'received' | 'retried';
 
 const transactionStatus: Record<TransactionStatus, Status> = {
   pending: 'warning',
   cancelled: 'error',
   completed: 'success',
   confirmed: 'warning',
+  received: 'success',
   retried: 'error'
 } as const;
 

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -41,7 +41,6 @@ const RequestCell = ({ request, date }: any) => (
 const TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Element => {
   const [selectedTableRow, setSelectedTableRow] = useState<any>(undefined);
 
-  // TODO: add type here
   const rows = data.map(({ request, amount, requestData, date, status }, key) => ({
     id: key,
     amount,

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -41,6 +41,7 @@ const RequestCell = ({ request, date }: any) => (
 const TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Element => {
   const [selectedTableRow, setSelectedTableRow] = useState<any>(undefined);
 
+  // TODO: add type here
   const rows = data.map(({ request, amount, requestData, date, status }, key) => ({
     id: key,
     amount,

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, useEffect, useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 
 import IssueRequestModal from '@/pages/Transactions/IssueRequestsTable/IssueRequestModal';
 import RedeemRequestModal from '@/pages/Transactions/RedeemRequestsTable/RedeemRequestModal';
@@ -50,17 +50,14 @@ const TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Elemen
     status: <TransactionStatusTag status={status} />
   }));
 
-  const handleRowAction = (key: React.Key) => {
-    setSelectedTableRow(rows.find((row) => row.id === key));
-  };
-
-  useEffect(() => {
-    console.log(selectedTableRow);
-  }, [selectedTableRow]);
-
   return (
     <>
-      <StyledTable onRowAction={(key) => handleRowAction(key)} columns={columns} rows={rows} {...props} />
+      <StyledTable
+        onRowAction={(key) => setSelectedTableRow(rows.find((row) => row.id === key))}
+        columns={columns}
+        rows={rows}
+        {...props}
+      />
       {/* TODO: these modals should be refactored/replaced */}
       {selectedTableRow?.type === 'Issue' && (
         <IssueRequestModal

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useState } from 'react';
+import React, { HTMLAttributes, useEffect, useState } from 'react';
 
 import IssueRequestModal from '@/pages/Transactions/IssueRequestsTable/IssueRequestModal';
 import RedeemRequestModal from '@/pages/Transactions/RedeemRequestsTable/RedeemRequestModal';
@@ -39,33 +39,41 @@ const RequestCell = ({ request, date }: any) => (
 );
 
 const TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Element => {
-  const [selectedRequest, setSelectedRequest] = useState<{ type: string; data: any } | undefined>(undefined);
+  const [selectedTableRow, setSelectedTableRow] = useState<any>(undefined);
 
-  const rows = data.map(({ request, requestData, amount, date, status }, key) => ({
+  const rows = data.map(({ request, amount, requestData, date, status }, key) => ({
     id: key,
     amount,
+    requestData,
+    type: request,
     request: <RequestCell request={request} date={date} />,
-    status: (
-      <TransactionStatusTag onClick={() => setSelectedRequest({ type: request, data: requestData })} status={status} />
-    )
+    status: <TransactionStatusTag status={status} />
   }));
+
+  const handleRowAction = (key: React.Key) => {
+    setSelectedTableRow(rows.find((row) => row.id === key));
+  };
+
+  useEffect(() => {
+    console.log(selectedTableRow);
+  }, [selectedTableRow]);
 
   return (
     <>
-      <StyledTable columns={columns} rows={rows} {...props} />
+      <StyledTable onRowAction={(key) => handleRowAction(key)} columns={columns} rows={rows} {...props} />
       {/* TODO: these modals should be refactored/replaced */}
-      {selectedRequest?.type === 'Issue' && (
+      {selectedTableRow?.type === 'Issue' && (
         <IssueRequestModal
-          open={selectedRequest.type === 'Issue'}
-          onClose={() => setSelectedRequest(undefined)}
-          request={selectedRequest.data}
+          open={selectedTableRow.type === 'Issue'}
+          onClose={() => setSelectedTableRow(undefined)}
+          request={selectedTableRow.requestData}
         />
       )}
-      {selectedRequest?.type === 'Redeem' && (
+      {selectedTableRow?.type === 'Redeem' && (
         <RedeemRequestModal
-          open={selectedRequest.type === 'Redeem'}
-          onClose={() => setSelectedRequest(undefined)}
-          request={selectedRequest.data}
+          open={selectedTableRow.type === 'Redeem'}
+          onClose={() => setSelectedTableRow(undefined)}
+          request={selectedTableRow.requestData}
         />
       )}
       ;

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -10,13 +10,16 @@ const columns = [
 ];
 
 type TransactionTableData = {
+  id: string;
   request: string;
   date: string;
   amount: string;
   status: TransactionStatus;
+  requestData: any;
 };
 
 type Props = {
+  callBack: (data: any) => void;
   data: TransactionTableData[];
 };
 
@@ -32,11 +35,11 @@ const RequestCell = ({ request, date }: any) => (
 );
 
 const _TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Element => {
-  const rows = data.map(({ request, amount, date, status }, key) => ({
+  const rows = data.map(({ request, requestData, amount, date, status }, key) => ({
     id: key,
     amount,
     request: <RequestCell request={request} date={date} />,
-    status: <TransactionStatusTag status={status} />
+    status: <TransactionStatusTag onClick={() => props.callBack(requestData)} status={status} />
   }));
 
   return <StyledTable columns={columns} rows={rows} {...props} />;

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useEffect, useState } from 'react';
+import { HTMLAttributes, useState } from 'react';
 
 import IssueRequestModal from '@/pages/Transactions/IssueRequestsTable/IssueRequestModal';
 import RedeemRequestModal from '@/pages/Transactions/RedeemRequestsTable/RedeemRequestModal';
@@ -41,14 +41,6 @@ const RequestCell = ({ request, date }: any) => (
 const TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Element => {
   const [selectedRequest, setSelectedRequest] = useState<{ type: string; data: any } | undefined>(undefined);
 
-  const handleIssueModalClose = () => {
-    setSelectedRequest(undefined);
-  };
-
-  useEffect(() => {
-    console.log(selectedRequest);
-  }, [selectedRequest]);
-
   const rows = data.map(({ request, requestData, amount, date, status }, key) => ({
     id: key,
     amount,
@@ -65,14 +57,14 @@ const TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Elemen
       {selectedRequest?.type === 'Issue' && (
         <IssueRequestModal
           open={selectedRequest.type === 'Issue'}
-          onClose={handleIssueModalClose}
+          onClose={() => setSelectedRequest(undefined)}
           request={selectedRequest.data}
         />
       )}
       {selectedRequest?.type === 'Redeem' && (
         <RedeemRequestModal
           open={selectedRequest.type === 'Redeem'}
-          onClose={handleIssueModalClose}
+          onClose={() => setSelectedRequest(undefined)}
           request={selectedRequest.data}
         />
       )}

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes, memo } from 'react';
 
-import { StyledDate, StyledRequest, StyledRequestCell, StyledTable } from './TransactionHistory.styles';
+import { StyledDate, StyledLink, StyledRequest, StyledRequestCell, StyledTable } from './TransactionHistory.styles';
 import { TransactionStatus, TransactionStatusTag } from './TransactionStatusTag';
 
 const columns = [
@@ -27,9 +27,11 @@ type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
 
 type TransactionTableProps = Props & NativeAttrs;
 
-const RequestCell = ({ request, date }: any) => (
+const RequestCell = ({ request, date, requestData, callBack }: any) => (
   <StyledRequestCell>
-    <StyledRequest>{request}</StyledRequest>
+    <StyledRequest onClick={() => callBack(requestData)}>
+      {requestData ? <StyledLink>{request}</StyledLink> : requestData}
+    </StyledRequest>
     <StyledDate color='tertiary'>{date}</StyledDate>
   </StyledRequestCell>
 );
@@ -38,8 +40,8 @@ const _TransactionTable = ({ data, ...props }: TransactionTableProps): JSX.Eleme
   const rows = data.map(({ request, requestData, amount, date, status }, key) => ({
     id: key,
     amount,
-    request: <RequestCell request={request} date={date} />,
-    status: <TransactionStatusTag onClick={() => props.callBack(requestData)} status={status} />
+    request: <RequestCell requestData={requestData} callBack={props.callBack} request={request} date={date} />,
+    status: <TransactionStatusTag status={status} />
   }));
 
   return <StyledTable columns={columns} rows={rows} {...props} />;

--- a/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
+++ b/src/pages/Vaults/Vault/components/TransactionHistory/TransactionTable.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes, memo } from 'react';
 
-import { StyledDate, StyledLink, StyledRequest, StyledRequestCell, StyledTable } from './TransactionHistory.styles';
+import { StyledDate, StyledRequest, StyledRequestCell, StyledTable } from './TransactionHistory.styles';
 import { TransactionStatus, TransactionStatusTag } from './TransactionStatusTag';
 
 const columns = [
@@ -29,9 +29,7 @@ type TransactionTableProps = Props & NativeAttrs;
 
 const RequestCell = ({ request, date, requestData, callBack }: any) => (
   <StyledRequestCell>
-    <StyledRequest onClick={() => callBack(requestData)}>
-      {requestData ? <StyledLink>{request}</StyledLink> : requestData}
-    </StyledRequest>
+    <StyledRequest onClick={() => callBack(requestData)}>{request}</StyledRequest>
     <StyledDate color='tertiary'>{date}</StyledDate>
   </StyledRequestCell>
 );

--- a/src/utils/hooks/api/vaults/use-get-vault-transactions.tsx
+++ b/src/utils/hooks/api/vaults/use-get-vault-transactions.tsx
@@ -14,7 +14,8 @@ import useStableBitcoinConfirmations from '@/services/hooks/use-stable-bitcoin-c
 import useStableParachainConfirmations from '@/services/hooks/use-stable-parachain-confirmations';
 
 // TODO: Bad stuff happening here! `getIssueWithStatus` and `getRedeemWithStatus` are
-// mutating the data which is why `status` is being set in this funky way.
+// mutating the data which is why `status` is being set like this. We need to refactor
+// the modal and fetchers to handle all use cases better.
 const setIssueStatus = (status: IssueStatus) => {
   switch (status) {
     case IssueStatus.Completed:

--- a/src/utils/hooks/api/vaults/use-get-vault-transactions.tsx
+++ b/src/utils/hooks/api/vaults/use-get-vault-transactions.tsx
@@ -16,13 +16,20 @@ import useStableParachainConfirmations from '@/services/hooks/use-stable-paracha
 // TODO: Bad stuff happening here! `getIssueWithStatus` and `getRedeemWithStatus are
 // mutating the data which is why `status` is being set in this funky way.
 const setStatus = (status: IssueStatus) => {
-  return status === IssueStatus.Completed
-    ? 'completed'
-    : status === IssueStatus.Cancelled
-    ? 'cancelled'
-    : IssueStatus.Expired
-    ? 'expired'
-    : 'retried';
+  switch (status) {
+    case IssueStatus.Completed:
+      return 'completed';
+    case IssueStatus.Cancelled:
+    case IssueStatus.Expired:
+      return 'cancelled';
+    case IssueStatus.PendingWithBtcTxNotIncluded:
+    case IssueStatus.PendingWithTooFewConfirmations:
+      return 'pending';
+    case IssueStatus.PendingWithEnoughConfirmations:
+      return 'confirmed'; // yellow
+    default:
+      throw new Error('Invalid issue request status!');
+  }
 };
 
 // TODO: Issues/Redeems/ReplaceRequests types are missing

--- a/src/utils/hooks/api/vaults/use-get-vault-transactions.tsx
+++ b/src/utils/hooks/api/vaults/use-get-vault-transactions.tsx
@@ -27,7 +27,7 @@ const setIssueStatus = (status: IssueStatus) => {
     case IssueStatus.PendingWithTooFewConfirmations:
       return 'pending';
     case IssueStatus.PendingWithEnoughConfirmations:
-      return 'confirmed'; // yellow
+      return 'confirmed';
     default:
       throw new Error('Invalid issue request status!');
   }
@@ -39,9 +39,9 @@ const setRedeemStatus = (status: RedeemStatus) => {
       return 'completed';
     case RedeemStatus.PendingWithBtcTxNotFound:
       return 'pending';
-    case RedeemStatus.Reimbursed: // Reimbursed - green
+    case RedeemStatus.Reimbursed:
       return 'reimbursed';
-    case RedeemStatus.Retried: // Retried
+    case RedeemStatus.Retried:
       return 'retried';
     default:
       return 'received';


### PR DESCRIPTION
This uses the modals from the transactions table to show issue and redeem request details. This is a quick fix to get the release out; we'll review the use of the modal, and if we decide to continue with it (rather than replace it) then we will need to refactor it, and move the modal components to a shared directory.

For now though, this is an acceptable solution - we'll be reviewing the dashboard and overview implementation soon, and we can review the modal at the same time.