### PR TITLE
fix(Loans): remove empty column

### DIFF
--- a/src/pages/Loans/LoansOverview/components/BorrowPositionsTable/BorrowPositionsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowPositionsTable/BorrowPositionsTable.tsx
@@ -10,8 +10,7 @@ import { StyledBorrowPositionsTable } from './BorrowPositionsTable.style';
 enum BorrowPositionColumns {
   ASSET = 'asset',
   APY_ACCRUED = 'apy-accrued',
-  BORROWED = 'borrowed',
-  EMPTY = 'empty'
+  BORROWED = 'borrowed'
 }
 
 type BorrowPositionTableRow = {
@@ -19,15 +18,13 @@ type BorrowPositionTableRow = {
   [BorrowPositionColumns.ASSET]: ReactNode;
   [BorrowPositionColumns.APY_ACCRUED]: ReactNode;
   [BorrowPositionColumns.BORROWED]: ReactNode;
-  [BorrowPositionColumns.EMPTY]: ReactNode;
 };
 
 // TODO: translations
 const borrowPositionColumns = [
   { name: 'Asset', uid: BorrowPositionColumns.ASSET },
   { name: 'APY / Accrued', uid: BorrowPositionColumns.APY_ACCRUED },
-  { name: 'Borrowed', uid: BorrowPositionColumns.BORROWED },
-  { name: '', uid: BorrowPositionColumns.EMPTY }
+  { name: 'Borrowed', uid: BorrowPositionColumns.BORROWED }
 ];
 
 type BorrowPositionsTableProps = {
@@ -66,14 +63,13 @@ const BorrowPositionsTable = ({
           />
         );
 
-        const borrowed = <BalanceCell amount={amount} prices={prices} />;
+        const borrowed = <BalanceCell alignItems='flex-end' amount={amount} prices={prices} />;
 
         return {
           id: currency.ticker,
           asset,
           'apy-accrued': apy,
-          borrowed,
-          empty: null
+          borrowed
         };
       }),
     [assets, onRowAction, positions, prices]

--- a/src/pages/Loans/LoansOverview/components/LoansBaseTable/BalanceCell.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoansBaseTable/BalanceCell.tsx
@@ -2,6 +2,7 @@ import { CurrencyExt } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 
 import { displayMonetaryAmountInUSDFormat, formatNumber } from '@/common/utils/utils';
+import { AlignItems } from '@/component-library';
 import { Prices } from '@/utils/hooks/api/use-get-prices';
 
 import { MonetaryCell } from './MonetaryCell';
@@ -9,15 +10,18 @@ import { MonetaryCell } from './MonetaryCell';
 type BalanceCellProps = {
   amount: MonetaryAmount<CurrencyExt>;
   prices?: Prices;
+  alignItems?: AlignItems;
 };
 
-const BalanceCell = ({ amount, prices }: BalanceCellProps): JSX.Element => {
+const BalanceCell = ({ amount, prices, alignItems }: BalanceCellProps): JSX.Element => {
   const assetBalanceUSD = displayMonetaryAmountInUSDFormat(amount, prices?.[amount.currency.ticker].usd);
   const assetBalance = formatNumber(amount.toBig().toNumber(), {
     maximumFractionDigits: amount.currency.humanDecimals
   });
 
-  return <MonetaryCell label={assetBalance} sublabel={assetBalanceUSD} labelColor='secondary' />;
+  return (
+    <MonetaryCell alignItems={alignItems} label={assetBalance} sublabel={assetBalanceUSD} labelColor='secondary' />
+  );
 };
 
 export { BalanceCell };

--- a/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
@@ -60,6 +60,7 @@ type UseLoanFormData = {
   };
 };
 
+// TODO: reduce GOVERNANCE for fees from max amount
 const useLoanFormData = (
   loanAction: BorrowAction | LendAction,
   asset: LoanAsset,


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

We had a temporary empty cell in borrow table column

## Current behaviour (updates)

Empty column on borrow  position table

## New behaviour

Removed this empty column and added necessary CSS

## Reproducible testing steps:

- Access lending page and open borrow position. Check if last column is correctly aligned.
