### PR TITLE
fix(TokenInput): state, input padding and list

### DIFF
--- a/src/component-library/Input/BaseInput.tsx
+++ b/src/component-library/Input/BaseInput.tsx
@@ -56,9 +56,8 @@ const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
     useEffect(() => {
       if (!endAdornmentRef.current || !endAdornment) return;
 
-      setEndAdornmentWidth(endAdornmentRef.current.clientWidth);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [endAdornment, endAdornmentRef.current]);
+      setEndAdornmentWidth(endAdornmentRef.current.getBoundingClientRect().width);
+    }, [endAdornment]);
 
     return (
       <Wrapper hidden={hidden} className={className} style={style} $isDisabled={!!disabled}>

--- a/src/component-library/Input/BaseInput.tsx
+++ b/src/component-library/Input/BaseInput.tsx
@@ -1,17 +1,18 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from 'react';
+import { useEffect } from 'react';
+import { useState } from 'react';
+import { forwardRef, InputHTMLAttributes, ReactNode, useRef } from 'react';
 
 import { HelperText, HelperTextProps } from '../HelperText';
 import { hasErrorMessage } from '../HelperText/HelperText';
 import { Label, LabelProps } from '../Label';
 import { Sizes } from '../utils/prop-types';
-import { Adornment, BaseInputWrapper, PaddingX, StyledBaseInput, Wrapper } from './Input.style';
+import { Adornment, BaseInputWrapper, StyledBaseInput, Wrapper } from './Input.style';
 
 type Props = {
   label?: ReactNode;
   labelProps?: LabelProps;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
-  paddingX?: PaddingX;
   bottomAdornment?: ReactNode;
   value?: string | ReadonlyArray<string> | number;
   defaultValue?: string | ReadonlyArray<string> | number;
@@ -33,7 +34,6 @@ const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
       hidden,
       startAdornment,
       endAdornment,
-      paddingX,
       bottomAdornment,
       label,
       labelProps,
@@ -47,8 +47,18 @@ const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
     },
     ref
   ): JSX.Element => {
+    const endAdornmentRef = useRef<HTMLDivElement>(null);
+    const [endAdornmentWidth, setEndAdornmentWidth] = useState(0);
+
     const hasError = hasErrorMessage(errorMessage);
     const hasHelpText = !!description || hasError;
+
+    useEffect(() => {
+      if (!endAdornmentRef.current || !endAdornment) return;
+
+      setEndAdornmentWidth(endAdornmentRef.current.clientWidth);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [endAdornment, endAdornmentRef.current]);
 
     return (
       <Wrapper hidden={hidden} className={className} style={style} $isDisabled={!!disabled}>
@@ -61,13 +71,17 @@ const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
             ref={ref}
             type='text'
             $adornments={{ bottom: !!bottomAdornment, left: !!startAdornment, right: !!endAdornment }}
-            $paddingX={paddingX}
             $hasError={hasError}
             $isDisabled={!!disabled}
+            $endAdornmentWidth={endAdornmentWidth}
             {...props}
           />
           {bottomAdornment && <Adornment $position='bottom'>{bottomAdornment}</Adornment>}
-          {endAdornment && <Adornment $position='right'>{endAdornment}</Adornment>}
+          {endAdornment && (
+            <Adornment ref={endAdornmentRef} $position='right'>
+              {endAdornment}
+            </Adornment>
+          )}
         </BaseInputWrapper>
         {hasHelpText && (
           <HelperText

--- a/src/component-library/Input/Input.style.tsx
+++ b/src/component-library/Input/Input.style.tsx
@@ -3,14 +3,12 @@ import styled from 'styled-components';
 import { theme } from '../theme';
 import { Placement, Sizes } from '../utils/prop-types';
 
-type PaddingX = { left?: keyof typeof theme.input.paddingX; right?: keyof typeof theme.input.paddingX };
-
 type BaseInputProps = {
   $size: Sizes;
-  $paddingX?: PaddingX;
   $adornments: { bottom: boolean; left: boolean; right: boolean };
   $isDisabled: boolean;
   $hasError: boolean;
+  $endAdornmentWidth: number;
 };
 
 type AdornmentProps = {
@@ -46,15 +44,17 @@ const StyledBaseInput = styled.input<BaseInputProps>`
     box-shadow ${theme.transition.duration.duration150}ms ease-in-out;
 
   padding-top: ${theme.spacing.spacing2};
-  padding-left: ${({ $adornments, $paddingX }) => {
-    if (!$adornments.left) return theme.spacing.spacing2;
+  padding-left: ${({ $adornments }) => ($adornments.left ? theme.input.paddingX.md : theme.spacing.spacing2)};
 
-    return $paddingX?.left ? theme.input.paddingX[$paddingX.left] : theme.input.paddingX.md;
-  }};
-  padding-right: ${({ $adornments, $paddingX }) => {
+  padding-right: ${({ $adornments, $endAdornmentWidth }) => {
     if (!$adornments.right) return theme.spacing.spacing2;
 
-    return $paddingX?.right ? theme.input.paddingX[$paddingX.right] : theme.input.paddingX.md;
+    // MEMO: adding `spacing6` is a hacky solution because
+    // the `endAdornmentWidth` does not update width correctly
+    // after fonts are loaded. Instead of falling back to a more
+    // complex solution, an extra offset does the job of not allowing
+    // the input overlap the adornment.
+    return `calc(${$endAdornmentWidth}px + ${theme.spacing.spacing6})`;
   }};
   padding-bottom: ${({ $adornments }) => ($adornments.bottom ? theme.spacing.spacing6 : theme.spacing.spacing2)};
 
@@ -111,4 +111,3 @@ const Wrapper = styled.div<Pick<BaseInputProps, '$isDisabled'>>`
 `;
 
 export { Adornment, BaseInputWrapper, StyledBaseInput, Wrapper };
-export type { PaddingX };

--- a/src/component-library/TokenInput/TokenInput.stories.tsx
+++ b/src/component-library/TokenInput/TokenInput.stories.tsx
@@ -19,7 +19,7 @@ const Template: Story<TokenInputProps> = (args) => {
 
 const WithBalance = Template.bind({});
 WithBalance.args = {
-  ticker: 'KSM',
+  defaultTicker: 'KSM',
   balance: 1000.0,
   decimals: 8,
   balanceLabel: 'Balance',
@@ -30,7 +30,7 @@ WithBalance.args = {
 
 const WithoutBalance = Template.bind({});
 WithoutBalance.args = {
-  ticker: 'KSM',
+  defaultTicker: 'KSM',
   label: 'Amount',
   placeholder: '0.00',
   isDisabled: false
@@ -44,7 +44,6 @@ WithCurrencySelect.args = {
   balanceLabel: 'Balance',
   placeholder: '0.00',
   label: 'From',
-  selectProps: {},
   tokens: [
     { balance: 200, ticker: 'KSM', balanceUSD: '$200' },
     { balance: 200, ticker: 'BTC', balanceUSD: '$200' },
@@ -56,7 +55,27 @@ WithCurrencySelect.args = {
   ]
 };
 
-export { WithBalance, WithCurrencySelect, WithoutBalance };
+const MultiToken = Template.bind({});
+MultiToken.args = {
+  ticker: { text: 'LP Token', icons: ['KSM', 'KBTC', 'KINT', 'USDT'] },
+  balance: 1000.0,
+  decimals: 8,
+  balanceLabel: 'Balance',
+  placeholder: '0.00',
+  label: 'Amount',
+  isDisabled: false,
+  tokens: [
+    { balance: 200, ticker: 'KSM', balanceUSD: '$200' },
+    { balance: 200, ticker: 'BTC', balanceUSD: '$200' },
+    { balance: 200, ticker: 'IBTC', balanceUSD: '$200' },
+    { balance: 200, ticker: 'KBTC', balanceUSD: '$200' },
+    { balance: 200, ticker: 'DOT', balanceUSD: '$200' },
+    { balance: 200, ticker: 'INTR', balanceUSD: '$200' },
+    { balance: 200, ticker: { text: 'LP Token', icons: ['KSM', 'KBTC', 'KINT', 'USDT'] }, balanceUSD: '$200' }
+  ]
+};
+
+export { MultiToken, WithBalance, WithCurrencySelect, WithoutBalance };
 
 export default {
   title: 'Forms/TokenInput',

--- a/src/component-library/TokenInput/TokenInput.style.tsx
+++ b/src/component-library/TokenInput/TokenInput.style.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import { ChevronDown } from '@/assets/icons';
 
-import { CoinIcon } from '../CoinIcon';
 import { Flex } from '../Flex';
 import { List } from '../List';
 import { Span } from '../Text';
@@ -10,7 +9,6 @@ import { theme } from '../theme';
 
 type StyledClickableProps = {
   $isClickable: boolean;
-  $hasToken: boolean;
 };
 
 type StyledTokenInputBalanceValueProps = {
@@ -25,7 +23,6 @@ type StyledListItemSelectedLabelProps = {
 const StyledTicker = styled.span`
   font-size: ${theme.text.s};
   color: ${theme.colors.textPrimary};
-  flex: 0 1 auto;
 `;
 
 const StyledUSDAdornment = styled.span`
@@ -44,20 +41,11 @@ const StyledTokenSelect = styled(Flex)<StyledClickableProps>`
   padding: ${theme.spacing.spacing3};
   cursor: ${({ $isClickable }) => $isClickable && 'pointer'};
   height: 3rem;
-  width: ${({ $hasToken, $isClickable }) => {
-    if (!$hasToken) return '8.5rem';
-
-    return $isClickable ? '7rem' : '5.25rem';
-  }};
+  width: auto;
 `;
 
 const StyledChevronDown = styled(ChevronDown)`
   margin-left: ${theme.spacing.spacing1};
-  flex: 1 0 auto;
-`;
-
-const StyledCoinIcon = styled(CoinIcon)`
-  flex: 1 0 auto;
 `;
 
 const StyledTokenInputBalanceWrapper = styled.dl`
@@ -100,7 +88,6 @@ const StyledListHeader = styled(Flex)`
 
 export {
   StyledChevronDown,
-  StyledCoinIcon,
   StyledList,
   StyledListHeader,
   StyledListItemLabel,

--- a/src/component-library/TokenInput/TokenList.tsx
+++ b/src/component-library/TokenInput/TokenList.tsx
@@ -2,10 +2,12 @@ import { CoinIcon } from '../CoinIcon';
 import { Flex } from '../Flex';
 import { ListItem, ListProps } from '../List';
 import { Span } from '../Text';
+import { TokenStack } from '../TokenStack';
+import { TokenTicker } from './TokenInput';
 import { StyledList, StyledListItemLabel } from './TokenInput.style';
 
 type TokenData = {
-  ticker: string;
+  ticker: TokenTicker;
   balance: number;
   balanceUSD: string;
 };
@@ -31,28 +33,35 @@ const TokenList = ({ items, selectedTicker, onSelectionChange, ...props }: Token
 
   return (
     <StyledList
+      aria-label='select token'
+      variant='secondary'
       selectionMode='single'
       onSelectionChange={handleSelectionChange}
       selectedKeys={selectedTicker ? [selectedTicker] : undefined}
       {...props}
     >
       {items.map((item) => {
-        const isSelected = selectedTicker === item.ticker;
+        const tickerText = typeof item.ticker === 'string' ? item.ticker : item.ticker.text;
+
+        const isSelected = selectedTicker === tickerText;
 
         return (
           <ListItem
-            aria-label='select token'
-            key={item.ticker}
-            textValue={item.ticker}
+            key={tickerText}
+            textValue={tickerText}
             alignItems='center'
             justifyContent='space-between'
             gap='spacing4'
           >
             <Flex alignItems='center' gap='spacing2'>
-              <CoinIcon ticker={item.ticker} />
-              <StyledListItemLabel $isSelected={isSelected}>{item.ticker}</StyledListItemLabel>
+              {typeof item.ticker === 'string' ? (
+                <CoinIcon ticker={item.ticker} />
+              ) : (
+                <TokenStack tickers={item.ticker.icons} />
+              )}
+              <StyledListItemLabel $isSelected={isSelected}>{tickerText}</StyledListItemLabel>
             </Flex>
-            <Flex direction='column' alignItems='center' gap='spacing2'>
+            <Flex direction='column' alignItems='flex-end' gap='spacing2'>
               <StyledListItemLabel $isSelected={isSelected}>{item.balance}</StyledListItemLabel>
               <Span size='s' color='tertiary'>
                 {item.balanceUSD}

--- a/src/component-library/TokenInput/TokenSelect.tsx
+++ b/src/component-library/TokenInput/TokenSelect.tsx
@@ -3,22 +3,35 @@ import { chain, mergeProps } from '@react-aria/utils';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { ChangeEventHandler, InputHTMLAttributes, useRef, useState } from 'react';
 
+import { CoinIcon } from '../CoinIcon';
+import { TokenStack } from '../TokenStack';
 import { assignFormRef, triggerChangeEvent } from '../utils/input';
-import { StyledChevronDown, StyledCoinIcon, StyledTicker, StyledTokenSelect } from './TokenInput.style';
+import { StyledChevronDown, StyledTicker, StyledTokenSelect } from './TokenInput.style';
 import { TokenData } from './TokenList';
 import { TokenListModal } from './TokenListModal';
+
+const Icon = ({ value, icons }: Pick<TokenSelectProps, 'value' | 'icons'>) => {
+  if (!value) return null;
+
+  if (icons?.length) {
+    return <TokenStack offset={icons.length > 2 ? '1/2' : '1/3'} tickers={icons} />;
+  }
+
+  return <CoinIcon ticker={value} />;
+};
 
 type SelectProps = InputHTMLAttributes<HTMLInputElement> & { ref?: any };
 
 type TokenSelectProps = {
-  ticker?: string;
+  value?: string;
+  icons?: string[];
   isDisabled: boolean;
   tokens: TokenData[];
   onChange: (ticker: string) => void;
   selectProps?: SelectProps;
 };
 
-const TokenSelect = ({ ticker, tokens, isDisabled, onChange, selectProps }: TokenSelectProps): JSX.Element => {
+const TokenSelect = ({ value, icons, tokens, isDisabled, onChange, selectProps }: TokenSelectProps): JSX.Element => {
   const [isOpen, setOpen] = useState(false);
 
   const tokenButtonRef = useRef<HTMLDivElement>(null);
@@ -47,22 +60,21 @@ const TokenSelect = ({ ticker, tokens, isDisabled, onChange, selectProps }: Toke
         {...(!isDisabled && buttonProps)}
         ref={tokenButtonRef}
         alignItems='center'
-        justifyContent='center'
+        justifyContent='space-evenly'
         gap='spacing1'
         $isClickable={!isDisabled}
-        $hasToken={!!ticker}
       >
-        {ticker && <StyledCoinIcon ticker={ticker} />}
-        <StyledTicker>{ticker || 'Select Token'}</StyledTicker>
+        <Icon value={value} icons={icons} />
+        <StyledTicker>{value || 'Select Token'}</StyledTicker>
         {!isDisabled && (
           <>
             <StyledChevronDown size='s' />
             <VisuallyHidden>
               <input
                 ref={assignFormRef(selectRef, inputRef)}
-                tabIndex={-1}
-                value={ticker}
                 {...mergeProps(inputProps, { onChange: handleChange })}
+                tabIndex={-1}
+                value={value}
               />
             </VisuallyHidden>
           </>
@@ -72,7 +84,7 @@ const TokenSelect = ({ ticker, tokens, isDisabled, onChange, selectProps }: Toke
         <TokenListModal
           isOpen={isOpen}
           tokens={tokens}
-          selectedTicker={ticker}
+          selectedTicker={value}
           onClose={handleClose}
           onSelectionChange={chain(onChange, handleSelectionChange, handleClose)}
         />

--- a/src/component-library/TokenInput/TokenSelect.tsx
+++ b/src/component-library/TokenInput/TokenSelect.tsx
@@ -14,7 +14,7 @@ const Icon = ({ value, icons }: Pick<TokenSelectProps, 'value' | 'icons'>) => {
   if (!value) return null;
 
   if (icons?.length) {
-    return <TokenStack offset={icons.length > 2 ? '1/2' : '1/3'} tickers={icons} />;
+    return <TokenStack offset={icons.length > 2 ? 'lg' : 'md'} tickers={icons} />;
   }
 
   return <CoinIcon ticker={value} />;

--- a/src/component-library/TokenInput/index.tsx
+++ b/src/component-library/TokenInput/index.tsx
@@ -1,2 +1,2 @@
-export type { TokenInputProps } from './TokenInput';
+export type { TokenInputProps, TokenTicker } from './TokenInput';
 export { TokenInput } from './TokenInput';

--- a/src/component-library/TokenStack/TokenStack.style.tsx
+++ b/src/component-library/TokenStack/TokenStack.style.tsx
@@ -4,7 +4,19 @@ import { Flex } from '../Flex';
 import { theme } from '../theme';
 import { IconSize } from '../utils/prop-types';
 
-type TokenOffset = 'none' | '1/2' | '1/3' | '1/4';
+const getOffset = (offset: TokenOffset) => {
+  switch (offset) {
+    case 'lg':
+      return '-0.5';
+    default:
+    case 'md':
+      return '-0.33';
+    case 's':
+      return '-0.25';
+  }
+};
+
+type TokenOffset = 'none' | 's' | 'md' | 'lg';
 
 type StyledWrapperProps = {
   $size: IconSize;
@@ -17,7 +29,7 @@ const StyledWrapper = styled(Flex)<StyledWrapperProps>`
   > :not(:last-child) {
     // Coin one covers 30% of coin two
     margin-right: ${({ $size, $offset }) =>
-      $offset !== 'none' && `calc(${theme.icon.sizes[$size]} * calc(${$offset}) * -1)`};
+      $offset !== 'none' && `calc(${theme.icon.sizes[$size]} * ${getOffset($offset)})`};
   }
 `;
 

--- a/src/component-library/TokenStack/TokenStack.tsx
+++ b/src/component-library/TokenStack/TokenStack.tsx
@@ -13,7 +13,7 @@ type InheritAttrs = Omit<FlexProps, keyof Props>;
 
 type TokenStackProps = Props & InheritAttrs;
 
-const TokenStack = ({ tickers, gap, size = 'md', offset = '1/3', ...props }: TokenStackProps): JSX.Element => (
+const TokenStack = ({ tickers, gap, size = 'md', offset = 'md', ...props }: TokenStackProps): JSX.Element => (
   <StyledWrapper $size={size} $offset={offset} gap={gap} {...props}>
     {tickers.map((ticker, key) => (
       <CoinIcon key={`${ticker}-${key}`} size={size} ticker={ticker} />

--- a/src/component-library/theme/theme.kintsugi.css
+++ b/src/component-library/theme/theme.kintsugi.css
@@ -86,7 +86,7 @@
   /* List */
   --color-list-primary-bg: var(--colors-bg-primary);
   --color-list-primary-hover-bg: #1c2c46;
-  --color-list-secondary-bg: var(--colors-blue);
+  --color-list-secondary-bg: #101e3d;
   --color-list-secondary-hover-bg: #1c2c46;
   --color-list-selected-text: var(--colors-neutral-black);
 }


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

These are some improvements found during swap and pools development. Also added concept of `SingleToken` & `MultiToken` (for LP Tokens)
 
## Current behaviour (updates)

- We programatically declared padding to avoid input overlapping the right adornment.
- Bad state handling

## New behaviour

- Uses a ref to determined the needed spacing 
- checks better for state changes by only reacting to when prop is different than `undefined`
