### PR TITLE
feat(CTA): add react-aria useButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@polkadot/extension-dapp": "0.44.1",
     "@polkadot/ui-keyring": "^2.9.7",
     "@reach/tooltip": "^0.16.0",
+    "@react-aria/button": "^3.6.4",
     "@react-aria/dialog": "^3.3.1",
     "@react-aria/focus": "^3.6.1",
     "@react-aria/interactions": "^3.11.0",

--- a/src/component-library/CTA/BaseCTA.tsx
+++ b/src/component-library/CTA/BaseCTA.tsx
@@ -17,6 +17,7 @@ type Props = {
   size?: Sizes;
   disabled?: boolean;
   as?: any;
+  isFocusVisible?: boolean;
 };
 
 type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
@@ -24,11 +25,21 @@ type NativeAttrs = Omit<HTMLAttributes<unknown>, keyof Props>;
 type BaseCTAProps = Props & NativeAttrs;
 
 const BaseCTA = forwardRef<HTMLElement, BaseCTAProps>(
-  ({ variant = 'primary', fullWidth = false, size = 'medium', children, disabled, ...props }, ref): JSX.Element => {
+  (
+    { variant = 'primary', fullWidth = false, size = 'medium', children, disabled, isFocusVisible, ...props },
+    ref
+  ): JSX.Element => {
     const StyledCTA = ctaElements[variant];
 
     return (
-      <StyledCTA ref={ref} $fullWidth={fullWidth} $size={size} disabled={disabled} {...props}>
+      <StyledCTA
+        ref={ref}
+        $fullWidth={fullWidth}
+        $size={size}
+        disabled={disabled}
+        $isFocusVisible={isFocusVisible}
+        {...props}
+      >
         {children}
       </StyledCTA>
     );

--- a/src/component-library/CTA/CTA.style.tsx
+++ b/src/component-library/CTA/CTA.style.tsx
@@ -6,6 +6,7 @@ import { Sizes } from '../utils/prop-types';
 interface StyledCTAProps {
   $fullWidth: boolean;
   $size: Sizes;
+  $isFocusVisible?: boolean;
 }
 
 const BaseCTA = styled.button<StyledCTAProps>`
@@ -22,6 +23,7 @@ const BaseCTA = styled.button<StyledCTAProps>`
   text-decoration: none;
   width: ${(props) => (props.$fullWidth ? '100%' : 'auto')};
   background: none;
+  outline: ${({ $isFocusVisible }) => !$isFocusVisible && 'none'};
 
   &[aria-disabled='true'],
   &[disabled] {

--- a/src/component-library/CTA/CTA.tsx
+++ b/src/component-library/CTA/CTA.tsx
@@ -1,6 +1,11 @@
+import { useButton } from '@react-aria/button';
+import { useFocusRing } from '@react-aria/focus';
+import { mergeProps } from '@react-aria/utils';
+import { PressEvent } from '@react-types/shared';
 import { ButtonHTMLAttributes, forwardRef } from 'react';
 
 import { LoadingSpinner } from '../LoadingSpinner';
+import { useDOMRef } from '../utils/dom';
 import { Sizes } from '../utils/prop-types';
 import { BaseCTA, BaseCTAProps } from './BaseCTA';
 import { LoadingWrapper } from './CTA.style';
@@ -15,6 +20,7 @@ type Props = {
   fullWidth?: boolean;
   size?: Sizes;
   loading?: boolean;
+  onPress?: (e: PressEvent) => void;
 };
 
 type NativeAttrs = Omit<ButtonHTMLAttributes<unknown>, keyof Props>;
@@ -24,11 +30,27 @@ type InheritAttrs = Omit<BaseCTAProps, keyof Props & NativeAttrs>;
 type CTAProps = Props & InheritAttrs & NativeAttrs;
 
 const CTA = forwardRef<HTMLButtonElement, CTAProps>(
-  ({ children, loading, disabled, variant = 'primary', fullWidth, size = 'medium', ...props }, ref): JSX.Element => {
+  (
+    { children, loading, disabled, variant = 'primary', fullWidth, size = 'medium', onPress, ...props },
+    ref
+  ): JSX.Element => {
+    const domRef = useDOMRef(ref);
+
     const isDisabled = disabled || loading;
 
+    const { buttonProps } = useButton({ isDisabled, onPress, ...props }, domRef);
+    const { focusProps, isFocusVisible } = useFocusRing(props);
+
     return (
-      <BaseCTA ref={ref} disabled={isDisabled} fullWidth={fullWidth} variant={variant} size={size} {...props}>
+      <BaseCTA
+        ref={domRef}
+        disabled={isDisabled}
+        fullWidth={fullWidth}
+        variant={variant}
+        size={size}
+        isFocusVisible={isFocusVisible}
+        {...mergeProps(props, buttonProps, focusProps)}
+      >
         {loading && (
           <LoadingWrapper>
             <LoadingSpinner

--- a/yarn.lock
+++ b/yarn.lock
@@ -6283,6 +6283,19 @@
     prop-types "^15.7.2"
     tslib "^2.3.0"
 
+"@react-aria/button@^3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/button/-/button-3.6.4.tgz#51927c9d968d0c1f741ee2081ca7f2e244abbc12"
+  integrity sha512-OEs5fNGiuZzyC5y0cNl96+6pRf/3ZhI1i2m6LlRYhJLsWXPhHt21UHEnlSchE/XGtgKojJEeTsXottoBFTBi5w==
+  dependencies:
+    "@react-aria/focus" "^3.10.1"
+    "@react-aria/interactions" "^3.13.1"
+    "@react-aria/utils" "^3.14.2"
+    "@react-stately/toggle" "^3.4.4"
+    "@react-types/button" "^3.7.0"
+    "@react-types/shared" "^3.16.0"
+    "@swc/helpers" "^0.4.14"
+
 "@react-aria/dialog@^3.3.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@react-aria/dialog/-/dialog-3.4.1.tgz#373c389e21b9b9fcc6947ec092074daedd46030c"
@@ -6305,6 +6318,17 @@
     "@react-aria/interactions" "^3.13.0"
     "@react-aria/utils" "^3.14.1"
     "@react-types/shared" "^3.16.0"
+    clsx "^1.1.1"
+
+"@react-aria/focus@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.10.1.tgz#624d02d2565151030a4156aeb17685d87f18ad58"
+  integrity sha512-HjgFUC1CznuYC7CxtBIFML6bOBxW3M3cSNtvmXU9QWlrPSwwOLkXCnfY6+UkjCc5huP4v7co4PoRDX8Vbe/cVQ==
+  dependencies:
+    "@react-aria/interactions" "^3.13.1"
+    "@react-aria/utils" "^3.14.2"
+    "@react-types/shared" "^3.16.0"
+    "@swc/helpers" "^0.4.14"
     clsx "^1.1.1"
 
 "@react-aria/focus@^3.6.1":
@@ -6446,6 +6470,15 @@
     "@babel/runtime" "^7.6.2"
     "@react-aria/utils" "^3.14.1"
     "@react-types/shared" "^3.16.0"
+
+"@react-aria/interactions@^3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.13.1.tgz#75e102c50a5c1d002cad4ee8d59677aee226186b"
+  integrity sha512-WCvfZOi1hhussVTHxVq76OR48ry13Zvp9U5hmuQufyxIUlf4hOvDk4/cbK4o4JiCs8X7C7SRzcwFM34M4NHzmg==
+  dependencies:
+    "@react-aria/utils" "^3.14.2"
+    "@react-types/shared" "^3.16.0"
+    "@swc/helpers" "^0.4.14"
 
 "@react-aria/interactions@^3.9.1":
   version "3.9.1"
@@ -6627,6 +6660,13 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
+"@react-aria/ssr@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.4.1.tgz#79e8bb621487e8f52890c917d3c734f448ba95e7"
+  integrity sha512-NmhoilMDyIfQiOSdQgxpVH2tC2u85Y0mVijtBNbI9kcDYLEiW/r6vKYVKtkyU+C4qobXhGMPfZ70PTc0lysSVA==
+  dependencies:
+    "@swc/helpers" "^0.4.14"
+
 "@react-aria/switch@^3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@react-aria/switch/-/switch-3.2.4.tgz#6a4f95d89347b77d215b5b6d3640baba0360880b"
@@ -6779,6 +6819,17 @@
     "@react-types/shared" "^3.16.0"
     clsx "^1.1.1"
 
+"@react-aria/utils@^3.14.2":
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.14.2.tgz#3a8d0d14abab4bb1095e101ee44dc5e3e43e6217"
+  integrity sha512-3nr5gsAf/J/W+6Tu4NF3Q7m+1mXjfpXESh7TPa6UR6v3tVDTsJVMrITg2BkHN1jM8xELcl2ZxyUffOWqOXzWuA==
+  dependencies:
+    "@react-aria/ssr" "^3.4.1"
+    "@react-stately/utils" "^3.5.2"
+    "@react-types/shared" "^3.16.0"
+    "@swc/helpers" "^0.4.14"
+    clsx "^1.1.1"
+
 "@react-aria/visually-hidden@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.6.0.tgz#cc4dd9e648a5c8b6d8dfbd1f70d8672b36d3f1bc"
@@ -6900,6 +6951,16 @@
     "@react-types/checkbox" "^3.4.0"
     "@react-types/shared" "^3.15.0"
 
+"@react-stately/toggle@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.4.4.tgz#b7825bf900725dcee0444fe6132b06948be36b44"
+  integrity sha512-OwVJpd2M7P7fekTWpl3TUdD3Brq+Z/xElOCJYP5QuVytXCa5seKsk40YPld8JQnA5dRKojpbUxMDOJpb6hOOfw==
+  dependencies:
+    "@react-stately/utils" "^3.5.2"
+    "@react-types/checkbox" "^3.4.1"
+    "@react-types/shared" "^3.16.0"
+    "@swc/helpers" "^0.4.14"
+
 "@react-stately/tooltip@^3.2.3":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/@react-stately/tooltip/-/tooltip-3.2.3.tgz#edcd70239b0b872753e6636085e53eafd023a61c"
@@ -6923,6 +6984,13 @@
   integrity sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==
   dependencies:
     "@babel/runtime" "^7.6.2"
+
+"@react-stately/utils@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.2.tgz#9b5f3bb9ad500bf9c5b636a42988dba60a221669"
+  integrity sha512-639gSKqamPHIEPaApb9ahVJS0HgAqNdVF3tQRoh+Ky6759Mbk6i3HqG4zk4IGQ1tVlYSYZvCckwehF7b2zndMg==
+  dependencies:
+    "@swc/helpers" "^0.4.14"
 
 "@react-stately/virtualizer@^3.2.2":
   version "3.2.2"
@@ -6960,6 +7028,13 @@
   integrity sha512-ZDqbtAYWWSGPjL4ydinaWHrD65Qft9yEGA6BCKQTxdJCgxiXxgGkA3pI7Sxwk+OulR+O0CYJ1JROExM9cSJyyQ==
   dependencies:
     "@react-types/shared" "^3.15.0"
+
+"@react-types/checkbox@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@react-types/checkbox/-/checkbox-3.4.1.tgz#75a78b3f21f4cc72d2382761ba4c326aefd699db"
+  integrity sha512-kDMpy9SntjGQ7x00m5zmW8GENPouOtyiDgiEDKsPXUr2iYqHsNtricqVyG9S9+6hqpzuu8BzTcvZamc/xYjzlg==
+  dependencies:
+    "@react-types/shared" "^3.16.0"
 
 "@react-types/dialog@^3.4.5":
   version "3.4.5"
@@ -8435,6 +8510,13 @@
     "@svgr/plugin-jsx" "^5.5.0"
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
+
+"@swc/helpers@^0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
+  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
+  dependencies:
+    tslib "^2.4.0"
 
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
@@ -23610,6 +23692,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsscmp@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

When using a button, it is not a good practise to solely pass `onClick` prop because this event does not consider `Enter` key from using the keyboard.

React-aria handles this with `useButton` by exposing an event called `onPress`, which will be emitted with `Mouse` and `Keyboard`.

There should be no breaking changes.

**NOTE:** I had to add `useFocusVisible` and the reason is explained in this thread from `react-spectrum` https://github.com/adobe/react-spectrum/issues/1247

## Current behaviour (updates)

`onPress` is not exposed as a prop

## New behaviour

`onPress` is now exposed as a prop

