### PR TITLE
fix: native currencies constant

### DIFF
--- a/src/utils/constants/currency.ts
+++ b/src/utils/constants/currency.ts
@@ -17,6 +17,7 @@ import { POLKADOT } from './relay-chain-names';
 const ZERO_VOTE_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, VOTE_GOVERNANCE_TOKEN, true);
 const ZERO_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, GOVERNANCE_TOKEN, true);
 
+// TODO: Pull values in from lib, as we do with vault collaterals
 const NATIVE_CURRENCIES: Array<CurrencyExt> =
   process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT ? [Polkadot, InterBtc, Interlay] : [KBtc, Kintsugi, Kusama];
 

--- a/src/utils/constants/currency.ts
+++ b/src/utils/constants/currency.ts
@@ -12,11 +12,13 @@ import {
 import { GOVERNANCE_TOKEN, VOTE_GOVERNANCE_TOKEN } from '@/config/relay-chains';
 
 import { COINGECKO_IDS } from './api';
+import { POLKADOT } from './relay-chain-names';
 
 const ZERO_VOTE_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, VOTE_GOVERNANCE_TOKEN, true);
 const ZERO_GOVERNANCE_TOKEN_AMOUNT = newMonetaryAmount(0, GOVERNANCE_TOKEN, true);
 
-const NATIVE_CURRENCIES: Array<CurrencyExt> = [Polkadot, InterBtc, Interlay, KBtc, Kintsugi, Kusama];
+const NATIVE_CURRENCIES: Array<CurrencyExt> =
+  process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT ? [Polkadot, InterBtc, Interlay] : [KBtc, Kintsugi, Kusama];
 
 const COINGECKO_ID_BY_CURRENCY_TICKER: Record<string, typeof COINGECKO_IDS[number]> = Object.freeze({
   [Bitcoin.ticker]: 'bitcoin',


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

When dealing with currencies, we should not mix native currencies from Interlay with Kintsugi, and vice-versa. 

## Current behaviour (updates)

Currently we mix them, leading us to query data using currencies that are not native to that parachain.

## New behaviour

Separate these native currencies 

## Reproducible testing steps:

This data is used primarily for `useGetCurrencies`, which is used by `useGetBalances` and `useGetPrices`. So, this change affects the whole app.
