### PR TITLE
fix: Loans and Vaults available balance and max loans repay

### DIFF
--- a/src/lib/form-validation/loans/borrow.ts
+++ b/src/lib/form-validation/loans/borrow.ts
@@ -41,11 +41,11 @@ const borrow = (t: TFunction, params: LoanBorrowSchemaParams): z.ZodEffects<z.Zo
     }
   });
 
-type LoanRepaySchemaParams = CommonSchemaParams & AvailableBalanceSchemaParams;
+type LoanRepaySchemaParams = CommonSchemaParams & MaxAmountSchemaParams & AvailableBalanceSchemaParams;
 
 const repay = (t: TFunction, params: LoanRepaySchemaParams): z.ZodEffects<z.ZodString, string, string> =>
   z.string().superRefine((value, ctx) => {
-    const { governanceBalance, transactionFee, availableBalance, minAmount } = params;
+    const { governanceBalance, transactionFee, availableBalance, minAmount, maxAmount } = params;
 
     if (!field.required.validate({ value })) {
       const issueArg = field.required.issue(t, { fieldName: t('loans.repay').toLowerCase(), fieldType: 'number' });
@@ -62,6 +62,14 @@ const repay = (t: TFunction, params: LoanRepaySchemaParams): z.ZodEffects<z.ZodS
       const issueArg = field.min.issue(t, {
         action: t('loans.repay').toLowerCase(),
         amount: minAmount.toString()
+      });
+      return ctx.addIssue(issueArg);
+    }
+
+    if (!field.max.validate({ inputAmount: inputAmount.toBig(), maxAmount: maxAmount.toBig() })) {
+      const issueArg = field.max.issue(t, {
+        action: t('loans.repay').toLowerCase(),
+        amount: maxAmount.toString()
       });
       return ctx.addIssue(issueArg);
     }

--- a/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
@@ -4,10 +4,9 @@ import Big from 'big.js';
 
 import { GOVERNANCE_TOKEN, TRANSACTION_FEE_AMOUNT } from '@/config/relay-chains';
 import { BorrowAction, LendAction, LoanAction } from '@/types/loans';
-import { getTokenPrice } from '@/utils/helpers/prices';
 import { useGetAccountPositions } from '@/utils/hooks/api/loans/use-get-account-positions';
 import { useGetBalances } from '@/utils/hooks/api/tokens/use-get-balances';
-import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
+import { useAvailableBalance } from '@/utils/hooks/use-available-balance';
 
 import { getMaxBorrowableAmount } from '../utils/get-max-borrowable-amount';
 import { getMaxWithdrawableAmount } from '../utils/get-max-withdrawable-amount';
@@ -67,18 +66,17 @@ const useLoanFormData = (
   position?: LendPosition | BorrowPosition
 ): UseLoanFormData => {
   const { data: balances } = useGetBalances();
-  const prices = useGetPrices();
   const {
     data: { statistics }
   } = useGetAccountPositions();
+  const { price: assetPrice, amount: assetBalance } = useAvailableBalance(asset.currency);
+
   const { borrowAmountUSD, collateralAmountUSD } = statistics || {};
 
   const zeroAssetAmount = newMonetaryAmount(0, asset.currency);
 
   const governanceBalance = balances?.[GOVERNANCE_TOKEN.ticker].free || newMonetaryAmount(0, GOVERNANCE_TOKEN);
   const transactionFee = TRANSACTION_FEE_AMOUNT;
-  const assetBalance = balances?.[asset.currency.ticker].free || zeroAssetAmount;
-  const assetPrice = getTokenPrice(prices, asset.currency.ticker)?.usd || 0;
 
   const maxAmountParams: GetMaxAmountParams = {
     loanAction,

--- a/src/utils/hooks/use-available-balance.tsx
+++ b/src/utils/hooks/use-available-balance.tsx
@@ -1,0 +1,35 @@
+import { CurrencyExt, newMonetaryAmount } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
+
+import { GOVERNANCE_TOKEN, TRANSACTION_FEE_AMOUNT } from '@/config/relay-chains';
+import { getTokenPrice } from '@/utils/helpers/prices';
+import { useGetBalances } from '@/utils/hooks/api/tokens/use-get-balances';
+import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
+
+type UseAvailableBalance = { price: number; amount: MonetaryAmount<CurrencyExt> };
+
+// MEMO: return available balance. If the currency is used for fees,
+// we deduct the necessary to pay for a transaction.
+const useAvailableBalance = (currency: CurrencyExt): UseAvailableBalance => {
+  const { data: balances } = useGetBalances();
+  const prices = useGetPrices();
+
+  const price = getTokenPrice(prices, currency.ticker)?.usd || 0;
+  const amount = balances?.[currency.ticker].free || newMonetaryAmount(0, currency);
+
+  if (currency.ticker === GOVERNANCE_TOKEN.ticker) {
+    const governanceAmount = amount.sub(TRANSACTION_FEE_AMOUNT);
+
+    return {
+      amount: governanceAmount.toBig().gte(0) ? governanceAmount : newMonetaryAmount(0, currency),
+      price
+    };
+  }
+
+  return {
+    amount,
+    price
+  };
+};
+
+export { useAvailableBalance };


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Handle better max repay and available balance. Current implementation affects Vaults page and Loans page.

## Current behaviour (updates)

Currently we could repay more than we borrowed, but the transaction would fail. Also when lending gonvernance token, we were not taking into consideration the necessary for transaction fees.

## New behaviour

- takes into consideration the necessary for transaction fees when dealing with Governance token
- Validates when user tries to repay an amount over what he is currently borrowing

## Reproducible testing steps:

- Try Vaults Deposit Collateral flow
- Try repay a loan
