### PR TITLE
refactor: add useGetBalances helpers

### DIFF
--- a/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
@@ -66,7 +66,7 @@ const useLoanFormData = (
   asset: LoanAsset,
   position?: LendPosition | BorrowPosition
 ): UseLoanFormData => {
-  const { data: balances } = useGetBalances();
+  const { getBalance, getAvailableBalance } = useGetBalances();
   const prices = useGetPrices();
   const {
     data: { statistics }
@@ -75,9 +75,9 @@ const useLoanFormData = (
 
   const zeroAssetAmount = newMonetaryAmount(0, asset.currency);
 
-  const governanceBalance = balances?.[GOVERNANCE_TOKEN.ticker].free || newMonetaryAmount(0, GOVERNANCE_TOKEN);
+  const governanceBalance = getBalance(GOVERNANCE_TOKEN.ticker)?.free || newMonetaryAmount(0, GOVERNANCE_TOKEN);
   const transactionFee = TRANSACTION_FEE_AMOUNT;
-  const assetBalance = balances?.[asset.currency.ticker].free || zeroAssetAmount;
+  const assetBalance = getAvailableBalance(asset.currency.ticker) || zeroAssetAmount;
   const assetPrice = getTokenPrice(prices, asset.currency.ticker)?.usd || 0;
 
   const maxAmountParams: GetMaxAmountParams = {


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Added some functionally primarily to handle available balance for governance.

## Current behaviour (updates)

There was no reusable implementation to deduct governance fees from transaction that involves governance tokens. Such as lending Governance or using it as collateral for a vault.

## New behaviour

Add getter of balance that includes logic for when we are trying to get governance available balance.

## Reproducible testing steps:

Check if necessary for fees is deducted from the following flows:
- Vault Onboarding with governance token as collateral.
- Lending with governance token.