### PR TITLE
Tom/xcm usdt support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^2.0.0",
     "@hookform/resolvers": "^2.9.7",
-    "@interlay/bridge": "^0.1.12",
+    "@interlay/bridge": "^0.1.13",
     "@interlay/interbtc-api": "1.19.0",
     "@material-icons/svg": "^1.0.28",
     "@polkadot/api": "9.8.1",

--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -1,6 +1,6 @@
 import { InterlayAdapter, KintsugiAdapter } from '@interlay/bridge/build/adapters/interlay';
 import { KusamaAdapter, PolkadotAdapter } from '@interlay/bridge/build/adapters/polkadot';
-import { StatemineAdapter } from '@interlay/bridge/build/adapters/statemint';
+import { StatemineAdapter, StatemintAdapter } from '@interlay/bridge/build/adapters/statemint';
 import { BaseCrossChainAdapter } from '@interlay/bridge/build/base-chain-adapter';
 import {
   CurrencyExt,
@@ -154,7 +154,8 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     TRANSACTION_FEE_AMOUNT = newMonetaryAmount(0.2, GOVERNANCE_TOKEN, true);
     XCM_ADAPTERS = {
       interlay: new InterlayAdapter(),
-      polkadot: new PolkadotAdapter()
+      polkadot: new PolkadotAdapter(),
+      statemint: new StatemintAdapter()
     };
 
     break;

--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -1,5 +1,6 @@
 import { InterlayAdapter, KintsugiAdapter } from '@interlay/bridge/build/adapters/interlay';
 import { KusamaAdapter, PolkadotAdapter } from '@interlay/bridge/build/adapters/polkadot';
+import { StatemineAdapter } from '@interlay/bridge/build/adapters/statemint';
 import { BaseCrossChainAdapter } from '@interlay/bridge/build/base-chain-adapter';
 import {
   CurrencyExt,
@@ -193,7 +194,8 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     TRANSACTION_FEE_AMOUNT = newMonetaryAmount(0.01, GOVERNANCE_TOKEN, true);
     XCM_ADAPTERS = {
       kintsugi: new KintsugiAdapter(),
-      kusama: new KusamaAdapter()
+      kusama: new KusamaAdapter(),
+      statemine: new StatemineAdapter()
     };
     break;
   }

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -265,6 +265,10 @@ const CrossChainTransferForm = (): JSX.Element => {
   };
 
   const handleSetFromChain = (chain: ChainOption) => {
+    // Note: this is a around but ok for now. Component will be refactored
+    // when we introduce support for multiple currencies per channel
+    setCurrency(undefined);
+    setToChain(undefined);
     setFromChain(chain);
   };
 

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -269,6 +269,7 @@ const CrossChainTransferForm = (): JSX.Element => {
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);
     setToChain(undefined);
+    setValue(TRANSFER_AMOUNT, '0');
     setFromChain(chain);
   };
 
@@ -276,11 +277,12 @@ const CrossChainTransferForm = (): JSX.Element => {
     // Note: this is a workaround but ok for now. Component will be refactored
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);
+    setValue(TRANSFER_AMOUNT, '0');
     setToChain(chain);
   };
 
   const handleClickBalance = () => {
-    setValue(TRANSFER_AMOUNT, transferableBalance);
+    setValue(TRANSFER_AMOUNT, transferableBalance.toString());
     handleUpdateUsdAmount(transferableBalance);
     trigger(TRANSFER_AMOUNT);
   };

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -265,11 +265,18 @@ const CrossChainTransferForm = (): JSX.Element => {
   };
 
   const handleSetFromChain = (chain: ChainOption) => {
-    // Note: this is a around but ok for now. Component will be refactored
+    // Note: this is a workaround but ok for now. Component will be refactored
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);
     setToChain(undefined);
     setFromChain(chain);
