### PR TITLE
Feature/address copy missing case

### DIFF
--- a/src/components/AddressWithCopyUI/index.tsx
+++ b/src/components/AddressWithCopyUI/index.tsx
@@ -3,14 +3,14 @@ import clsx from 'clsx';
 import { shortAddress } from '@/common/utils/utils';
 import CopyToClipboardButton from '@/components/CopyToClipboardButton';
 
-interface Props {
+interface Props extends React.ComponentPropsWithRef<'div'> {
   address: string;
   className?: string;
 }
 
-const AddressWithCopyUI = ({ address, className }: Props): JSX.Element => {
+const AddressWithCopyUI = ({ address, className, ...rest }: Props): JSX.Element => {
   return (
-    <div className={clsx('flex', 'items-center', 'space-x-1', 'font-medium', className)}>
+    <div className={clsx('flex', 'items-center', 'space-x-1', 'font-medium', className)} {...rest}>
       <span>{shortAddress(address)}</span>
       <CopyToClipboardButton text={address} />
     </div>

--- a/src/pages/Bridge/RedeemForm/SubmittedRedeemRequestModal/index.tsx
+++ b/src/pages/Bridge/RedeemForm/SubmittedRedeemRequestModal/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { FaExclamationCircle } from 'react-icons/fa';
 
 import { displayMonetaryAmountInUSDFormat } from '@/common/utils/utils';
+import AddressWithCopyUI from '@/components/AddressWithCopyUI';
 import CloseIconButton from '@/components/buttons/CloseIconButton';
 import InterlayDefaultContainedButton from '@/components/buttons/InterlayDefaultContainedButton';
 import InterlayModal, { InterlayModalInnerWrapper, Props as ModalProps } from '@/components/UI/InterlayModal';
@@ -76,7 +77,7 @@ const SubmittedRedeemRequestModal = ({
                 )}`}
               </span>
             </div>
-            <div>
+            <div className={clsx('flex', 'items-center', 'justify-center', 'space-x-2')}>
               <label
                 htmlFor={USER_BTC_ADDRESS}
                 className={clsx(
@@ -84,15 +85,9 @@ const SubmittedRedeemRequestModal = ({
                   { 'dark:text-kintsugiTextSecondaryInDarkMode': process.env.REACT_APP_RELAY_CHAIN_NAME === KUSAMA }
                 )}
               >
-                {t('redeem_page.btc_destination_address')}
+                {t('redeem_page.btc_destination_address')}:
               </label>
-              <span
-                id={USER_BTC_ADDRESS}
-                // TODO: could componentize
-                className={clsx('block', 'p-2.5', 'border-2', 'font-medium', 'rounded-lg', 'text-center')}
-              >
-                {request.userBTCAddress}
-              </span>
+              <AddressWithCopyUI id={USER_BTC_ADDRESS} address={request.userBTCAddress} />
             </div>
             <div>
               <p>{t('redeem_page.we_will_inform_you_btc')}</p>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

In the process, I found this case missing from the main "address copy feature" PR so added it (progressive enhancement).

## Current behaviour (updates)

<img width="1496" alt="206886448-e140f172-f243-469b-8002-2810e34b7989" src="https://user-images.githubusercontent.com/84005068/207439758-663696bb-19d2-4717-8bbf-3e3ba675a4cb.png">

## New behaviour

<img width="1496" alt="206886453-57d84d27-dcb0-44ba-a6c1-568b76b9c7fe" src="https://user-images.githubusercontent.com/84005068/207439804-9dded46d-c805-4802-b4f4-c0ee2d4645c7.png">

## Reproducible testing steps:

- Successfully redeem on the redeem form.
- Then this notification modal will appear.
- Please make sure that the address is updated with a copy button.
