### PR TITLE
feat: add vault identities

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -38,6 +38,7 @@
   "parachain_block": "Parachain Block",
   "user": "User",
   "account_id": "Account ID",
+  "identity": "Identity",
   "btc_address": "BTC Address",
   "enter_btc_address": "Enter your BTC address",
   "register": "Register",

--- a/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/VaultsTable/index.tsx
@@ -33,17 +33,20 @@ import { getColorShade } from '@/utils/helpers/colors';
 import { getCollateralization, getVaultStatusLabel } from '@/utils/helpers/vaults';
 import { useGetCollateralCurrenciesData } from '@/utils/hooks/api/use-get-collateral-currencies-data';
 import { useGetCurrencies } from '@/utils/hooks/api/use-get-currencies';
+import { useGetIdentities } from '@/utils/hooks/api/use-get-identities';
 
 interface CollateralizationCellProps {
   settledCollateralization: Big | undefined;
   unsettledCollateralization: Big | undefined;
   collateralSecureThreshold: Big;
+  collateralPremiumThreshold: Big;
 }
 
 const CollateralizationCell = ({
   settledCollateralization,
   unsettledCollateralization,
-  collateralSecureThreshold
+  collateralSecureThreshold,
+  collateralPremiumThreshold
 }: CollateralizationCellProps) => {
   const { t } = useTranslation();
 
@@ -53,14 +56,14 @@ const CollateralizationCell = ({
     return (
       <>
         <div>
-          <p className={getCollateralizationColor(settledCollateralization, collateralSecureThreshold)}>
+          <p className={getCollateralizationColor(settledCollateralization, collateralSecureThreshold, collateralPremiumThreshold)}>
             {settledCollateralization === undefined
               ? '∞'
               : formatPercentage(settledCollateralization.mul(100).toNumber())}
           </p>
           <p className='text-xs'>
             <span>{t('vault.pending_table_subcell')}</span>
-            <span className={getCollateralizationColor(unsettledCollateralization, collateralSecureThreshold)}>
+            <span className={getCollateralizationColor(unsettledCollateralization, collateralSecureThreshold, collateralPremiumThreshold)}>
               {unsettledCollateralization === undefined
                 ? '∞'
                 : formatPercentage(unsettledCollateralization.mul(100).toNumber())}
@@ -74,12 +77,17 @@ const CollateralizationCell = ({
 
 const getCollateralizationColor = (
   collateralization: Big | undefined,
-  collateralSecureThreshold: Big
+  collateralSecureThreshold: Big,
+  collateralPremiumThreshold: Big
 ): string | undefined => {
   if (collateralization === undefined) return undefined;
 
   if (collateralization.gte(collateralSecureThreshold)) {
     return clsx(getColorShade('green'), 'font-medium');
+  }
+  else if (collateralization.gte(collateralPremiumThreshold)) {
+    // Below premium redeem threshold
+    return clsx(getColorShade('yellow'), 'font-medium');
   } else {
     // Liquidation
     return clsx(getColorShade('red'), 'font-medium');
@@ -89,6 +97,7 @@ const getCollateralizationColor = (
 enum Accessor {
   VaultId = 'vaultId',
   Collateral = 'collateral',
+  Identity = 'identity',
   LockedCollateralTokenAmount = 'lockedCollateralTokenAmount',
   LockedBTCAmount = 'lockedBTCAmount',
   PendingBTCAmount = 'pendingBTCAmount',
@@ -98,6 +107,8 @@ enum Accessor {
 
 interface Vault {
   [Accessor.VaultId]: string;
+  [Accessor.Collateral]: string;
+  [Accessor.Identity]: string | undefined;
   [Accessor.LockedCollateralTokenAmount]: string;
   [Accessor.LockedBTCAmount]: BitcoinAmount;
   [Accessor.PendingBTCAmount]: string;
@@ -142,6 +153,14 @@ const VaultsTable = (): JSX.Element => {
   });
   useErrorHandler(vaultsExtError);
 
+  const {
+    isIdle: identitiesIdle,
+    isLoading: identitiesLoading,
+    data: identities,
+    error: identitiesError
+  } = useGetIdentities(bridgeLoaded);
+  useErrorHandler(identitiesError);
+
   const columns = React.useMemo(
     () => [
       {
@@ -153,9 +172,9 @@ const VaultsTable = (): JSX.Element => {
         }
       },
       {
-        Header: t('collateral'),
-        accessor: Accessor.Collateral,
-        classNames: ['text-center']
+        Header: t('identity'),
+        accessor: Accessor.Identity,
+        classNames: ['text-left']
       },
       {
         Header: t('locked_collateral'),
@@ -206,13 +225,14 @@ const VaultsTable = (): JSX.Element => {
   );
 
   const vaults: Array<Vault> | undefined = React.useMemo(() => {
-    if (vaultsExt && collateralCurrenciesData && currentActiveBlockNumber && !currenciesIdle && !currenciesLoading) {
+    if (vaultsExt && collateralCurrenciesData && currentActiveBlockNumber && !currenciesIdle && !currenciesLoading && identities) {
       const rawVaults = vaultsExt.map((vaultExt) => {
         const collateral = vaultExt.id.currencies.collateral;
         const collateralTokenSymbol = getCurrencyFromIdPrimitive(collateral).ticker;
 
         const collateralLiquidationThreshold = collateralCurrenciesData[collateralTokenSymbol].liquidationThreshold;
         const collateralSecureThreshold = collateralCurrenciesData[collateralTokenSymbol].secureThreshold;
+        const collateralPremiumThreshold = collateralCurrenciesData[collateralTokenSymbol].premiumThreshold;
         const btcToCollateralTokenRate = collateralCurrenciesData[collateralTokenSymbol].exchangeRate;
         const statusLabel = getVaultStatusLabel(
           vaultExt,
@@ -233,9 +253,12 @@ const VaultsTable = (): JSX.Element => {
           btcToCollateralTokenRate
         );
 
+        const identity = identities.get(vaultExt.id.accountId.toString());
+
         return {
           [Accessor.VaultId]: vaultExt.id.accountId.toString(),
           [Accessor.Collateral]: collateralTokenSymbol,
+          [Accessor.Identity]: identity,
           // TODO: fetch collateral reserved
           [Accessor.LockedCollateralTokenAmount]: `${displayMonetaryAmount(vaultCollateral)} ${collateralTokenSymbol}`,
           [Accessor.LockedBTCAmount]: settledTokens,
@@ -245,6 +268,7 @@ const VaultsTable = (): JSX.Element => {
               settledCollateralization={settledCollateralization}
               unsettledCollateralization={unsettledCollateralization}
               collateralSecureThreshold={collateralSecureThreshold}
+              collateralPremiumThreshold={collateralPremiumThreshold}
             />
           ),
           [Accessor.Status]: statusLabel
@@ -266,7 +290,8 @@ const VaultsTable = (): JSX.Element => {
     vaultsExt,
     currenciesIdle,
     currenciesLoading,
-    getCurrencyFromIdPrimitive
+    getCurrencyFromIdPrimitive,
+    identities
   ]);
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable({
@@ -281,7 +306,9 @@ const VaultsTable = (): JSX.Element => {
       collateralCurrenciesDataIdle ||
       collateralCurrenciesDataLoading ||
       vaultsExtIdle ||
-      vaultsExtLoading
+      vaultsExtLoading ||
+      identitiesIdle ||
+      identitiesLoading
     ) {
       return <PrimaryColorEllipsisLoader />;
     }

--- a/src/pages/Vaults/Vault/VaultDashboard.tsx
+++ b/src/pages/Vaults/Vault/VaultDashboard.tsx
@@ -12,6 +12,7 @@ import { useSubstrateSecureState } from '@/lib/substrate';
 import MainContainer from '@/parts/MainContainer';
 import { URL_PARAMETERS } from '@/utils/constants/links';
 import { useGetCurrencies } from '@/utils/hooks/api/use-get-currencies';
+import { useGetIdentities } from '@/utils/hooks/api/use-get-identities';
 import { useGetVaultData } from '@/utils/hooks/api/vaults/use-get-vault-data';
 import { useGetVaultTransactions } from '@/utils/hooks/api/vaults/use-get-vault-transactions';
 
@@ -31,11 +32,18 @@ const VaultDashboard = (): JSX.Element => {
 
   const vaultData = useGetVaultData({ address: selectedVaultAccountAddress });
   const transactions = useGetVaultTransactions(selectedVaultAccountAddress, vaultCollateral, bridgeLoaded);
+  const {
+    isIdle: identitiesIdle,
+    isLoading: identitiesLoading,
+    data: identities
+  } = useGetIdentities(bridgeLoaded);
+
   const { getCurrencyFromTicker, isSuccess: currenciesSuccess } = useGetCurrencies(bridgeLoaded);
 
   const vault = vaultData?.vaults?.find((vault: any) => vault.collateralId === vaultCollateral);
+  const displayName = identities?.get(selectedVaultAccountAddress);
 
-  if (!vault || !transactions || !currenciesSuccess) {
+  if (!vault || !transactions || !currenciesSuccess || identitiesIdle || identitiesLoading) {
     return (
       <MainContainer>
         <Stack>
@@ -89,6 +97,7 @@ const VaultDashboard = (): JSX.Element => {
           collateralAmount={vault.collateral.raw}
           vaultStatus={vault?.vaultStatus}
           vaultAddress={selectedVaultAccountAddress}
+          vaultDisplayName={displayName}
           collateralToken={collateralToken}
           lockedAmountBTC={vault.issuedTokens.amount}
           hasManageVaultBtn={!isReadOnlyVault}

--- a/src/pages/Vaults/Vault/components/VaultInfo/VaultInfo.tsx
+++ b/src/pages/Vaults/Vault/components/VaultInfo/VaultInfo.tsx
@@ -33,6 +33,7 @@ type Props = {
   collateralAmount: MonetaryAmount<CollateralCurrencyExt>;
   vaultStatus: VaultStatusExt;
   vaultAddress: string;
+  vaultDisplayName: string | undefined;
   collateralToken: CollateralCurrencyExt;
   lockedAmountBTC: Big;
   hasManageVaultBtn: boolean;
@@ -45,6 +46,7 @@ type VaultInfoProps = Props & NativeAttrs;
 const VaultInfo = ({
   vaultStatus,
   vaultAddress,
+  vaultDisplayName,
   collateralToken,
   collateralAmount,
   lockedAmountBTC,
@@ -62,6 +64,12 @@ const VaultInfo = ({
       render: (children: ReactNode) => <StatusTag status={status}>{children}</StatusTag>
     }
   ];
+
+  if (vaultDisplayName) {
+    headlineItems.push(
+      { term: 'Identity', definition: vaultDisplayName }
+    )
+  }
 
   return (
     <StyledWrapper variant='bordered' {...props}>

--- a/src/utils/hooks/api/use-get-collateral-currencies-data.tsx
+++ b/src/utils/hooks/api/use-get-collateral-currencies-data.tsx
@@ -9,18 +9,20 @@ type CollateralCurrenciesData = { [currencyTicker: string]: CollateralCurrencyDa
 
 type CollateralCurrencyData = {
   liquidationThreshold: Big;
+  premiumThreshold: Big;
   secureThreshold: Big;
   exchangeRate: ExchangeRate<Currency, CurrencyExt>;
 };
 
 const getCollateralCurrencyData = async (collateralToken: CollateralCurrencyExt): Promise<CollateralCurrencyData> => {
-  const [liquidationThreshold, secureThreshold, exchangeRate] = await Promise.all([
+  const [liquidationThreshold, premiumThreshold, secureThreshold, exchangeRate] = await Promise.all([
     window.bridge.vaults.getLiquidationCollateralThreshold(collateralToken),
+    window.bridge.vaults.getPremiumRedeemThreshold(collateralToken),
     window.bridge.vaults.getSecureCollateralThreshold(collateralToken),
     window.bridge.oracle.getExchangeRate(collateralToken)
   ]);
 
-  return { liquidationThreshold, secureThreshold, exchangeRate };
+  return { liquidationThreshold, premiumThreshold, secureThreshold, exchangeRate };
 };
 
 const getCollateralCurrenciesData = (

--- a/src/utils/hooks/api/use-get-identities.ts
+++ b/src/utils/hooks/api/use-get-identities.ts
@@ -1,0 +1,25 @@
+import { Registration } from '@polkadot/types/interfaces';
+import { encodeAddress } from '@polkadot/util-crypto';
+import { useQuery, UseQueryResult } from 'react-query';
+
+import { SS58_FORMAT } from '@/constants';
+
+// Return mapping of account id to display name
+// TODO: can return entire identity and showcase that via a component
+const getIdentities = async (): Promise<Map<string, string>> => {
+  const identities = await window.bridge.api.query.identity.identityOf.entries();
+  const accountDisplayMapping: Map<string, string> = new Map;
+  identities.forEach((identity) => {
+    const formattedAccountId = encodeAddress(identity[0].args.toString(), SS58_FORMAT);
+    const registration: Registration = identity[1].unwrap();
+    const displayName = registration.info.display.asRaw.toHuman()?.toString();
+    accountDisplayMapping.set(formattedAccountId, displayName? displayName : '');
+  });
+  return accountDisplayMapping;
+}
+
+const useGetIdentities = (bridgeLoaded: boolean): UseQueryResult<Map<string, string>> => {
+  return useQuery({ queryKey: 'getIdentities', queryFn: getIdentities, enabled: bridgeLoaded });
+};
+
+export { useGetIdentities };


### PR DESCRIPTION
Adds vault identities to the vault dashboard and the vault overview table

![image](https://user-images.githubusercontent.com/14966470/196670886-8bfa6277-41fd-4e7c-b585-115c451cb716.png)
![image](https://user-images.githubusercontent.com/14966470/196671041-0b046672-bd2d-4c25-8752-81fa2d63e710.png)

Opening this as a WIP as I'm unsure if this is the best way to add this to our project. I saw that we have different approaches in the vault overview table and the vault dashboard and seemingly another approach in the Issue -> Vault Selector.

@tomjeatt what would be the right approach to adding this?

Main contribution of this PR is to show how we can get the onchain identities.