### PR TITLE
fix: remove incorrect usage of vaults nav item

### DIFF
--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -143,6 +143,7 @@
     "you_will_receive": "Redeem {{wrappedTokenSymbol}} 1:1 for BTC",
     "must_select_account_warning": "No account selected. Please select an account to redeem.",
     "waiting_for": "Waiting for",
+    "vault": "Vault",
     "typically_takes": "This typically takes only a few minutes but may sometimes take up to 6 hours.",
     "from_vault": "from Vault",
     "we_will_inform_you_btc": "We will inform you when the BTC payment is executed.",

--- a/src/components/RedeemUI/RedeemRequestStatusUI/PendingWithBtcTxNotFoundRedeemRequest/index.tsx
+++ b/src/components/RedeemUI/RedeemRequestStatusUI/PendingWithBtcTxNotFoundRedeemRequest/index.tsx
@@ -64,7 +64,7 @@ const PendingWithBtcTxNotFoundRedeemRequest = ({ redeem }: Props): JSX.Element =
       </p>
       <Ring48 className='ring-interlayPaleSky'>
         <Ring48Title>{t('redeem_page.waiting_for')}</Ring48Title>
-        <Ring48Value>{t('nav_vaults')}</Ring48Value>
+        <Ring48Value>{t('redeem_page.vault')}</Ring48Value>
       </Ring48>
     </RequestWrapper>
   );


### PR DESCRIPTION
The `nav_vaults` key was being incorrectly used in place of the word 'Vault' in the redeem UI. This corrects that. 