### PR TITLE
fix(Loans): remove earnedInterest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@heroicons/react": "^2.0.0",
     "@hookform/resolvers": "^2.9.7",
     "@interlay/bridge": "^0.2.1",
-    "@interlay/interbtc-api": "1.20.0",
+    "@interlay/interbtc-api": "1.20.1",
     "@material-icons/svg": "^1.0.28",
     "@polkadot/api": "9.11.1",
     "@polkadot/extension-dapp": "0.44.1",

--- a/src/pages/Loans/LoansOverview/components/LendPositionsTable/LendPositionsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/LendPositionsTable/LendPositionsTable.tsx
@@ -51,7 +51,7 @@ const LendPositionsTable = ({
 
   const rows: LendPositionTableRow[] = useMemo(
     () =>
-      positions.map(({ amount, currency, earnedInterest, isCollateral }) => {
+      positions.map(({ amount, currency, isCollateral }) => {
         const asset = <AssetCell currency={currency.ticker} />;
 
         const { lendApy, lendReward } = assets[currency.ticker];
@@ -62,7 +62,6 @@ const LendPositionsTable = ({
             currency={currency}
             prices={prices}
             rewards={lendReward}
-            earnedInterest={earnedInterest}
             // TODO: temporary until we find why row click is being ignored
             onClick={() => onRowAction?.(currency.ticker as Key)}
           />

--- a/src/pages/Loans/LoansOverview/components/LoansInsights/LoansInsights.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoansInsights/LoansInsights.tsx
@@ -27,10 +27,11 @@ const LoansInsights = ({ statistics }: LoansInsightsProps): JSX.Element => {
 
   const handleClickClaimRewards = () => claimRewardsMutation.mutate();
 
-  const { supplyAmountUSD, netAmountUSD, netAPY } = statistics || {};
+  const { supplyAmountUSD, netAPY } = statistics || {};
 
   const supplyBalanceLabel = formatUSD(supplyAmountUSD?.toNumber() || 0);
-  const netBalanceLabel = formatUSD(netAmountUSD?.toNumber() || 0);
+  // TODO: temporary until squid has earned interest calculation.
+  // const netBalanceLabel = formatUSD(netAmountUSD?.toNumber() || 0);
   const netPercentage = formatPercentage(netAPY?.toNumber() || 0);
   const netPercentageLabel = `${netAPY?.gt(0) ? '+' : ''}${netPercentage}`;
 
@@ -52,9 +53,8 @@ const LoansInsights = ({ statistics }: LoansInsightsProps): JSX.Element => {
         <Card flex='1'>
           <DlGroup direction='column' alignItems='flex-start' gap='spacing1'>
             <StyledDt color='primary'>Net APY</StyledDt>
-            <StyledDd color='secondary'>
-              {netPercentageLabel} ({netBalanceLabel})
-            </StyledDd>
+            {/* {netPercentageLabel} ({netBalanceLabel}) */}
+            <StyledDd color='secondary'>{netPercentageLabel}</StyledDd>
           </DlGroup>
         </Card>
         <Card

--- a/src/utils/hooks/api/loans/use-get-account-positions.tsx
+++ b/src/utils/hooks/api/loans/use-get-account-positions.tsx
@@ -55,7 +55,6 @@ interface AccountPositionsStatisticsData {
   earnedDeptAmountUSD: Big;
   netAmountUSD: Big;
   netAPY: Big;
-  thresholds?: PositionsThresholdsData;
 }
 
 const getNetAPY = (
@@ -139,24 +138,25 @@ const getAccountPositionsStats = (
   );
 
   const collateralizedAmountUSD = getPositionsSumOfFieldsInUSD('amount', collateralLendPositions, prices);
-  const earnedInterestAmountUSD = getPositionsSumOfFieldsInUSD<LendPosition>('earnedInterest', lendPositions, prices);
   const earnedDeptAmountUSD = getPositionsSumOfFieldsInUSD('accumulatedDebt', borrowPositions, prices);
 
-  const totalEarnedRewardsUSDValue =
-    convertMonetaryAmountToValueInUSD(subsidyRewards, getTokenPrice(prices, subsidyRewards.currency.ticker)?.usd) || 0;
-  const netAmountUSD = earnedInterestAmountUSD.add(totalEarnedRewardsUSDValue).sub(earnedDeptAmountUSD);
+  // TODO: This is temporary, atleast until earned interest
+  // is moved into squid.
+  // const totalEarnedRewardsUSDValue =
+  //   convertMonetaryAmountToValueInUSD(subsidyRewards, getTokenPrice(prices, subsidyRewards.currency.ticker)?.usd) || 0;
+  // const netAmountUSD = earnedInterestAmountUSD.add(totalEarnedRewardsUSDValue).sub(earnedDeptAmountUSD);
 
   const netAPY = getNetAPY(lendPositions, borrowPositions, assets, supplyAmountUSD, prices);
 
   return {
     supplyAmountUSD,
     borrowAmountUSD,
-    earnedInterestAmountUSD,
+    earnedInterestAmountUSD: new Big(0),
     collateralAmountUSD,
     liquidationAmountUSD,
     collateralizedAmountUSD,
     earnedDeptAmountUSD,
-    netAmountUSD,
+    netAmountUSD: new Big(0),
     netAPY
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,10 +2583,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@1.20.0":
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-1.20.0.tgz#9726395cd42abc1bde8ce948412668de915bc746"
-  integrity sha512-tAA2rMAIHwC7/vEuhMJ5NgyYVNa84TZ3w/dzBwwGVaGUW8RyobDza0q4eFdSNPR9EFYy2yg+pQ/bTlHZgrnHLg==
+"@interlay/interbtc-api@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-1.20.1.tgz#28988fdc1dd59089e48c9ac3e29100b21e5e2a80"
+  integrity sha512-YbhJJtcW1ZS5X6j/lxSfTJPzWNzw6nWj1i6UtwLL5u6nLANBeo7jL6VLM1MpWhCe1sXOG60CoTejkhdzNDVqXQ==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "1.11.0"


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Remove `earnedInterest` from Loans page

## Current behaviour (updates)

Loans page displays user earned interest in USD

## New behaviour

Temporarily removed it, leave only the net apy.

## Reproducible testing steps:

- Create lend positions and borrow positions