### PR TITLE
Bugfix/tooltip text overflow

### DIFF
--- a/src/components/UI/InterlayTooltip/index.tsx
+++ b/src/components/UI/InterlayTooltip/index.tsx
@@ -1,4 +1,4 @@
-import '@reach/tooltip/styles.css';
+import './interlay-tooltip.css';
 
 import Tooltip, { TooltipProps } from '@reach/tooltip';
 import clsx from 'clsx';

--- a/src/components/UI/InterlayTooltip/interlay-tooltip.css
+++ b/src/components/UI/InterlayTooltip/interlay-tooltip.css
@@ -4,15 +4,15 @@
 }
 
 [data-reach-tooltip] {
-  z-index: 1;
+  /* z-index: 1; */
   pointer-events: none;
   position: absolute;
-  padding: 0.25em 0.5em;
-  box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1);
+  /* padding: 0.25em 0.5em; */
+  /* box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1); */
   /* white-space: nowrap; */
-  font-size: 85%;
-  background: #f0f0f0;
-  color: #444;
+  /* font-size: 85%; */
+  /* background: #f0f0f0; */
+  /* color: #444; */
   border: solid 1px #ccc;
 }
 /* ray test touch > */

--- a/src/components/UI/InterlayTooltip/interlay-tooltip.css
+++ b/src/components/UI/InterlayTooltip/interlay-tooltip.css
@@ -1,4 +1,3 @@
-/* ray test touch < */
 :root {
   --reach-tooltip: 1;
 }
@@ -15,4 +14,3 @@
   /* color: #444; */
   border: solid 1px #ccc;
 }
-/* ray test touch > */

--- a/src/components/UI/InterlayTooltip/interlay-tooltip.css
+++ b/src/components/UI/InterlayTooltip/interlay-tooltip.css
@@ -3,14 +3,7 @@
 }
 
 [data-reach-tooltip] {
-  /* z-index: 1; */
   pointer-events: none;
   position: absolute;
-  /* padding: 0.25em 0.5em; */
-  /* box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1); */
-  /* white-space: nowrap; */
-  /* font-size: 85%; */
-  /* background: #f0f0f0; */
-  /* color: #444; */
   border: solid 1px #ccc;
 }

--- a/src/components/UI/InterlayTooltip/interlay-tooltip.css
+++ b/src/components/UI/InterlayTooltip/interlay-tooltip.css
@@ -1,0 +1,18 @@
+/* ray test touch < */
+:root {
+  --reach-tooltip: 1;
+}
+
+[data-reach-tooltip] {
+  z-index: 1;
+  pointer-events: none;
+  position: absolute;
+  padding: 0.25em 0.5em;
+  box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1);
+  /* white-space: nowrap; */
+  font-size: 85%;
+  background: #f0f0f0;
+  color: #444;
+  border: solid 1px #ccc;
+}
+/* ray test touch > */


### PR DESCRIPTION
Before:
![183848942-bb9385cf-ef85-406b-953c-0b7c97ed3e8b](https://user-images.githubusercontent.com/84005068/198171519-c64dd17d-df87-4cfc-a97c-bb946210a739.png)
After:
<img width="1496" alt="Screen Shot 2022-10-27 at 03 36 24" src="https://user-images.githubusercontent.com/84005068/198171554-70bee371-b3b8-49f7-8e06-18d605f4ca4d.png">
