### PR TITLE
fix: TokenInput, ModalHeader, Input styles

### DIFF
--- a/src/component-library/Input/BaseInput.tsx
+++ b/src/component-library/Input/BaseInput.tsx
@@ -60,7 +60,7 @@ const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
     }, [endAdornment]);
 
     return (
-      <Wrapper hidden={hidden} className={className} style={style} $isDisabled={!!disabled}>
+      <Wrapper hidden={hidden} className={className} style={style}>
         {label && <Label {...labelProps}>{label}</Label>}
         <BaseInputWrapper>
           {startAdornment && <Adornment $position='left'>{startAdornment}</Adornment>}

--- a/src/component-library/Input/Input.style.tsx
+++ b/src/component-library/Input/Input.style.tsx
@@ -104,10 +104,9 @@ const Adornment = styled.div<AdornmentProps>`
   bottom: ${({ $position }) => $position === 'bottom' && theme.spacing.spacing1};
 `;
 
-const Wrapper = styled.div<Pick<BaseInputProps, '$isDisabled'>>`
+const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  opacity: ${({ $isDisabled }) => $isDisabled && 0.5};
 `;
 
 export { Adornment, BaseInputWrapper, StyledBaseInput, Wrapper };

--- a/src/component-library/Modal/Modal.stories.tsx
+++ b/src/component-library/Modal/Modal.stories.tsx
@@ -21,7 +21,7 @@ const Template: Story<ModalProps & { hasFooter: boolean; hasTitle: boolean }> = 
       <Modal {...args} isOpen={state.isOpen} onClose={state.close}>
         {hasTitle && (
           <>
-            <ModalHeader color='secondary' alignment='center'>
+            <ModalHeader color='secondary' align='center'>
               Title
             </ModalHeader>
             <ModalDivider color='secondary' />

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -7,7 +7,7 @@ import { Divider } from '../Divider';
 import { Flex } from '../Flex';
 import { H3 } from '../Text';
 import { theme } from '../theme';
-import { NormalAlignments, Overflow } from '../utils/prop-types';
+import { Overflow } from '../utils/prop-types';
 
 type StyledDialogWrapperProps = {
   $transitionTrigger?: TransitionTrigger;
@@ -16,10 +16,6 @@ type StyledDialogWrapperProps = {
 
 type StyledDialogProps = {
   $isCentered?: boolean;
-};
-
-type StyledModalHeaderProps = {
-  $alignment?: NormalAlignments;
 };
 
 type StyledModalBodyProps = {
@@ -78,10 +74,7 @@ const StyledCloseCTA = styled(CTA)`
   z-index: ${theme.modal.closeBtn.zIndex};
 `;
 
-const StyledModalHeader = styled(H3)<StyledModalHeaderProps>`
-  font-size: ${theme.text.xl};
-  line-height: ${theme.lineHeight.base};
-  text-align: ${({ $alignment }) => $alignment};
+const StyledModalHeader = styled(H3)`
   padding: ${theme.modal.header.paddingY} ${theme.modal.header.paddingX};
   flex-shrink: 0;
 `;

--- a/src/component-library/Modal/ModalHeader.tsx
+++ b/src/component-library/Modal/ModalHeader.tsx
@@ -2,12 +2,10 @@ import { mergeProps } from '@react-aria/utils';
 import { ElementType } from 'react';
 
 import { TextProps } from '../Text';
-import { NormalAlignments } from '../utils/prop-types';
 import { StyledModalHeader } from './Modal.style';
 import { useModalContext } from './ModalContext';
 
 type Props = {
-  alignment?: NormalAlignments;
   elementType?: ElementType;
 };
 
@@ -15,11 +13,24 @@ type InheritAttrs = Omit<TextProps, keyof Props>;
 
 type ModalHeaderProps = Props & InheritAttrs;
 
-const ModalHeader = ({ alignment = 'center', elementType, children, ...props }: ModalHeaderProps): JSX.Element => {
+const ModalHeader = ({
+  align = 'center',
+  size = 'xl',
+  weight = 'semibold',
+  elementType,
+  children,
+  ...props
+}: ModalHeaderProps): JSX.Element => {
   const { titleProps } = useModalContext();
 
   return (
-    <StyledModalHeader as={elementType} $alignment={alignment} {...mergeProps(titleProps || {}, props)}>
+    <StyledModalHeader
+      as={elementType}
+      align={align}
+      size={size}
+      weight={weight}
+      {...mergeProps(titleProps || {}, props)}
+    >
       {children}
     </StyledModalHeader>
   );

--- a/src/component-library/TokenInput/TokenInput.style.tsx
+++ b/src/component-library/TokenInput/TokenInput.style.tsx
@@ -25,11 +25,11 @@ const StyledTicker = styled.span`
   color: ${theme.colors.textPrimary};
 `;
 
-const StyledUSDAdornment = styled.span`
+const StyledUSDAdornment = styled.span<Pick<StyledTokenInputBalanceValueProps, '$isDisabled'>>`
   display: block;
   font-size: ${theme.text.xs};
   line-height: ${theme.lineHeight.s};
-  color: ${theme.colors.textTertiary};
+  color: ${({ $isDisabled }) => ($isDisabled ? theme.input.disabled.color : theme.colors.textTertiary)};
   white-space: nowrap;
   align-self: flex-start;
 `;

--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -137,7 +137,9 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
           isDisabled={isDisabled}
           formatOptions={formatOptions}
           endAdornment={endAdornment}
-          bottomAdornment={<StyledUSDAdornment>{formatUSD(valueUSD, { compact: true })}</StyledUSDAdornment>}
+          bottomAdornment={
+            <StyledUSDAdornment $isDisabled={isDisabled}>{formatUSD(valueUSD, { compact: true })}</StyledUSDAdornment>
+          }
           {...mergeProps(props, fieldProps)}
         />
       </Flex>

--- a/src/component-library/TokenInput/TokenSelect.tsx
+++ b/src/component-library/TokenInput/TokenSelect.tsx
@@ -71,6 +71,9 @@ const TokenSelect = ({ value, icons, tokens, isDisabled, onChange, selectProps }
             <StyledChevronDown size='s' />
             <VisuallyHidden>
               <input
+                // TODO: react-hook-forms sets initial value using ref
+                // so we will need to keep up out state with that initial value
+                // using our ref.
                 ref={assignFormRef(selectRef, inputRef)}
                 {...mergeProps(inputProps, { onChange: handleChange })}
                 tabIndex={-1}

--- a/src/component-library/theme/theme.interlay.css
+++ b/src/component-library/theme/theme.interlay.css
@@ -56,7 +56,7 @@
   --colors-input-default-border: var(--colors-neutral-light-grey);
   --colors-input-hover-border: var(--colors-lighter-blue);
   --colors-input-focus-border: var(--colors-light-blue-90);
-  --colors-input-disabled-text: var(--colors-neutral-lighter-grey);
+  --colors-input-disabled-text: #9a9a9a;
   --colors-input-disabled-border: var(--colors-neutral-lighter-grey);
   --colors-input-background: var(--colors-neutral-white);
   /* Token Input */

--- a/src/component-library/theme/theme.kintsugi.css
+++ b/src/component-library/theme/theme.kintsugi.css
@@ -59,7 +59,7 @@
   --colors-input-default-border: var(--colors-neutral-white-25);
   --colors-input-hover-border: var(--colors-slate-gray);
   --colors-input-focus-border: var(--colors-neutral-white);
-  --colors-input-disabled-text: var(--colors-mid-blue);
+  --colors-input-disabled-text: var(--colors-slate-gray);
   --colors-input-disabled-border: var(--colors-mid-blue);
   --colors-input-background: transparent;
   /* Token Input */

--- a/src/pages/Vaults/VaultsOverview/components/CreateVaultWizard/DisclaimerStep.tsx
+++ b/src/pages/Vaults/VaultsOverview/components/CreateVaultWizard/DisclaimerStep.tsx
@@ -28,7 +28,7 @@ const DisclaimerStep = ({ onClickAgree }: DisclaimerStepProps): JSX.Element => {
 
   return (
     <>
-      <StyledModalHeader alignment='center'>
+      <StyledModalHeader align='center'>
         <StyledWarningIcon />
         {t('vault.disclaimer.plase_read_before_you_start')}
       </StyledModalHeader>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Some more improvements to styles:
- `ModalHeader`: unnecessary style in stylesheet. Moved to props. Removed `alignment`, so we use `H3` native `align`.
- `Input`: remove unwanted opacity when disable and increase text visibility when input is disabled.
- `TokenInput`: apply same disable color to `bottomAdornment` when input is disabled.