### PR TITLE
fix(Loans): loan form disable btn

### DIFF
--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -148,7 +148,7 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
     register,
     handleSubmit: h,
     watch,
-    formState: { errors, isDirty }
+    formState: { errors, isDirty, isValid }
   } = useForm<LoanFormData>({
     mode: 'onChange',
     resolver: zodResolver(schema)
@@ -157,7 +157,7 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
   const amount = watch(formField) || 0;
   const monetaryAmount = newMonetaryAmount(amount, asset.currency, true);
 
-  const isBtnDisabled = !isValidForm(errors) || !isDirty;
+  const isBtnDisabled = !isValidForm(errors) || !isDirty || !isValid;
 
   const handleSubmit = (data: LoanFormData) => {
     try {


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

On loan forms, focusing the input and blur it, makes the button loses disable.

## Current behaviour (updates)

Button loses disable by focus and unfocusing the input.

## New behaviour

Button is disabled until valid input.

## Reproducible testing steps:

- lend asset on lending page
