### PR TITLE
fix: ss58format accountId in queries

### DIFF
--- a/src/utils/hooks/api/vaults/get-vault-data.ts
+++ b/src/utils/hooks/api/vaults/get-vault-data.ts
@@ -7,6 +7,7 @@ import {
 } from '@interlay/interbtc-api';
 import { BitcoinAmount, MonetaryAmount } from '@interlay/monetary-js';
 import { AccountId } from '@polkadot/types/interfaces';
+import { encodeAddress } from "@polkadot/util-crypto"
 import Big from 'big.js';
 
 import { Prices } from '@/common/types/util.types';
@@ -19,12 +20,11 @@ import {
   WRAPPED_TOKEN_SYMBOL,
   WrappedTokenAmount
 } from '@/config/relay-chains';
-import { HYDRA_URL } from '@/constants';
+import { HYDRA_URL, SS58_FORMAT } from '@/constants';
 import issueCountQuery from '@/services/queries/issue-count-query';
 import redeemCountQuery from '@/services/queries/redeem-count-query';
 import { ForeignAssetIdLiteral } from '@/types/currency';
 import { getTokenPrice } from '@/utils/helpers/prices';
-
 interface VaultData {
   apy: Big;
   collateralization: Big | undefined;
@@ -125,6 +125,7 @@ const getVaultData = async (vault: VaultExt, accountId: AccountId, prices: Price
     wrappedTokenRewards,
     getTokenPrice(prices, WRAPPED_TOKEN_SYMBOL)?.usd
   );
+  const formattedAccountId = encodeAddress(accountId, SS58_FORMAT)
 
   // TODO: move issues and redeems to separate hook
   const issues = await fetch(HYDRA_URL, {
@@ -134,7 +135,7 @@ const getVaultData = async (vault: VaultExt, accountId: AccountId, prices: Price
     },
     body: JSON.stringify({
       query: issueCountQuery(
-        `vault: {accountId_eq: "${accountId.toString()}", collateralToken: {token_eq: ${collateralTokenIdLiteral}}}, status_eq: Pending` // TODO: add condition for asset_eq when the page is refactored for accepting ForeignAsset currencies too (cf. e.g. issued graph in dashboard for example)
+        `vault: {accountId_eq: "${formattedAccountId}", collateralToken: {token_eq: ${collateralTokenIdLiteral}}}, status_eq: Pending` // TODO: add condition for asset_eq when the page is refactored for accepting ForeignAsset currencies too (cf. e.g. issued graph in dashboard for example)
       )
     })
   });
@@ -146,7 +147,7 @@ const getVaultData = async (vault: VaultExt, accountId: AccountId, prices: Price
     },
     body: JSON.stringify({
       query: redeemCountQuery(
-        `vault: {accountId_eq: "${accountId.toString()}", collateralToken: {token_eq: ${collateralTokenIdLiteral}}}, status_eq: Pending` // TODO: add asset_eq, see comment above
+        `vault: {accountId_eq: "${formattedAccountId}", collateralToken: {token_eq: ${collateralTokenIdLiteral}}}, status_eq: Pending` // TODO: add asset_eq, see comment above
       )
     })
   });


### PR DESCRIPTION
Fixing incorrect squid queries (wrong address format) that resulted in incorrect count of pending requests in Vault Overview page.