### PR TITLE
fix(Meter): handle use-meter missing ranges

### DIFF
--- a/src/component-library/Meter/use-meter.tsx
+++ b/src/component-library/Meter/use-meter.tsx
@@ -1,17 +1,29 @@
 import { useMeter as useAriaMeter } from '@react-aria/meter';
 import { AriaMeterProps } from '@react-types/meter';
+import { HTMLAttributes } from 'react';
 
 import { MeterRanges } from './Meter';
 
-type UseMeterProps = Omit<AriaMeterProps, 'minValue' | 'maxValue'> & { ranges: MeterRanges };
+interface MeterAria {
+  meterProps: Omit<HTMLAttributes<HTMLElement>, 'onChange'>;
+  labelProps: HTMLAttributes<HTMLElement>;
+}
 
-// TODO: stop exporting hook
-const useMeter = ({ ranges, value: valueProp = 0, ...props }: UseMeterProps): ReturnType<typeof useAriaMeter> => {
-  const [minRange, , , maxRange] = ranges;
+const getMaxRange = (value: number, maxRange?: number): number => {
+  if (!maxRange) return 100;
 
-  const isOverMaxValue = valueProp > maxRange;
-  const maxValue = isOverMaxValue ? valueProp : maxRange;
-  const value = isOverMaxValue ? maxValue : valueProp;
+  const isOverMaxValue = !!maxRange && value > maxRange;
+  return isOverMaxValue ? value : maxRange;
+};
+
+type UseMeterProps = Omit<AriaMeterProps, 'minValue' | 'maxValue'> & { ranges?: MeterRanges };
+
+const useMeter = ({ ranges, value: valueProp = 0, ...props }: UseMeterProps): MeterAria => {
+  const [minRange, , , maxRange] = ranges || [];
+
+  const maxValue = getMaxRange(valueProp, maxRange);
+
+  const value = valueProp > maxValue ? maxValue : valueProp;
 
   const aria = useAriaMeter({
     minValue: minRange,


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Return 100 as max range when no ranges is provided

## Current behaviour (updates)

There is no max range if ranges is provided

## New behaviour

Max range defaults to 100

## Reproducible testing steps:

Same as https://github.com/interlay/interbtc-ui/pull/707