### PR TITLE
feat: add AuthCTA

### DIFF
--- a/src/components/AuthCTA/AuthCTA.tsx
+++ b/src/components/AuthCTA/AuthCTA.tsx
@@ -1,0 +1,40 @@
+import { mergeProps } from '@react-aria/utils';
+import { forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+
+import { showAccountModalAction } from '@/common/actions/general.actions';
+import { CTA, CTAProps } from '@/component-library';
+import { useSubstrateSecureState } from '@/lib/substrate';
+
+type AuthCTAProps = CTAProps;
+
+const AuthCTA = forwardRef<HTMLButtonElement, AuthCTAProps>(
+  ({ onPress, children, type: typeProp, disabled, ...props }, ref): JSX.Element => {
+    const { t } = useTranslation();
+
+    const { selectedAccount } = useSubstrateSecureState();
+    const dispatch = useDispatch();
+
+    const otherProps = selectedAccount
+      ? {
+          type: typeProp,
+          disabled,
+          onPress,
+          children
+        }
+      : {
+          type: 'button',
+          disabled: false,
+          onPress: () => dispatch(showAccountModalAction(true)),
+          children: t('connect_wallet')
+        };
+
+    return <CTA ref={ref} {...mergeProps(props, otherProps)} />;
+  }
+);
+
+AuthCTA.displayName = 'AuthCTA';
+
+export { AuthCTA };
+export type { AuthCTAProps };

--- a/src/components/AuthCTA/index.tsx
+++ b/src/components/AuthCTA/index.tsx
@@ -1,0 +1,2 @@
+export type { AuthCTAProps } from './AuthCTA';
+export { AuthCTA } from './AuthCTA';


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

The purpose of this component is to have a button that has 2 states:
- `No Auth`: the button will have the text `Connect` and by clicking in it, the modal to select account will appear. Any kind of behaviour passed to it, wont be executed.
- `With Auth`: the button regains the intended behaviour.