+  };
+
+  const handleSetToChain = (chain: ChainOption) => {
+    // Note: this is a workaround but ok for now. Component will be refactored
+    // when we introduce support for multiple currencies per channel
+    setCurrency(undefined);
+    setToChain(chain);
   };
 
   const handleClickBalance = () => {
@@ -331,6 +338,7 @@ const CrossChainTransferForm = (): JSX.Element => {
           chainOptions={toChains}
           label={t('transfer_page.cross_chain_transfer_form.to_chain')}
           selectedChain={toChain}
+          onChange={handleSetToChain}
         />
         <Accounts
           label={t('transfer_page.cross_chain_transfer_form.target_account')}

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -265,6 +265,9 @@ const CrossChainTransferForm = (): JSX.Element => {
   };
 
   const handleSetFromChain = (chain: ChainOption) => {
+    // Return from function is user clicks on current chain option
+    if (chain === fromChain) return;
+
     // Note: this is a workaround but ok for now. Component will be refactored
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);
@@ -274,6 +277,9 @@ const CrossChainTransferForm = (): JSX.Element => {
   };
 
   const handleSetToChain = (chain: ChainOption) => {
+    // Return from function is user clicks on current chain option
+    if (chain === toChain) return;
+
     // Note: this is a workaround but ok for now. Component will be refactored
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -283,7 +283,7 @@ const CrossChainTransferForm = (): JSX.Element => {
     // Note: this is a workaround but ok for now. Component will be refactored
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);
-    setValue(TRANSFER_AMOUNT, '0');
+    setValue(TRANSFER_AMOUNT, '');
     setToChain(chain);
   };
 

--- a/src/pages/Transfer/CrossChainTransferForm/index.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/index.tsx
@@ -269,7 +269,7 @@ const CrossChainTransferForm = (): JSX.Element => {
     // when we introduce support for multiple currencies per channel
     setCurrency(undefined);
     setToChain(undefined);
-    setValue(TRANSFER_AMOUNT, '0');
+    setValue(TRANSFER_AMOUNT, '');
     setFromChain(chain);
   };
 

--- a/src/utils/hooks/api/xcm/use-xcm-bridge.ts
+++ b/src/utils/hooks/api/xcm/use-xcm-bridge.ts
@@ -24,12 +24,22 @@ const getEndpoints = (chains: ChainName[]) => {
           'wss://kusama.api.onfinality.io/public-ws',
           'wss://kusama-rpc.dwellir.com'
         ],
-        kintsugi: ['wss://api-kusama.interlay.io/parachain', 'wss://kintsugi.api.onfinality.io/public-ws']
+        kintsugi: ['wss://api-kusama.interlay.io/parachain', 'wss://kintsugi.api.onfinality.io/public-ws'],
+        statemine: [
+          'wss://statemine-rpc.polkadot.io',
+          'wss://statemine.api.onfinality.io/public-ws',
+          'wss://statemine-rpc.dwellir.com'
+        ]
       };
     case chains.includes('polkadot'):
       return {
         polkadot: ['wss://rpc.polkadot.io', 'wss://polkadot.api.onfinality.io/public-ws'],
-        interlay: ['wss://api.interlay.io/parachain', 'wss://interlay.api.onfinality.io/public-ws']
+        interlay: ['wss://api.interlay.io/parachain', 'wss://interlay.api.onfinality.io/public-ws'],
+        statemint: [
+          'wss://statemint-rpc.polkadot.io',
+          'wss://statemint.api.onfinality.io/public-ws',
+          'wss://statemint-rpc.dwellir.com'
+        ]
       };
 
     default:

--- a/src/utils/hooks/api/xcm/use-xcm-bridge.ts
+++ b/src/utils/hooks/api/xcm/use-xcm-bridge.ts
@@ -19,27 +19,15 @@ const getEndpoints = (chains: ChainName[]) => {
   switch (true) {
     case chains.includes('kusama'):
       return {
-        kusama: [
-          'wss://kusama-rpc.polkadot.io',
-          'wss://kusama.api.onfinality.io/public-ws',
-          'wss://kusama-rpc.dwellir.com'
-        ],
+        kusama: ['wss://kusama-rpc.polkadot.io', 'wss://kusama.api.onfinality.io/public-ws'],
         kintsugi: ['wss://api-kusama.interlay.io/parachain', 'wss://kintsugi.api.onfinality.io/public-ws'],
-        statemine: [
-          'wss://statemine-rpc.polkadot.io',
-          'wss://statemine.api.onfinality.io/public-ws',
-          'wss://statemine-rpc.dwellir.com'
-        ]
+        statemine: ['wss://statemine-rpc.polkadot.io', 'wss://statemine.api.onfinality.io/public-ws']
       };
     case chains.includes('polkadot'):
       return {
         polkadot: ['wss://rpc.polkadot.io', 'wss://polkadot.api.onfinality.io/public-ws'],
         interlay: ['wss://api.interlay.io/parachain', 'wss://interlay.api.onfinality.io/public-ws'],
-        statemint: [
-          'wss://statemint-rpc.polkadot.io',
-          'wss://statemint.api.onfinality.io/public-ws',
-          'wss://statemint-rpc.dwellir.com'
-        ]
+        statemint: ['wss://statemint-rpc.polkadot.io', 'wss://statemint.api.onfinality.io/public-ws']
       };
 
     default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,10 +3070,10 @@
   dependencies:
     browser-headers "^0.4.1"
 
-"@interlay/bridge@^0.1.12":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@interlay/bridge/-/bridge-0.1.12.tgz#74f00bd735eb5771220751d015bb4e1157bbe22b"
-  integrity sha512-yClLq+8xuVWnzybZET4hf+ZLVhQtmhuyBb7McgECaQX0bo6Twq1cDUO4yHvkcbZ/ykZQR8K2lLCa8uQfgcZuiA==
+"@interlay/bridge@^0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@interlay/bridge/-/bridge-0.1.13.tgz#f17974ef6b65aa541943494d682be33b9b303dce"
+  integrity sha512-sqh+8fTPZarLYmeCejaxOi0M/2ral4E26ViVQREt8MWFEUg1hEkaUi9AFWpqKrbHOEj8GTrI8ipNMFdqwVUMew==
   dependencies:
     "@acala-network/api" "4.1.6-23"
     "@acala-network/sdk" "4.1.6-23"


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Add USDT support to Interlay and Kintsugi

## Current behaviour (updates)

Only DOT and KSM are supported as XCM transfer assets

## New behaviour

USDT can be transferred between Interlay/Kintsugi and Statemint/Statemine. Existing behaviour is maintained.
This PR also fixes an issue populating the form field with the max transferable balance.

## Reproducible testing steps:

Note: testing must be done against mainnet.

* Transfer USDT between Interlay and Statemint in both directions.
* Transfer USDT between Kintsugi and Statemine in both directions.
* Transfer DOT between Interlay and Polkadot in both directions.
* Transfer KSM between Kintsugi and Kusama in both directions.
* Check that the max transferable balance functionality is working for all currencies by clicking on the transferable balance amount above the input.