### PR TITLE
feat(TokenStack): add component

### DIFF
--- a/src/component-library/TokenStack/TokenStack.stories.tsx
+++ b/src/component-library/TokenStack/TokenStack.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, Story } from '@storybook/react';
+
+import { TokenStack, TokenStackProps } from '.';
+
+const Template: Story<TokenStackProps> = (args) => <TokenStack {...args} />;
+
+const Default = Template.bind({});
+Default.args = {
+  tickers: ['IBTC', 'KBTC', 'KINT', 'INTR'],
+  size: 'xl2'
+};
+
+export { Default };
+
+export default {
+  title: 'Elements/TokenStack',
+  component: TokenStack
+} as Meta;

--- a/src/component-library/TokenStack/TokenStack.style.tsx
+++ b/src/component-library/TokenStack/TokenStack.style.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+import { Flex } from '../Flex';
+import { theme } from '../theme';
+import { IconSize } from '../utils/prop-types';
+
+type TokenOffset = 'none' | '1/2' | '1/3' | '1/4' | '1/5';
+
+type StyledWrapperProps = {
+  $size: IconSize;
+  $offset: TokenOffset;
+};
+
+const StyledWrapper = styled(Flex)<StyledWrapperProps>`
+  display: flex;
+
+  > :not(:last-child) {
+    // Coin one covers 30% of coin two
+    margin-right: ${({ $size, $offset }) =>
+      $offset !== 'none' && `calc(${theme.icon.sizes[$size]} * calc(${$offset}) * -1)`};
+  }
+`;
+
+export { StyledWrapper };
+export type { StyledWrapperProps, TokenOffset };

--- a/src/component-library/TokenStack/TokenStack.style.tsx
+++ b/src/component-library/TokenStack/TokenStack.style.tsx
@@ -4,7 +4,7 @@ import { Flex } from '../Flex';
 import { theme } from '../theme';
 import { IconSize } from '../utils/prop-types';
 
-type TokenOffset = 'none' | '1/2' | '1/3' | '1/4' | '1/5';
+type TokenOffset = 'none' | '1/2' | '1/3' | '1/4';
 
 type StyledWrapperProps = {
   $size: IconSize;

--- a/src/component-library/TokenStack/TokenStack.tsx
+++ b/src/component-library/TokenStack/TokenStack.tsx
@@ -1,0 +1,25 @@
+import { CoinIcon } from '../CoinIcon';
+import { FlexProps } from '../Flex';
+import { IconSize } from '../utils/prop-types';
+import { StyledWrapper, TokenOffset } from './TokenStack.style';
+
+type Props = {
+  tickers: string[];
+  size?: IconSize;
+  offset?: TokenOffset;
+};
+
+type InheritAttrs = Omit<FlexProps, keyof Props>;
+
+type TokenStackProps = Props & InheritAttrs;
+
+const TokenStack = ({ tickers, gap, size = 'md', offset = '1/3', ...props }: TokenStackProps): JSX.Element => (
+  <StyledWrapper $size={size} $offset={offset} gap={gap} {...props}>
+    {tickers.map((ticker, key) => (
+      <CoinIcon key={`${ticker}-${key}`} size={size} ticker={ticker} />
+    ))}
+  </StyledWrapper>
+);
+
+export { TokenStack };
+export type { TokenStackProps };

--- a/src/component-library/TokenStack/index.tsx
+++ b/src/component-library/TokenStack/index.tsx
@@ -1,0 +1,2 @@
+export type { TokenStackProps } from './TokenStack';
+export { TokenStack } from './TokenStack';

--- a/src/component-library/index.tsx
+++ b/src/component-library/index.tsx
@@ -48,6 +48,8 @@ export type { TokenBalanceProps } from './TokenBalance';
 export { TokenBalance } from './TokenBalance';
 export type { TokenInputProps } from './TokenInput';
 export { TokenInput } from './TokenInput';
+export type { TokenStackProps } from './TokenStack';
+export { TokenStack } from './TokenStack';
 export type { TooltipProps } from './Tooltip';
 export { Tooltip } from './Tooltip';
 export * from './types';


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

For AMM, we will need to handle up to 4 tokens, which is not possible with the current `CoinPair`. Changing it do address this feature would open doors for breaking changes, as well as regressions.

This new component contains features like `offset`, where you can increase or decrease the offset of each token. Useful when there is a need to preserve space.

![image](https://user-images.githubusercontent.com/43269067/211016379-2c9ee85b-b1fa-4b64-b396-35d52aa5cedd.png)

![image](https://user-images.githubusercontent.com/43269067/211016411-e34145a1-ad86-4208-831f-df813df0bc42.png)
