### PR TITLE
Rui/modal overflow

### DIFF
--- a/src/component-library/Modal/Modal.stories.tsx
+++ b/src/component-library/Modal/Modal.stories.tsx
@@ -96,7 +96,6 @@ LargeContent.args = {
   isOpen: false,
   hasFooter: true,
   hasTitle: true,
-  isCentered: true,
   children: (
     <>
       Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.

--- a/src/component-library/Modal/Modal.stories.tsx
+++ b/src/component-library/Modal/Modal.stories.tsx
@@ -96,6 +96,7 @@ LargeContent.args = {
   isOpen: false,
   hasFooter: true,
   hasTitle: true,
+  isCentered: true,
   children: (
     <>
       Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -45,7 +45,6 @@ const StyledUnderlay = styled.div<Pick<StyledDialogWrapperProps, '$isCentered'>>
 const StyledDialogWrapper = styled.div<StyledDialogWrapperProps>`
   justify-content: center;
   display: flex;
-  height: max-content;
   z-index: ${theme.modal.zIndex};
   transition: opacity ${theme.transition.duration.duration100}ms ease-out;
   margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -7,7 +7,7 @@ import { Divider } from '../Divider';
 import { Flex } from '../Flex';
 import { H3 } from '../Text';
 import { theme } from '../theme';
-import { NormalAlignments, Overflow } from '../utils/prop-types';
+import { Overflow } from '../utils/prop-types';
 
 type StyledDialogWrapperProps = {
   $transitionTrigger?: TransitionTrigger;
@@ -18,10 +18,6 @@ type StyledDialogProps = {
   $isCentered?: boolean;
 };
 
-type StyledModalHeaderProps = {
-  $alignment?: NormalAlignments;
-};
-
 type StyledModalBodyProps = {
   $overflow?: Overflow;
   $noPadding?: boolean;
@@ -30,29 +26,25 @@ type StyledModalBodyProps = {
 const StyledUnderlay = styled.div`
   position: fixed;
   z-index: ${theme.modal.underlay.zIndex};
-  inset: 0;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+
   background: ${theme.modal.underlay.bg};
   display: flex;
-  align-items: center;
   justify-content: center;
-  height: 100vh;
-  overflow: hidden;
-  pointer-events: auto;
+  overflow: auto;
 `;
 
 const StyledDialogWrapper = styled.div<StyledDialogWrapperProps>`
-  width: 100vw;
-  height: 100vh;
   justify-content: center;
-  align-items: ${({ $isCentered }) => ($isCentered ? 'center' : 'flex-start')};
   display: flex;
-  position: fixed;
-  pointer-events: ${({ $isCentered }) => $isCentered && 'none'};
-  overflow: ${({ $isCentered }) => !$isCentered && 'auto'};
+  height: max-content;
   z-index: ${theme.modal.zIndex};
-  top: 0;
-  left: 0;
   transition: opacity ${theme.transition.duration.duration100}ms ease-out;
+  margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};
+
   transition-property: opacity, transform;
   ${({ $transitionTrigger }) =>
     $transitionTrigger === 'in' ? `opacity: 1; transform: translateY(0);` : `opacity: 0; transform: translateY(2em);`}
@@ -68,7 +60,6 @@ const StyledDialog = styled.section<StyledDialogProps>`
   width: 100%;
   max-height: ${({ $isCentered }) => $isCentered && theme.modal.maxHeight};
   overflow: ${({ $isCentered }) => $isCentered && 'hidden'};
-  margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};
   pointer-events: auto;
 
   display: flex;
@@ -83,10 +74,7 @@ const StyledCloseCTA = styled(CTA)`
   z-index: ${theme.modal.closeBtn.zIndex};
 `;
 
-const StyledModalHeader = styled(H3)<StyledModalHeaderProps>`
-  font-size: ${theme.text.xl};
-  line-height: ${theme.lineHeight.base};
-  text-align: ${({ $alignment }) => $alignment};
+const StyledModalHeader = styled(H3)`
   padding: ${theme.modal.header.paddingY} ${theme.modal.header.paddingX};
   flex-shrink: 0;
 `;

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -7,7 +7,7 @@ import { Divider } from '../Divider';
 import { Flex } from '../Flex';
 import { H3 } from '../Text';
 import { theme } from '../theme';
-import { Overflow } from '../utils/prop-types';
+import { NormalAlignments, Overflow } from '../utils/prop-types';
 
 type StyledDialogWrapperProps = {
   $transitionTrigger?: TransitionTrigger;
@@ -18,12 +18,16 @@ type StyledDialogProps = {
   $isCentered?: boolean;
 };
 
+type StyledModalHeaderProps = {
+  $alignment?: NormalAlignments;
+};
+
 type StyledModalBodyProps = {
   $overflow?: Overflow;
   $noPadding?: boolean;
 };
 
-const StyledUnderlay = styled.div`
+const StyledUnderlay = styled.div<Pick<StyledDialogWrapperProps, '$isCentered'>>`
   position: fixed;
   z-index: ${theme.modal.underlay.zIndex};
   top: 0;
@@ -34,7 +38,8 @@ const StyledUnderlay = styled.div`
   background: ${theme.modal.underlay.bg};
   display: flex;
   justify-content: center;
-  overflow: auto;
+  align-items: ${({ $isCentered }) => ($isCentered ? 'center' : 'flex-start')};
+  overflow: ${({ $isCentered }) => !$isCentered && 'auto'};
 `;
 
 const StyledDialogWrapper = styled.div<StyledDialogWrapperProps>`
@@ -44,7 +49,9 @@ const StyledDialogWrapper = styled.div<StyledDialogWrapperProps>`
   z-index: ${theme.modal.zIndex};
   transition: opacity ${theme.transition.duration.duration100}ms ease-out;
   margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};
-
+  max-width: ${theme.modal.maxWidth};
+  max-height: ${({ $isCentered }) => $isCentered && theme.modal.maxHeight};
+  width: 100%;
   transition-property: opacity, transform;
   ${({ $transitionTrigger }) =>
     $transitionTrigger === 'in' ? `opacity: 1; transform: translateY(0);` : `opacity: 0; transform: translateY(2em);`}
@@ -56,9 +63,7 @@ const StyledDialog = styled.section<StyledDialogProps>`
   border-radius: ${theme.rounded.md};
   color: ${theme.colors.textPrimary};
 
-  max-width: ${theme.modal.maxWidth};
   width: 100%;
-  max-height: ${({ $isCentered }) => $isCentered && theme.modal.maxHeight};
   overflow: ${({ $isCentered }) => $isCentered && 'hidden'};
   pointer-events: auto;
 
@@ -74,7 +79,10 @@ const StyledCloseCTA = styled(CTA)`
   z-index: ${theme.modal.closeBtn.zIndex};
 `;
 
-const StyledModalHeader = styled(H3)`
+const StyledModalHeader = styled(H3)<StyledModalHeaderProps>`
+  font-size: ${theme.text.xl};
+  line-height: ${theme.lineHeight.base};
+  text-align: ${({ $alignment }) => $alignment};
   padding: ${theme.modal.header.paddingY} ${theme.modal.header.paddingX};
   flex-shrink: 0;
 `;

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -11,6 +11,11 @@ import { NormalAlignments, Overflow } from '../utils/prop-types';
 
 type StyledDialogWrapperProps = {
   $transitionTrigger?: TransitionTrigger;
+  $isCentered?: boolean;
+};
+
+type StyledDialogProps = {
+  $isCentered?: boolean;
 };
 
 type StyledModalHeaderProps = {
@@ -39,21 +44,21 @@ const StyledDialogWrapper = styled.div<StyledDialogWrapperProps>`
   width: 100vw;
   height: 100vh;
   justify-content: center;
-  align-items: center;
+  align-items: ${({ $isCentered }) => ($isCentered ? 'center' : 'flex-start')};
   display: flex;
   position: fixed;
-  pointer-events: none;
+  pointer-events: ${({ $isCentered }) => $isCentered && 'none'};
+  overflow: ${({ $isCentered }) => !$isCentered && 'auto'};
   z-index: ${theme.modal.zIndex};
   top: 0;
   left: 0;
-
   transition: opacity ${theme.transition.duration.duration100}ms ease-out;
   transition-property: opacity, transform;
   ${({ $transitionTrigger }) =>
     $transitionTrigger === 'in' ? `opacity: 1; transform: translateY(0);` : `opacity: 0; transform: translateY(2em);`}
 `;
 
-const StyledDialog = styled.section`
+const StyledDialog = styled.section<StyledDialogProps>`
   background: ${theme.colors.bgPrimary};
   border: ${theme.border.default};
   border-radius: ${theme.rounded.md};
@@ -61,10 +66,10 @@ const StyledDialog = styled.section`
 
   max-width: ${theme.modal.maxWidth};
   width: 100%;
-  max-height: ${theme.modal.maxHeight};
-  margin: 0 ${theme.spacing.spacing6};
+  max-height: ${({ $isCentered }) => $isCentered && theme.modal.maxHeight};
+  overflow: ${({ $isCentered }) => $isCentered && 'hidden'};
+  margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};
   pointer-events: auto;
-  overflow: hidden;
 
   display: flex;
   flex-direction: column;

--- a/src/component-library/Modal/Modal.tsx
+++ b/src/component-library/Modal/Modal.tsx
@@ -41,7 +41,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
 
     return isOpen || shouldRender ? (
       <OverlayContainer>
-        <StyledUnderlay {...underlayProps}>
+        <StyledUnderlay {...underlayProps} $isCentered={isCentered}>
           <FocusScope contain restoreFocus autoFocus>
             <StyledDialogWrapper
               ref={dialogRef}
@@ -49,7 +49,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
               $isCentered={isCentered}
               {...modalProps}
             >
-              <ModalContext.Provider value={{ titleProps }}>
+              <ModalContext.Provider value={{ titleProps, bodyProps: { overflow: isCentered ? 'auto' : undefined } }}>
                 <StyledDialog $isCentered={isCentered} {...dialogProps}>
                   <StyledCloseCTA size='small' variant='text' aria-label='Dismiss' onPress={onClose}>
                     <XMark />

--- a/src/component-library/Modal/Modal.tsx
+++ b/src/component-library/Modal/Modal.tsx
@@ -14,7 +14,7 @@ import { ModalContext } from './ModalContext';
 
 type Props = {
   children: ReactNode;
-  isCentered?: boolean;
+  align?: 'top' | 'center';
 };
 
 type InheritAttrs = Omit<AriaDialogProps & AriaOverlayProps, keyof Props>;
@@ -22,7 +22,7 @@ type InheritAttrs = Omit<AriaDialogProps & AriaOverlayProps, keyof Props>;
 type ModalProps = Props & InheritAttrs;
 
 const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ children, isDismissable = true, isCentered, ...props }, ref): JSX.Element | null => {
+  ({ children, isDismissable = true, align = 'center', ...props }, ref): JSX.Element | null => {
     const dialogRef = useDOMRef(ref);
     const { isOpen, onClose } = props;
     const { shouldRender, transitionTrigger } = useMountTransition(!!isOpen, theme.transition.duration.duration100);
@@ -38,6 +38,8 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
 
     // Get props for the dialog and its title
     const { dialogProps, titleProps } = useDialog(props, dialogRef);
+
+    const isCentered = align === 'center';
 
     return isOpen || shouldRender ? (
       <OverlayContainer>

--- a/src/component-library/Modal/Modal.tsx
+++ b/src/component-library/Modal/Modal.tsx
@@ -14,6 +14,7 @@ import { ModalContext } from './ModalContext';
 
 type Props = {
   children: ReactNode;
+  isCentered?: boolean;
 };
 
 type InheritAttrs = Omit<AriaDialogProps & AriaOverlayProps, keyof Props>;
@@ -21,7 +22,7 @@ type InheritAttrs = Omit<AriaDialogProps & AriaOverlayProps, keyof Props>;
 type ModalProps = Props & InheritAttrs;
 
 const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ children, isDismissable = true, ...props }, ref): JSX.Element | null => {
+  ({ children, isDismissable = true, isCentered, ...props }, ref): JSX.Element | null => {
     const dialogRef = useDOMRef(ref);
     const { isOpen, onClose } = props;
     const { shouldRender, transitionTrigger } = useMountTransition(!!isOpen, theme.transition.duration.duration100);
@@ -42,9 +43,14 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
       <OverlayContainer>
         <StyledUnderlay {...underlayProps} />
         <FocusScope contain restoreFocus autoFocus>
-          <StyledDialogWrapper ref={dialogRef} {...modalProps} $transitionTrigger={transitionTrigger}>
+          <StyledDialogWrapper
+            ref={dialogRef}
+            $transitionTrigger={transitionTrigger}
+            $isCentered={isCentered}
+            {...modalProps}
+          >
             <ModalContext.Provider value={{ titleProps }}>
-              <StyledDialog {...dialogProps}>
+              <StyledDialog $isCentered={isCentered} {...dialogProps}>
                 <StyledCloseCTA size='small' variant='text' aria-label='Dismiss' onPress={onClose}>
                   <XMark />
                 </StyledCloseCTA>

--- a/src/component-library/Modal/Modal.tsx
+++ b/src/component-library/Modal/Modal.tsx
@@ -41,24 +41,25 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
 
     return isOpen || shouldRender ? (
       <OverlayContainer>
-        <StyledUnderlay {...underlayProps} />
-        <FocusScope contain restoreFocus autoFocus>
-          <StyledDialogWrapper
-            ref={dialogRef}
-            $transitionTrigger={transitionTrigger}
-            $isCentered={isCentered}
-            {...modalProps}
-          >
-            <ModalContext.Provider value={{ titleProps }}>
-              <StyledDialog $isCentered={isCentered} {...dialogProps}>
-                <StyledCloseCTA size='small' variant='text' aria-label='Dismiss' onPress={onClose}>
-                  <XMark />
-                </StyledCloseCTA>
-                {children}
-              </StyledDialog>
-            </ModalContext.Provider>
-          </StyledDialogWrapper>
-        </FocusScope>
+        <StyledUnderlay {...underlayProps}>
+          <FocusScope contain restoreFocus autoFocus>
+            <StyledDialogWrapper
+              ref={dialogRef}
+              $transitionTrigger={transitionTrigger}
+              $isCentered={isCentered}
+              {...modalProps}
+            >
+              <ModalContext.Provider value={{ titleProps }}>
+                <StyledDialog $isCentered={isCentered} {...dialogProps}>
+                  <StyledCloseCTA size='small' variant='text' aria-label='Dismiss' onPress={onClose}>
+                    <XMark />
+                  </StyledCloseCTA>
+                  {children}
+                </StyledDialog>
+              </ModalContext.Provider>
+            </StyledDialogWrapper>
+          </FocusScope>
+        </StyledUnderlay>
       </OverlayContainer>
     ) : null;
   }

--- a/src/component-library/Modal/ModalBody.tsx
+++ b/src/component-library/Modal/ModalBody.tsx
@@ -11,7 +11,7 @@ type InheritAttrs = Omit<FlexProps, keyof Props>;
 
 type ModalBodyProps = Props & InheritAttrs;
 
-const ModalBody = ({ overflow = 'auto', noPadding, direction = 'column', ...props }: ModalBodyProps): JSX.Element => (
+const ModalBody = ({ overflow, noPadding, direction = 'column', ...props }: ModalBodyProps): JSX.Element => (
   <StyledModalBody {...props} $overflow={overflow} $noPadding={noPadding} direction={direction} />
 );
 

--- a/src/component-library/Modal/ModalBody.tsx
+++ b/src/component-library/Modal/ModalBody.tsx
@@ -18,7 +18,7 @@ const ModalBody = ({ overflow, noPadding, direction = 'column', ...props }: Moda
   return (
     <StyledModalBody
       {...props}
-      $overflow={bodyProps?.overflow || overflow}
+      $overflow={overflow || bodyProps?.overflow}
       $noPadding={noPadding}
       direction={direction}
     />

--- a/src/component-library/Modal/ModalBody.tsx
+++ b/src/component-library/Modal/ModalBody.tsx
@@ -1,6 +1,7 @@
 import { FlexProps } from '../Flex';
 import { Overflow } from '../utils/prop-types';
 import { StyledModalBody } from './Modal.style';
+import { useModalContext } from './ModalContext';
 
 type Props = {
   overflow?: Overflow;
@@ -11,9 +12,18 @@ type InheritAttrs = Omit<FlexProps, keyof Props>;
 
 type ModalBodyProps = Props & InheritAttrs;
 
-const ModalBody = ({ overflow, noPadding, direction = 'column', ...props }: ModalBodyProps): JSX.Element => (
-  <StyledModalBody {...props} $overflow={overflow} $noPadding={noPadding} direction={direction} />
-);
+const ModalBody = ({ overflow, noPadding, direction = 'column', ...props }: ModalBodyProps): JSX.Element => {
+  const { bodyProps } = useModalContext();
+
+  return (
+    <StyledModalBody
+      {...props}
+      $overflow={bodyProps?.overflow || overflow}
+      $noPadding={noPadding}
+      direction={direction}
+    />
+  );
+};
 
 export { ModalBody };
 export type { ModalBodyProps };

--- a/src/component-library/Modal/ModalContext.tsx
+++ b/src/component-library/Modal/ModalContext.tsx
@@ -1,8 +1,11 @@
 import { DOMAttributes } from '@react-types/shared';
 import React from 'react';
 
+import { ModalBodyProps } from './ModalBody';
+
 interface ModalConfig {
   titleProps?: DOMAttributes;
+  bodyProps?: ModalBodyProps;
 }
 
 const defaultContext = {};

--- a/src/component-library/theme/theme.base.css
+++ b/src/component-library/theme/theme.base.css
@@ -97,6 +97,7 @@
   --spacing-10: 2.5rem;
   --spacing-12: 3rem;
   --spacing-14: 3.5rem;
+  --spacing-16: 4rem;
   --spacing-28: 7rem;
 
   --rounded-sm: 2px;

--- a/src/component-library/theme/theme.ts
+++ b/src/component-library/theme/theme.ts
@@ -56,6 +56,7 @@ const theme = {
     spacing10: 'var(--spacing-10)',
     spacing12: 'var(--spacing-12)',
     spacing14: 'var(--spacing-14)',
+    spacing16: 'var(--spacing-16)',
     spacing28: 'var(--spacing-28)'
   },
   rounded: {

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.style.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.style.tsx
@@ -2,14 +2,8 @@ import styled from 'styled-components';
 
 import { Flex, theme } from '@/component-library';
 
-type StyledFormWrapperProps = {
-  $showBorrowLimit: boolean;
-};
-
-const StyledFormWrapper = styled(Flex)<StyledFormWrapperProps>`
+const StyledFormWrapper = styled(Flex)`
   margin-top: ${theme.spacing.spacing8};
-  // MEMO: keep the same height across each tab
-  min-height: ${({ $showBorrowLimit }) => ($showBorrowLimit ? '32rem' : '20rem')};
 `;
 
 export { StyledFormWrapper };

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -178,12 +178,7 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
   return (
     <>
       <form onSubmit={h(handleSubmit)}>
-        <StyledFormWrapper
-          $showBorrowLimit={showBorrowLimit}
-          direction='column'
-          justifyContent='space-between'
-          gap='spacing4'
-        >
+        <StyledFormWrapper direction='column' justifyContent='space-between' gap='spacing4'>
           <Flex direction='column' gap='spacing4'>
             <TokenInput
               placeholder='0.00'

--- a/src/pages/Loans/LoansOverview/components/LoanModal/LoanModal.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanModal/LoanModal.tsx
@@ -50,7 +50,7 @@ const LoanModal = ({ variant = 'lend', asset, position, onClose, ...props }: Loa
   const { tabs } = getData(t, variant);
 
   return (
-    <Modal aria-label={`${variant} ${asset.currency.ticker}`} onClose={onClose} {...props}>
+    <Modal aria-label={`${variant} ${asset.currency.ticker}`} onClose={onClose} align='top' {...props}>
       <ModalBody noPadding>
         <StyledTabs size='large' fullWidth>
           {tabs.map((tab) => (


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Allow the possibility of having two placements for our modal:
1. On the top of the screen (default), with the functionality o scroll the overlay when content overflows
![image](https://user-images.githubusercontent.com/43269067/212917200-8c15724a-b9f1-4591-b5df-b1733fcf88a4.png)
2. On the center of the screen, with the functionality of scroll the modal body when content overflows
![image](https://user-images.githubusercontent.com/43269067/212917120-ccd0a97a-cb22-47dc-b6d6-a79c81659e09.png)


This `1.` solves a on going problem with content shift when modal contains `Tabs`.

## Current behaviour (updates)

Modal is solely centered on the screen.

## New behaviour

Modal placed on the top of the screen.

## Reproducible testing steps:

- Vault onboarding
- Lending