### PR TITLE
feat(loans): show alert when borrowing liquidity is low

### DIFF
--- a/src/component-library/Alert/Alert.stories.tsx
+++ b/src/component-library/Alert/Alert.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, Story } from '@storybook/react';
+
+import { Alert, AlertProps } from '.';
+
+const Template: Story<AlertProps> = (args) => <Alert {...args} />;
+
+const Error = Template.bind({});
+Error.args = {
+  status: 'error',
+  children: 'Error happened, please contact our support.'
+};
+
+const Warning = Template.bind({});
+Warning.args = {
+  children: 'This is a warning message...',
+  status: 'warning'
+};
+
+const Success = Template.bind({});
+Success.args = {
+  children: 'Transaction was succesful!',
+  status: 'success'
+};
+
+export { Error, Warning };
+
+export default {
+  title: 'Components/Alert',
+  component: Alert
+} as Meta;

--- a/src/component-library/Alert/Alert.style.tsx
+++ b/src/component-library/Alert/Alert.style.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+import { ReactComponent as WarningIcon } from '@/assets/img/icons/exclamation-triangle.svg';
+
+import { Flex } from '../Flex';
+import { theme } from '../theme';
+import { Status } from '../utils/prop-types';
+
+interface StyledAlertProps {
+  $status: Status;
+}
+
+const StyledAlert = styled(Flex)<StyledAlertProps>`
+  padding: ${theme.spacing.spacing2};
+  color: ${({ $status }) => theme.alert.status[$status]};
+  border: 1px solid ${({ $status }) => theme.alert.status[$status]};
+  background-color: ${({ $status }) => theme.alert.bg[$status]};
+  border-radius: ${theme.rounded.md};
+  font-size: ${theme.text.xs};
+`;
+
+const StyledWarningIcon = styled(WarningIcon)`
+  width: ${theme.spacing.spacing5};
+  height: ${theme.spacing.spacing5};
+  flex-shrink: 0;
+`;
+
+export { StyledAlert, StyledWarningIcon };

--- a/src/component-library/Alert/Alert.tsx
+++ b/src/component-library/Alert/Alert.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+import { Status } from '../utils/prop-types';
+import { StyledAlert, StyledWarningIcon } from './Alert.style';
+
+interface AlertProps {
+  status: Status;
+  children: ReactNode;
+}
+
+const Alert = ({ status, children }: AlertProps): JSX.Element => (
+  <StyledAlert $status={status} role='alert' gap='spacing4' alignItems='center'>
+    <StyledWarningIcon />
+    <div>{children}</div>
+  </StyledAlert>
+);
+
+export { Alert };
+export type { AlertProps };

--- a/src/component-library/Alert/index.tsx
+++ b/src/component-library/Alert/index.tsx
@@ -1,0 +1,2 @@
+export type { AlertProps } from './Alert';
+export { Alert } from './Alert';

--- a/src/component-library/index.tsx
+++ b/src/component-library/index.tsx
@@ -1,3 +1,5 @@
+export type { AlertProps } from './Alert';
+export { Alert } from './Alert';
 export type { CardProps } from './Card';
 export { Card } from './Card';
 export type { CoinIconProps } from './CoinIcon';

