### PR TITLE
fix(Meter): overlapping indicators

### DIFF
--- a/src/component-library/Meter/Meter.stories.tsx
+++ b/src/component-library/Meter/Meter.stories.tsx
@@ -1,8 +1,20 @@
 import { Meta, Story } from '@storybook/react';
+import { useState } from 'react';
 
 import { Meter, MeterProps } from '.';
 
-const Template: Story<MeterProps> = (args) => <Meter {...args} />;
+const Template: Story<MeterProps> = (args) => {
+  const [warning, setWarning] = useState(60);
+  const [error, setError] = useState(80);
+
+  return (
+    <>
+      <input value={warning} type='number' onChange={(e) => e.target.value && setWarning(Number(e.target.value))} />
+      <input value={error} type='number' onChange={(e) => e.target.value && setError(Number(e.target.value))} />
+      <Meter {...args} ranges={[0, warning, error, 100]} />
+    </>
+  );
+};
 
 const StaticMeter = Template.bind({});
 StaticMeter.args = {

--- a/src/component-library/Meter/Meter.style.tsx
+++ b/src/component-library/Meter/Meter.style.tsx
@@ -60,7 +60,7 @@ const StyledMeter = styled.div<StyledMeterProps>`
       &::before {
         content: '';
         position: absolute;
-        // need for a correct placement
+        // needed for a correct placement
         width: calc(50% - 1px);
         top: -8px;
         bottom: -8px;
@@ -90,7 +90,7 @@ const StyledIndicatorWrapper = styled(Flex)<Omit<StyledMeterProps, '$hasRanges'>
   font-weight: ${theme.fontWeight.bold};
 `;
 
-const StyledRangeIndicator = styled(Span)<StyledRangeIndicatorProps>`
+const StyledRangeIndicator = styled(Span)<StyledRangeIndicatorProps & { $hasOffset?: boolean }>`
   position: absolute;
   width: 0;
   top: -2px;
@@ -104,7 +104,18 @@ const StyledRangeIndicator = styled(Span)<StyledRangeIndicatorProps>`
   &::after {
     content: '${({ $position }) => $position}%';
     position: absolute;
-    transform: translate(-45%, -120%);
+    transform: ${({ $status, $hasOffset }) => {
+      if ($hasOffset) {
+        switch ($status) {
+          case 'warning':
+            return `translate(-100%, -120%);`;
+          case 'error':
+            return `translate(-0%, -120%);`;
+        }
+      }
+
+      return `translate(-45%, -120%);`;
+    }};
     font-size: ${theme.text.xs};
     font-weight: ${theme.fontWeight.bold};
   }

--- a/src/component-library/Meter/Meter.tsx
+++ b/src/component-library/Meter/Meter.tsx
@@ -5,14 +5,9 @@ import { formatPercentage } from '@/common/utils/utils';
 import { Span } from '../Text';
 import { Status, Variants } from '../utils/prop-types';
 import { Indicator } from './Indicator';
-import {
-  StyledContainer,
-  StyledIndicatorWrapper,
-  StyledMeter,
-  StyledRangeIndicator,
-  StyledWrapper
-} from './Meter.style';
-import { getBarPercentage, getMaxRange, getStatus } from './utils';
+import { StyledContainer, StyledIndicatorWrapper, StyledMeter, StyledWrapper } from './Meter.style';
+import { RangeIndicators } from './RangeIndicators';
+import { getBarPercentage, getStatus } from './utils';
 
 const getPosition = (percentage: number) => (percentage > 100 ? 100 : percentage < 0 ? 0 : percentage);
 
@@ -72,12 +67,7 @@ const Meter = ({
           <Indicator />
           {!isPrimary && <Span>{formatPercentage(position, formatOptions)}</Span>}
         </StyledIndicatorWrapper>
-        {!isPrimary && !!ranges && (
-          <>
-            <StyledRangeIndicator $position={getMaxRange(ranges, 'warning', true)} $status='warning' />
-            <StyledRangeIndicator $position={getMaxRange(ranges, 'error', true)} $status='error' />
-          </>
-        )}
+        {!isPrimary && !!ranges && <RangeIndicators ranges={ranges} />}
       </StyledContainer>
     </StyledWrapper>
   );

--- a/src/component-library/Meter/RangeIndicators.tsx
+++ b/src/component-library/Meter/RangeIndicators.tsx
@@ -1,0 +1,43 @@
+import { useRef } from 'react';
+
+import { MeterRanges } from './Meter';
+import { StyledRangeIndicator } from './Meter.style';
+import { getMaxRange } from './utils';
+
+type RangeIndicatorsProps = {
+  ranges: MeterRanges;
+};
+
+const RangeIndicators = ({ ranges }: RangeIndicatorsProps): JSX.Element => {
+  const warningRef = useRef<HTMLSpanElement>(null);
+  const errorRef = useRef<HTMLSpanElement>(null);
+
+  const warning = getMaxRange(ranges, 'warning', true);
+  const error = getMaxRange(ranges, 'error', true);
+
+  const distance =
+    (errorRef.current?.getBoundingClientRect().left || 0) - (warningRef.current?.getBoundingClientRect().left || 0);
+
+  const warningLength = warning.toString().length;
+  const errorLength = error.toString().length;
+
+  let hasOffset = false;
+
+  if (warningLength <= 2 && errorLength <= 2) {
+    hasOffset = distance < 26;
+  } else if ((warningLength <= 2 && errorLength >= 3) || (warningLength >= 3 && errorLength <= 2)) {
+    hasOffset = distance < 30;
+  } else {
+    hasOffset = distance < 45;
+  }
+
+  return (
+    <>
+      <StyledRangeIndicator ref={warningRef} $hasOffset={hasOffset} $position={warning} $status='warning' />
+      <StyledRangeIndicator ref={errorRef} $hasOffset={hasOffset} $position={error} $status='error' />
+    </>
+  );
+};
+
+export { RangeIndicators };
+export type { RangeIndicatorsProps };


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Fixes https://github.com/interlay/interbtc-ui/issues/761

## Current behaviour (updates)

Indicators overlap

## New behaviour

Indicators do not overlap.

## Reproducible testing steps:

- On lending page, try combining assets as collateral with small thresholds ranges.