### PR TITLE
feat: changes to TableRow, Switch and theme

### DIFF
--- a/src/component-library/Switch/Switch.tsx
+++ b/src/component-library/Switch/Switch.tsx
@@ -1,13 +1,18 @@
 import { useFocusRing } from '@react-aria/focus';
+import { usePress } from '@react-aria/interactions';
 import { AriaSwitchProps, useSwitch } from '@react-aria/switch';
 import { mergeProps } from '@react-aria/utils';
 import { useToggleState } from '@react-stately/toggle';
-import { forwardRef, HTMLAttributes, useRef } from 'react';
+import { PressEvent } from '@react-types/shared';
+import React, { forwardRef, HTMLAttributes, useRef } from 'react';
 
 import { useDOMRef } from '../utils/dom';
 import { StyledInput, StyledLabel, StyledSwitch, StyledWrapper } from './Switch.style';
 
-type Props = { onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void };
+type Props = {
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPress?: (e: PressEvent) => void;
+};
 
 type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
 
@@ -27,9 +32,11 @@ const Switch = forwardRef<HTMLLabelElement, SwitchProps>(
       autoFocus: inputProps.autoFocus
     });
 
+    const { pressProps } = usePress(props);
+
     return (
       <StyledWrapper ref={labelRef} className={className} style={style} hidden={hidden}>
-        <StyledInput {...mergeProps(inputProps, focusProps, { onChange })} ref={inputRef} />
+        <StyledInput {...mergeProps(inputProps, focusProps, pressProps, { onChange })} ref={inputRef} />
         <StyledSwitch $isChecked={inputProps.checked} $isFocusVisible={isFocusVisible} />
         {children && <StyledLabel>{children}</StyledLabel>}
       </StyledWrapper>

--- a/src/component-library/Table/TableRow.tsx
+++ b/src/component-library/Table/TableRow.tsx
@@ -2,7 +2,23 @@ import { useTableRow } from '@react-aria/table';
 import { mergeProps } from '@react-aria/utils';
 import { TableState } from '@react-stately/table';
 import { GridNode } from '@react-types/grid';
-import { HTMLAttributes, useRef } from 'react';
+import { FocusableElement } from '@react-types/shared';
+import { HTMLAttributes, MouseEventHandler, PointerEventHandler, useRef } from 'react';
+
+// TODO: improve solution
+const interactiveElements = ['button', 'input'];
+
+// MEMO: Allows us to not emit inherited event from react-aria, if we are trying
+// to interact with a element that resides inside of a row cell.
+const shouldEmitInheritedEvent = (ref: React.RefObject<HTMLTableRowElement>, targetEl: HTMLElement) => {
+  const elementTag = targetEl.tagName.toLowerCase();
+
+  const isInteractiveElement = interactiveElements.includes(elementTag);
+
+  const tableRowCells = [...(ref.current?.cells as any)] as HTMLElement[];
+
+  return !isInteractiveElement || tableRowCells.includes(targetEl);
+};
 
 type Props = {
   state: TableState<Record<string, any>>;
@@ -15,7 +31,9 @@ type TableRowProps = Props & NativeAttrs;
 
 const TableRow = ({ item, children, state, ...props }: TableRowProps): JSX.Element => {
   const ref = useRef<HTMLTableRowElement>(null);
-  const { rowProps } = useTableRow(
+  const {
+    rowProps: { onPointerDown, onPointerUp, onClick, ...otherRowProps }
+  } = useTableRow(
     {
       node: item
     },
@@ -23,8 +41,33 @@ const TableRow = ({ item, children, state, ...props }: TableRowProps): JSX.Eleme
     ref
   );
 
+  const handlePointerUp: PointerEventHandler<FocusableElement> = (e) => {
+    if (shouldEmitInheritedEvent(ref, e.target as HTMLElement)) {
+      onPointerUp?.(e);
+    }
+  };
+
+  const handlePointerDown: PointerEventHandler<FocusableElement> = (e) => {
+    if (shouldEmitInheritedEvent(ref, e.target as HTMLElement)) {
+      onPointerDown?.(e);
+    }
+  };
+
+  const handleClick: MouseEventHandler<FocusableElement> = (e) => {
+    if (shouldEmitInheritedEvent(ref, e.target as HTMLElement)) {
+      onClick?.(e);
+    }
+  };
+
   return (
-    <tr ref={ref} {...mergeProps(props, rowProps)}>
+    <tr
+      ref={ref}
+      {...mergeProps(props, otherRowProps, {
+        onPointerDown: handlePointerDown,
+        onPointerUp: handlePointerUp,
+        onClick: handleClick
+      })}
+    >
       {children}
     </tr>
   );

--- a/src/component-library/theme/theme.ts
+++ b/src/component-library/theme/theme.ts
@@ -163,6 +163,11 @@ const theme = {
       error: 'var(--colors-error)',
       warning: 'var(--colors-warning)',
       success: 'var(--colors-success)'
+    },
+    bg: {
+      error: 'var(--colors-error-20)',
+      warning: 'var(--colors-warning-light-20)',
+      success: 'var(--colors-success-20)'
     }
   },
   transition: {


### PR DESCRIPTION
- `TableRow` changes allows interacting with html element such as `input` without emitting a `onRowAction` event.
- `Switch` changes adds emitting `onClick` and `onKeyDown` event under a single event called `onPress`.
- Theme changes are related to some colors needed for interlend