### PR TITLE
chore(interlend): update lib to 0.31.0, refactor subsidy rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@craco/craco": "^6.1.1",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^2.0.0",
-    "@interlay/interbtc-api": "0.30.8",
+    "@interlay/interbtc-api": "0.31.0",
     "@hookform/resolvers": "^2.9.7",
     "@material-icons/svg": "^1.0.28",
     "@polkadot/api": "9.4.1",

--- a/src/pages/Loans/LoansOverview/LoansOverview.tsx
+++ b/src/pages/Loans/LoansOverview/LoansOverview.tsx
@@ -11,8 +11,8 @@ const LoansOverview = (): JSX.Element => {
     netYieldUSDValue,
     borrowUSDValue: borrowBalance,
     supplyUSDValue: supplyBalance,
-    earnedRewardsAmount,
-    hasEarnedRewards
+    subsidyRewardsAmount,
+    hasSubsidyRewards
   } = overview;
 
   if (lendPositions === undefined || borrowPositions === undefined || assets === undefined) {
@@ -26,8 +26,8 @@ const LoansOverview = (): JSX.Element => {
           netYield={netYieldUSDValue}
           borrow={borrowBalance}
           supply={supplyBalance}
-          rewards={earnedRewardsAmount}
-          hasEarnedRewards={hasEarnedRewards}
+          rewards={subsidyRewardsAmount}
+          hasSubsidyRewards={hasSubsidyRewards}
         />
         <LoansTables borrowPositions={borrowPositions} lendPositions={lendPositions} assets={assets} />
       </Flex>

--- a/src/pages/Loans/LoansOverview/components/LoansInsights/LoansInsights.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoansInsights/LoansInsights.tsx
@@ -14,7 +14,7 @@ type LoansInsightsProps = {
   borrow: string | undefined;
   netYield: string | undefined;
   rewards: string | undefined;
-  hasEarnedRewards: boolean;
+  hasSubsidyRewards: boolean;
 };
 
 const LoansInsights = ({
@@ -22,14 +22,14 @@ const LoansInsights = ({
   netYield,
   borrow,
   rewards,
-  hasEarnedRewards: hasEarnedRewardsProp
+  hasSubsidyRewards: hasSubsidyRewardsProp
 }: LoansInsightsProps): JSX.Element => {
-  const [hasEarnedRewards, setEarnedRewards] = useState(hasEarnedRewardsProp);
+  const [hasSubsidyRewards, setSubsidyRewards] = useState(hasSubsidyRewardsProp);
 
   const { refetch } = useGetAccountLoansOverview();
 
   const handleSuccess = () => {
-    setEarnedRewards(false);
+    setSubsidyRewards(false);
     refetch();
   };
 
@@ -38,8 +38,8 @@ const LoansInsights = ({
   });
 
   useEffect(() => {
-    setEarnedRewards(hasEarnedRewardsProp);
-  }, [hasEarnedRewardsProp]);
+    setSubsidyRewards(hasSubsidyRewards);
+  }, [hasSubsidyRewards]);
 
   const handleClickClaimRewards = () => claimRewardsMutation.mutate();
 
@@ -66,7 +66,7 @@ const LoansInsights = ({
         </Card>
         <Card
           direction='row'
-          flex={hasEarnedRewards ? '1.5' : '1'}
+          flex={hasSubsidyRewards ? '1.5' : '1'}
           gap='spacing2'
           alignItems='center'
           justifyContent='space-between'
@@ -75,7 +75,7 @@ const LoansInsights = ({
             <StyledDt color='primary'>Rewards</StyledDt>
             <StyledDd color='secondary'>{rewards}</StyledDd>
           </DlGroup>
-          {hasEarnedRewards && (
+          {hasSubsidyRewards && (
             <CTA onClick={handleClickClaimRewards} loading={claimRewardsMutation.isLoading}>
               Claim
             </CTA>

--- a/src/utils/constants/api.ts
+++ b/src/utils/constants/api.ts
@@ -1,3 +1,5 @@
+import { BLOCK_TIME } from '@/config/parachain';
+
 const PRICES_API = Object.freeze({
   URL: 'https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd',
   QUERY_PARAMETERS: {
@@ -7,4 +9,6 @@ const PRICES_API = Object.freeze({
 
 const COINGECKO_IDS = ['bitcoin', 'kintsugi', 'kusama', 'polkadot', 'interlay'] as const;
 
-export { COINGECKO_IDS, PRICES_API };
+const BLOCKTIME_REFETCH_INTERVAL = BLOCK_TIME * 1000;
+
+export { BLOCKTIME_REFETCH_INTERVAL, COINGECKO_IDS, PRICES_API };

--- a/src/utils/hooks/api/loans/use-get-account-positions.tsx
+++ b/src/utils/hooks/api/loans/use-get-account-positions.tsx
@@ -3,6 +3,8 @@ import { AccountId } from '@polkadot/types/interfaces';
 import { useErrorHandler } from 'react-error-boundary';
 import { useQueries, useQueryClient } from 'react-query';
 
+import { BLOCKTIME_REFETCH_INTERVAL } from '@/utils/constants/api';
+
 interface AccountPositionsData {
   data: {
     lendPositions: Array<LendPosition> | undefined;
@@ -27,14 +29,14 @@ const useGetAccountPositions = (accountId: AccountId | undefined): AccountPositi
       queryFn: () => accountId && getAccountLendPositions(accountId),
       enabled: !!accountId,
       initialData: [],
-      refetchInterval: 12000
+      refetchInterval: BLOCKTIME_REFETCH_INTERVAL
     },
     {
       queryKey: ['borrow-positions', accountId?.toString()],
       queryFn: () => accountId && getAccountBorrowPositions(accountId),
       enabled: !!accountId,
       initialData: [],
-      refetchInterval: 12000
+      refetchInterval: BLOCKTIME_REFETCH_INTERVAL
     }
   ]);
 

--- a/src/utils/hooks/api/loans/use-get-account-subsidy-rewards.tsx
+++ b/src/utils/hooks/api/loans/use-get-account-subsidy-rewards.tsx
@@ -1,0 +1,35 @@
+import { CurrencyExt } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
+import { AccountId } from '@polkadot/types/interfaces';
+import { useErrorHandler } from 'react-error-boundary';
+import { useQuery, useQueryClient } from 'react-query';
+
+import { BLOCKTIME_REFETCH_INTERVAL } from '@/utils/constants/api';
+
+interface AccountAccruedRewards {
+  data: MonetaryAmount<CurrencyExt> | undefined;
+  refetch: () => void;
+}
+
+const getAccountSubsidyRewards = (accountId: AccountId) => window.bridge.loans.getAccruedRewardsOfAccount(accountId);
+
+const useGetAccountSubsidyRewards = (accountId: AccountId | undefined): AccountAccruedRewards => {
+  const queryKey = ['accruedRewards', accountId?.toString()];
+
+  const { data, error } = useQuery({
+    queryKey,
+    queryFn: () => accountId && getAccountSubsidyRewards(accountId),
+    enabled: !!accountId,
+    refetchInterval: BLOCKTIME_REFETCH_INTERVAL
+  });
+
+  useErrorHandler(error);
+
+  const queryClient = useQueryClient();
+
+  const refetch = () => queryClient.invalidateQueries(queryKey);
+
+  return { data, refetch };
+};
+
+export { useGetAccountSubsidyRewards };

--- a/src/utils/hooks/api/loans/use-get-loan-assets.tsx
+++ b/src/utils/hooks/api/loans/use-get-loan-assets.tsx
@@ -1,23 +1,32 @@
 import { LoanAsset, TickerToData } from '@interlay/interbtc-api';
 import { useErrorHandler } from 'react-error-boundary';
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
+
+import { BLOCKTIME_REFETCH_INTERVAL } from '@/utils/constants/api';
 
 interface LoanAssetsData {
-  assets: TickerToData<LoanAsset> | undefined;
+  data: TickerToData<LoanAsset> | undefined;
+  refetch: () => void;
 }
 
 const getLoanAssets = (): Promise<TickerToData<LoanAsset>> => window.bridge.loans.getLoanAssets();
 
 const useGetLoanAssets = (): LoanAssetsData => {
-  const { data: assets, error } = useQuery({
-    queryKey: ['loan-assets'],
+  const queryKey = ['loan-assets'];
+
+  const { data, error } = useQuery({
+    queryKey,
     queryFn: getLoanAssets,
-    refetchInterval: 12000
+    refetchInterval: BLOCKTIME_REFETCH_INTERVAL
   });
 
   useErrorHandler(error);
 
-  return { assets };
+  const queryClient = useQueryClient();
+
+  const refetch = () => queryClient.invalidateQueries(queryKey);
+
+  return { data, refetch };
 };
 
 export { useGetLoanAssets };

--- a/src/utils/hooks/api/loans/use-get-loans-data.tsx
+++ b/src/utils/hooks/api/loans/use-get-loans-data.tsx
@@ -10,8 +10,8 @@ type LoansData = {
     supplyUSDValue: string | undefined;
     borrowUSDValue: string | undefined;
     netYieldUSDValue: string | undefined;
-    earnedRewardsAmount: string | undefined;
-    hasEarnedRewards: boolean;
+    subsidyRewardsAmount: string | undefined;
+    hasSubsidyRewards: boolean;
   };
   lendPositions: LendPosition[] | undefined;
   borrowPositions: BorrowPosition[] | undefined;
@@ -25,23 +25,23 @@ const useGetLoansData = (): LoansData => {
       borrowPositions,
       lentAssetsUSDValue,
       borrowedAssetsUSDValue,
-      earnedRewards,
+      subsidyRewards,
       netYieldUSDValue
     }
   } = useGetAccountLoansOverview();
-  const { assets } = useGetLoanAssets();
+  const { data: assets } = useGetLoanAssets();
 
   return {
     overview: {
       supplyUSDValue: lentAssetsUSDValue && formatUSD(lentAssetsUSDValue.toNumber()),
       borrowUSDValue: borrowedAssetsUSDValue && formatUSD(borrowedAssetsUSDValue.toNumber()),
       netYieldUSDValue: netYieldUSDValue ? formatUSD(netYieldUSDValue.toNumber()) : formatUSD(0),
-      earnedRewardsAmount: earnedRewards
-        ? `${formatNumber(earnedRewards.toBig().toNumber(), {
-            maximumFractionDigits: earnedRewards.currency.humanDecimals || 5
-          })} ${earnedRewards.currency.ticker}`
+      subsidyRewardsAmount: subsidyRewards
+        ? `${formatNumber(subsidyRewards.toBig().toNumber(), {
+            maximumFractionDigits: subsidyRewards.currency.humanDecimals || 5
+          })} ${subsidyRewards.currency.ticker}`
         : formatUSD(0),
-      hasEarnedRewards: !!earnedRewards && !earnedRewards?.isZero()
+      hasSubsidyRewards: !!subsidyRewards && !subsidyRewards?.isZero()
     },
     lendPositions,
     borrowPositions,

--- a/src/utils/hooks/api/loans/utils.ts
+++ b/src/utils/hooks/api/loans/utils.ts
@@ -1,5 +1,4 @@
-import { BorrowPosition, CurrencyExt, LendPosition } from '@interlay/interbtc-api';
-import { MonetaryAmount } from '@interlay/monetary-js';
+import { BorrowPosition, LendPosition } from '@interlay/interbtc-api';
 import Big from 'big.js';
 
 import { convertMonetaryAmountToValueInUSD } from '@/common/utils/utils';
@@ -8,8 +7,8 @@ import { getTokenPrice } from '@/utils/helpers/prices';
 import { Prices } from '../use-get-prices';
 
 type Field<T> = T extends LendPosition
-  ? Extract<keyof LendPosition, 'earnedInterest' | 'earnedReward' | 'amount'>
-  : Extract<keyof BorrowPosition, 'earnedReward' | 'amount' | 'accumulatedDebt'>;
+  ? Extract<keyof LendPosition, 'earnedInterest' | 'amount'>
+  : Extract<keyof BorrowPosition, 'accumulatedDebt' | 'amount'>;
 
 /**
  * This function uses the value specified in the object key `field` param
@@ -35,17 +34,4 @@ const getPositionsSumOfFieldsInUSD = <T extends LendPosition | BorrowPosition>(
     return positionUSDValue === null ? totalValue : totalValue.add(positionUSDValue);
   }, Big(0));
 
-// MEMO: each position has total rewards
-const getTotalEarnedRewards = (
-  lendPositions: LendPosition[] = [],
-  borrowPositions: BorrowPosition[] = []
-): MonetaryAmount<CurrencyExt> | undefined => {
-  if (!lendPositions?.length && !borrowPositions?.length) {
-    return undefined;
-  }
-
-  const [firstPosition] = [...lendPositions, ...borrowPositions];
-  return firstPosition.earnedReward || undefined;
-};
-
-export { getPositionsSumOfFieldsInUSD, getTotalEarnedRewards };
+export { getPositionsSumOfFieldsInUSD };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,10 +2022,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@0.30.8":
-  version "0.30.8"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-0.30.8.tgz#1f55d67f8316f3b056a4221cac806705805929e9"
-  integrity sha512-CZP/Xd26WT3DaaR3RhOV1meW6LAL24ebjHtrkCq4LyJs46ELwFY/aNkV/oE0Q9FHjL4UbAb3tvjJbcBVK8gTkw==
+"@interlay/interbtc-api@0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-0.31.0.tgz#ab95a4b7862fa9a2167f47d035fe76278d200cb3"
+  integrity sha512-P/687Z8Uy2P7EYTL24Y4sOLz4/SrIdiILa1tHAG4GmphWo/9lFDodQ3mnAgFSOKziPj+AaVx8qJ/5qWXTFVKmg==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "0.30.4"


### PR DESCRIPTION
- Upgrading lib version to 0.31.0, that changes how earned subsidy reward is returned. 
- Renaming `earnedReward` -> `subsidyReward` to make clear distinction between subsidies and interest rewards.
- Adding refetch interval to separate constant
- Creating one main function for refetching of positions, loan assets and rewards in `useGetAccountLoansOverview`, to refresh to be able to refresh all data with 1 call. 