### PR TITLE
chore: update chromatic checkout action to v2

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - uses: actions/checkout@v1
+       # 👇 Version 2 of the action
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # 👈 Required to retrieve git history
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
Updating chromatic checkout action to version 2 in order to fix deployments that are not taking into account latest changes.