### PR TITLE
refactor(Loans): extend positions

### DIFF
--- a/src/utils/hooks/api/loans/type.ts
+++ b/src/utils/hooks/api/loans/type.ts
@@ -1,0 +1,14 @@
+import { BorrowPosition as LibBorrowPosition, LendPosition as LibLendPosition } from '@interlay/interbtc-api';
+import Big from 'big.js';
+
+type ExtendPosition = {
+  amountUSD: Big;
+  rewardsApy: Big;
+  totalApy: Big;
+};
+
+type LendPositionExt = LibLendPosition & Partial<ExtendPosition>;
+
+type BorrowPositionExt = LibBorrowPosition & Partial<ExtendPosition>;
+
+export type { BorrowPositionExt, LendPositionExt };


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Instead of computing each time each position amountUSD and all apys, we can extend the current positions and just compute these fields once.

## Current behaviour (updates)

> Please describe the current behaviour that you are modifying

## New behaviour

> Please describe the behaviour or changes this PR adds

## Reproducible testing steps:

> Please list all testing steps required for the reviewer to test this specific issue. Consider regressions and edge cases.
