### PR TITLE
rui/element-type

### DIFF
--- a/src/component-library/CTA/BaseCTA.tsx
+++ b/src/component-library/CTA/BaseCTA.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, HTMLAttributes } from 'react';
 import { StyledComponent } from 'styled-components';
 
-import { CTAVariants, Sizes } from '../utils/prop-types';
+import { CTAVariants, ElementTypeProp, Sizes } from '../utils/prop-types';
 import { OutlinedCTA, PrimaryCTA, SecondaryCTA, StyledCTAProps, TextCTA } from './CTA.style';
 
 const ctaElements: Record<CTAVariants, StyledComponent<'button', any, StyledCTAProps, never>> = {
@@ -16,17 +16,25 @@ type Props = {
   fullWidth?: boolean;
   size?: Sizes;
   disabled?: boolean;
-  as?: any;
   isFocusVisible?: boolean;
 };
 
 type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
 
-type BaseCTAProps = Props & NativeAttrs;
+type BaseCTAProps = Props & NativeAttrs & ElementTypeProp;
 
 const BaseCTA = forwardRef<HTMLElement, BaseCTAProps>(
   (
-    { variant = 'primary', fullWidth = false, size = 'medium', children, disabled, isFocusVisible, ...props },
+    {
+      variant = 'primary',
+      fullWidth = false,
+      size = 'medium',
+      children,
+      disabled,
+      elementType,
+      isFocusVisible,
+      ...props
+    },
     ref
   ): JSX.Element => {
     const StyledCTA = ctaElements[variant];
@@ -34,6 +42,7 @@ const BaseCTA = forwardRef<HTMLElement, BaseCTAProps>(
     return (
       <StyledCTA
         ref={ref}
+        as={elementType}
         $fullWidth={fullWidth}
         $size={size}
         disabled={disabled}

--- a/src/component-library/CTA/CTALink.tsx
+++ b/src/component-library/CTA/CTALink.tsx
@@ -24,7 +24,7 @@ const CTALink = forwardRef<HTMLAnchorElement, CTALinkProps>(
     return (
       <BaseCTA
         ref={ref}
-        as={Link}
+        elementType={Link}
         onClick={onClick}
         aria-disabled={disabled ? 'true' : undefined}
         {...props}

--- a/src/component-library/Divider/Divider.tsx
+++ b/src/component-library/Divider/Divider.tsx
@@ -2,22 +2,21 @@ import { useSeparator } from '@react-aria/separator';
 import { mergeProps } from '@react-aria/utils';
 import { forwardRef, HTMLAttributes } from 'react';
 
-import { Colors, Orientation } from '../utils/prop-types';
+import { Colors, ElementTypeProp, Orientation } from '../utils/prop-types';
 import { StyledDivider } from './Divider.style';
 
 type Props = {
-  orientation: Orientation;
+  orientation?: Orientation;
   color?: Colors;
-  as?: any;
 };
 
 type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
 
-type DividerProps = Props & NativeAttrs;
+type DividerProps = Props & NativeAttrs & ElementTypeProp;
 
 const Divider = forwardRef<HTMLHRElement, DividerProps>(
-  ({ as, orientation, color = 'primary', ...props }, ref): JSX.Element => {
-    const elementType = as || orientation === 'vertical' ? 'div' : 'hr';
+  ({ elementType: elementTypeProp, orientation = 'horizontal', color = 'primary', ...props }, ref): JSX.Element => {
+    const elementType = elementTypeProp || orientation === 'vertical' ? 'div' : 'hr';
 
     const { separatorProps } = useSeparator({
       ...props,

--- a/src/component-library/Flex/Flex.tsx
+++ b/src/component-library/Flex/Flex.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, HTMLAttributes } from 'react';
 
-import { AlignItems, AlignSelf, Direction, JustifyContent, Spacing, Wrap } from '../utils/prop-types';
+import { AlignItems, AlignSelf, Direction, ElementTypeProp, JustifyContent, Spacing, Wrap } from '../utils/prop-types';
 import { StyledFlex } from './Flex.style';
 
 type Props = {
@@ -11,17 +11,20 @@ type Props = {
   flex?: string | number;
   wrap?: Wrap | boolean;
   alignSelf?: AlignSelf;
-  as?: any;
 };
 
 type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
 
-type FlexProps = Props & NativeAttrs;
+type FlexProps = Props & NativeAttrs & ElementTypeProp;
 
 const Flex = forwardRef<HTMLElement, FlexProps>(
-  ({ children, gap, justifyContent, alignItems, direction, flex, wrap, alignSelf, as, ...props }, ref): JSX.Element => (
+  (
+    { children, gap, justifyContent, alignItems, direction, flex, wrap, alignSelf, elementType, ...props },
+    ref
+  ): JSX.Element => (
     <StyledFlex
       ref={ref}
+      as={elementType}
       $gap={gap}
       $justifyContent={justifyContent}
       $alignItems={alignItems}
@@ -29,7 +32,6 @@ const Flex = forwardRef<HTMLElement, FlexProps>(
       $flex={flex}
       $wrap={wrap}
       $alignSelf={alignSelf}
-      as={as}
       {...props}
     >
       {children}

--- a/src/component-library/Modal/ModalTitle.tsx
+++ b/src/component-library/Modal/ModalTitle.tsx
@@ -1,24 +1,23 @@
 import { mergeProps } from '@react-aria/utils';
 
 import { TextProps } from '../Text';
-import { NormalAlignments } from '../utils/prop-types';
+import { ElementTypeProp, NormalAlignments } from '../utils/prop-types';
 import { StyledModalTitle } from './Modal.style';
 import { useModalContext } from './ModalContext';
 
 type Props = {
   alignment?: NormalAlignments;
-  as?: any;
 };
 
 type InheritAttrs = Omit<TextProps, keyof Props>;
 
-type ModalTitleProps = Props & InheritAttrs;
+type ModalTitleProps = Props & InheritAttrs & ElementTypeProp;
 
-const ModalTitle = ({ alignment = 'center', as, children, ...props }: ModalTitleProps): JSX.Element => {
+const ModalTitle = ({ alignment = 'center', elementType, children, ...props }: ModalTitleProps): JSX.Element => {
   const { titleProps } = useModalContext();
 
   return (
-    <StyledModalTitle as={as} $alignment={alignment} {...mergeProps(titleProps || {}, props)}>
+    <StyledModalTitle as={elementType} $alignment={alignment} {...mergeProps(titleProps || {}, props)}>
       {children}
     </StyledModalTitle>
   );

--- a/src/component-library/Table/BaseTable.tsx
+++ b/src/component-library/Table/BaseTable.tsx
@@ -31,7 +31,7 @@ const BaseTable = forwardRef<HTMLTableElement, BaseTableProps>(
 
     return (
       <StyledTable ref={tableRef} {...mergeProps(props, gridProps)}>
-        <TableRowGroup as='thead'>
+        <TableRowGroup elementType='thead'>
           {collection.headerRows.map((headerRow) => (
             <TableHeaderRow key={headerRow.key} item={headerRow} state={state}>
               {[...headerRow.childNodes].map((column) => (
@@ -40,7 +40,7 @@ const BaseTable = forwardRef<HTMLTableElement, BaseTableProps>(
             </TableHeaderRow>
           ))}
         </TableRowGroup>
-        <TableRowGroup as='tbody'>
+        <TableRowGroup elementType='tbody'>
           {[...collection.body.childNodes].map((row) => (
             <TableRow key={row.key} item={row} state={state}>
               {[...row.childNodes].map((cell) => (

--- a/src/component-library/Table/TableRowGroup.tsx
+++ b/src/component-library/Table/TableRowGroup.tsx
@@ -2,16 +2,13 @@ import { useTableRowGroup } from '@react-aria/table';
 import { mergeProps } from '@react-aria/utils';
 import { HTMLAttributes } from 'react';
 
-type Props = {
-  // TODO: create a util type for this
-  as?: keyof JSX.IntrinsicElements;
-};
+import { ElementTypeProp } from '../utils/prop-types';
 
-type NativeAttrs = Omit<HTMLAttributes<HTMLTableSectionElement>, keyof Props>;
+type NativeAttrs = HTMLAttributes<HTMLTableSectionElement>;
 
-type TableRowGroupProps = Props & NativeAttrs;
+type TableRowGroupProps = NativeAttrs & ElementTypeProp;
 
-const TableRowGroup = ({ as: Component = 'thead', children, ...props }: TableRowGroupProps): JSX.Element => {
+const TableRowGroup = ({ elementType: Component = 'thead', children, ...props }: TableRowGroupProps): JSX.Element => {
   const { rowGroupProps } = useTableRowGroup();
 
   return <Component {...mergeProps(props, rowGroupProps)}>{children}</Component>;

--- a/src/component-library/Text/Dl/Dl.tsx
+++ b/src/component-library/Text/Dl/Dl.tsx
@@ -2,7 +2,9 @@ import { Flex, FlexProps } from '@/component-library/Flex';
 
 type DlProps = FlexProps;
 
-const Dl = ({ gap = 'spacing4', as = 'dl', ...props }: DlProps): JSX.Element => <Flex gap={gap} as={as} {...props} />;
+const Dl = ({ gap = 'spacing4', elementType = 'dl', ...props }: DlProps): JSX.Element => (
+  <Flex gap={gap} elementType={elementType} {...props} />
+);
 
 Dl.displayName = 'Dl';
 

--- a/src/component-library/utils/prop-types.ts
+++ b/src/component-library/utils/prop-types.ts
@@ -72,8 +72,8 @@ export type Spacing = keyof typeof theme.spacing;
 
 export type Placement = 'top' | 'right' | 'bottom' | 'left';
 
-export interface AsProp<As extends ElementType = ElementType> {
-  as?: As;
+export interface ElementTypeProp {
+  elementType?: ElementType;
 }
 
 export type FontWeight = keyof typeof theme.fontWeight;


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Our `as` prop is being overridden by `style-components` when styling components such as `styled(Flex)`. This is problematic because `styled-component` `as` prop replaces the component while we just want to replace the html tag.

Also improved types so the new `elementType` prop is added in a common way across our components.