--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.style.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.style.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
-import { ReactComponent as WarningIcon } from '@/assets/img/icons/exclamation-triangle.svg';
-import { Dd, Dl, Flex, theme } from '@/component-library';
+import { Dd, Dl, theme } from '@/component-library';
 import { Status } from '@/component-library/utils/prop-types';
 
 type StyledDdProps = {
@@ -23,19 +22,4 @@ const StyledDl = styled(Dl)`
   font-size: ${theme.text.s};
 `;
 
-const StyledWarningIcon = styled(WarningIcon)`
-  width: ${theme.spacing.spacing5};
-  height: ${theme.spacing.spacing5};
-  flex: 1 0 auto;
-`;
-
-const StyledAlert = styled(Flex)`
-  padding: ${theme.spacing.spacing2};
-  color: ${theme.alert.status.error};
-  border: 1px solid ${theme.alert.status.error};
-  background-color: ${theme.alert.bg.error};
-  border-radius: ${theme.rounded.md};
-  font-size: ${theme.text.xs};
-`;
-
-export { StyledAlert, StyledDd, StyledDl, StyledWarningIcon };
+export { StyledDd, StyledDl };

--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
@@ -2,7 +2,7 @@ import { CurrencyExt, LoanAsset } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 import { useTranslation } from 'react-i18next';
 
-import { formatUSD } from '@/common/utils/utils';
+import { displayMonetaryAmount, formatUSD } from '@/common/utils/utils';
 import { DlGroup, Dt } from '@/component-library';
 import { useAccountBorrowLimit } from '@/pages/Loans/LoansOverview/hooks/use-get-account-borrow-limit';
 import { LoanAction } from '@/types/loans';
@@ -47,6 +47,8 @@ const BorrowLimit = ({
   const currentBorrowLimitLabel = formatUSD(borrowLimitUSD.toNumber(), { compact: true });
   const newBorrowLimitLabel = formatUSD(newBorrowLimit.toNumber(), { compact: true });
 
+  const isExceedingBorrowingLiquidity = loanAction === 'borrow' && asset.availableCapacity.lt(actionAmount);
+
   return (
     <StyledDl direction='column'>
       <DlGroup justifyContent='space-between'>
@@ -69,6 +71,15 @@ const BorrowLimit = ({
       </DlGroup>
       <LoanScore score={value} aria-label='loan score' />
       {/* TODO: replace with Alert component */}
+      {isExceedingBorrowingLiquidity && (
+        <StyledAlert role='warining' gap='spacing4' alignItems='center'>
+          <StyledWarningIcon />
+          <div>
+            The available liquidity to borrow {asset.currency.ticker} has exceed. Please borrow at most{' '}
+            {displayMonetaryAmount(asset.availableCapacity)}
+          </div>
+        </StyledAlert>
+      )}
       {hasLiquidationAlert && (
         <StyledAlert role='alert' gap='spacing4' alignItems='center'>
           <StyledWarningIcon />

--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
@@ -3,14 +3,16 @@ import { MonetaryAmount } from '@interlay/monetary-js';
 import { useTranslation } from 'react-i18next';
 
 import { displayMonetaryAmount, formatUSD } from '@/common/utils/utils';
-import { DlGroup, Dt } from '@/component-library';
+import { Alert, DlGroup, Dt } from '@/component-library';
 import { useAccountBorrowLimit } from '@/pages/Loans/LoansOverview/hooks/use-get-account-borrow-limit';
 import { LoanAction } from '@/types/loans';
+import { getTokenPrice } from '@/utils/helpers/prices';
+import { Prices } from '@/utils/hooks/api/use-get-prices';
 
 import { useGetAccountHealthFactor } from '../../hooks/use-get-account-health-factor';
 import { isBorrowAsset } from '../../utils/is-loan-asset';
 import { LoanScore } from '../LoanScore';
-import { StyledAlert, StyledDd, StyledDl, StyledWarningIcon } from './BorrowLimit.style';
+import { StyledDd, StyledDl } from './BorrowLimit.style';
 
 const LIQUIDATION_ALERT_SCORE = 1.5;
 
@@ -18,6 +20,7 @@ type BorrowLimitProps = {
   loanAction: LoanAction;
   asset: LoanAsset;
   actionAmount: MonetaryAmount<CurrencyExt>;
+  prices: Prices | undefined;
   shouldDisplayLiquidationAlert?: boolean;
 };
 
@@ -25,6 +28,7 @@ const BorrowLimit = ({
   loanAction,
   asset,
   actionAmount,
+  prices,
   shouldDisplayLiquidationAlert
 }: BorrowLimitProps): JSX.Element | null => {
   const { t } = useTranslation();
@@ -47,10 +51,18 @@ const BorrowLimit = ({
   const currentBorrowLimitLabel = formatUSD(borrowLimitUSD.toNumber(), { compact: true });
   const newBorrowLimitLabel = formatUSD(newBorrowLimit.toNumber(), { compact: true });
 
-  const isExceedingBorrowingLiquidity = loanAction === 'borrow' && asset.availableCapacity.lt(actionAmount);
+  const assetPrice = getTokenPrice(prices, asset.currency.ticker);
+  const capacityUSD = asset.availableCapacity.toBig().mul(assetPrice?.usd || 0);
+  const isExceedingBorrowingLiquidity = loanAction === 'borrow' && borrowLimitUSD.gt(capacityUSD);
 
   return (
     <StyledDl direction='column'>
+      {isExceedingBorrowingLiquidity && (
+        <Alert status='warning'>
+          The available liquidity to borrow {asset.currency.ticker} is lower than your borrow limit. You can borrow at
+          most {displayMonetaryAmount(asset.availableCapacity)} {asset.currency.ticker}.
+        </Alert>
+      )}
       <DlGroup justifyContent='space-between'>
         <Dt>Borrow Limit</Dt>
         <StyledDd $status={status}>
@@ -70,25 +82,13 @@ const BorrowLimit = ({
         </StyledDd>
       </DlGroup>
       <LoanScore score={value} aria-label='loan score' />
-      {/* TODO: replace with Alert component */}
-      {isExceedingBorrowingLiquidity && (
-        <StyledAlert role='alert' gap='spacing4' alignItems='center'>
-          <StyledWarningIcon />
-          <div>
-            The available liquidity to borrow {asset.currency.ticker} has exceed. Please borrow at most{' '}
-            {displayMonetaryAmount(asset.availableCapacity)}
-          </div>
-        </StyledAlert>
-      )}
+
       {hasLiquidationAlert && (
-        <StyledAlert role='alert' gap='spacing4' alignItems='center'>
-          <StyledWarningIcon />
-          <div>
-            {t('loans.action_will_recude_health_score', {
-              action: loanAction === 'borrow' ? t('loans.borrowing') : t('loans.withdrawing')
-            })}
-          </div>
-        </StyledAlert>
+        <Alert status='error'>
+          {t('loans.action_will_recude_health_score', {
+            action: loanAction === 'borrow' ? t('loans.borrowing') : t('loans.withdrawing')
+          })}
+        </Alert>
       )}
     </StyledDl>
   );

--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
@@ -72,7 +72,7 @@ const BorrowLimit = ({
       <LoanScore score={value} aria-label='loan score' />
       {/* TODO: replace with Alert component */}
       {isExceedingBorrowingLiquidity && (
-        <StyledAlert role='warining' gap='spacing4' alignItems='center'>
+        <StyledAlert role='alert' gap='spacing4' alignItems='center'>
           <StyledWarningIcon />
           <div>
             The available liquidity to borrow {asset.currency.ticker} has exceed. Please borrow at most{' '}

--- a/src/pages/Loans/LoansOverview/components/CollateralModal/CollateralModal.tsx
+++ b/src/pages/Loans/LoansOverview/components/CollateralModal/CollateralModal.tsx
@@ -108,7 +108,12 @@ const CollateralModal = ({ asset, position, onClose, ...props }: CollateralModal
             <StyledTitle>{content.title}</StyledTitle>
             <StyledDescription color='tertiary'>{content.description}</StyledDescription>
           </Flex>
-          <BorrowLimit loanAction={borrowLimitVariant} asset={asset} actionAmount={lendPositionAmount} />
+          <BorrowLimit
+            loanAction={borrowLimitVariant}
+            asset={asset}
+            actionAmount={lendPositionAmount}
+            prices={prices}
+          />
           {variant !== 'disable-error' && <LoanActionInfo prices={prices} />}
           <CTA size='large' onClick={handleClickBtn} loading={toggleCollateralMutation.isLoading}>
             {content.buttonLabel}

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -206,6 +206,7 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
                 loanAction={variant}
                 asset={asset}
                 actionAmount={monetaryAmount}
+                prices={prices}
               />
             )}
           </Flex>


### PR DESCRIPTION
Adding alert component to let user know when borrowing liquidity is lower than his borrow limit.
![image](https://user-images.githubusercontent.com/47864599/205300721-77790002-9841-498c-94cd-6c69428dc824.png)

**Test**
- alert MUST be shown when liquidity is lower than user's borrow limit in Borrow section of LoanForm
- alert MUST NOT be shown otherwise  or in any other place