### PR TITLE
fix: TokenInput, Modal props and CoinIcon fallback icon

### DIFF
--- a/src/component-library/CoinIcon/CoinIcon.style.tsx
+++ b/src/component-library/CoinIcon/CoinIcon.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { Icon } from '../Icon';
+import { theme } from '../theme';
+
+const StyledFallbackIcon = styled(Icon)`
+  stroke: ${theme.icon.fallback.stroke};
+  color: ${theme.icon.fallback.color};
+`;
+
+export { StyledFallbackIcon };

--- a/src/component-library/CoinIcon/CoinIcon.tsx
+++ b/src/component-library/CoinIcon/CoinIcon.tsx
@@ -1,9 +1,12 @@
-import { FC, forwardRef } from 'react';
+import { forwardRef, ForwardRefExoticComponent, RefAttributes } from 'react';
 
 import { IconProps } from '../Icon';
+import { StyledFallbackIcon } from './CoinIcon.style';
 import { BTC, DOT, IBTC, INTR, KBTC, KINT, KSM, LKSM, USDT } from './icons';
 
-const coinsIcon: Record<string, FC> = {
+type CoinComponent = ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>>;
+
+const coinsIcon: Record<string, CoinComponent> = {
   BTC,
   DOT,
   IBTC,
@@ -25,7 +28,22 @@ type CoinIconProps = Props & NativeAttrs;
 
 const CoinIcon = forwardRef<SVGSVGElement, CoinIconProps>(
   ({ ticker, ...props }, ref): JSX.Element => {
-    const CoinIcon = (coinsIcon[ticker] || (() => null)) as any;
+    const CoinIcon = coinsIcon[ticker];
+
+    if (!CoinIcon) {
+      return (
+        <StyledFallbackIcon
+          {...props}
+          ref={ref}
+          viewBox='0 0 24 24'
+          strokeWidth='.5'
+          xmlns='http://www.w3.org/2000/svg'
+        >
+          <title>{ticker}</title>
+          <circle cx='12' cy='12' r='11.5' fill='currentColor' />
+        </StyledFallbackIcon>
+      );
+    }
 
     return <CoinIcon ref={ref} {...props} />;
   }

--- a/src/component-library/Input/Input.style.tsx
+++ b/src/component-library/Input/Input.style.tsx
@@ -102,6 +102,8 @@ const Adornment = styled.div<AdornmentProps>`
   right: ${({ $position }) => $position === 'right' && theme.spacing.spacing2};
   transform: ${({ $position }) => ($position === 'left' || $position === 'right') && 'translateY(-50%)'};
   bottom: ${({ $position }) => $position === 'bottom' && theme.spacing.spacing1};
+  // to not allow adornment to take more than 50% of the input. We might want to reduce this in the future.
+  max-width: 50%;
 `;
 
 const Wrapper = styled.div`

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -16,6 +16,7 @@ type StyledDialogWrapperProps = {
 
 type StyledDialogProps = {
   $isCentered?: boolean;
+  $hasMaxHeight?: boolean;
 };
 
 type StyledModalBodyProps = {
@@ -59,6 +60,7 @@ const StyledDialog = styled.section<StyledDialogProps>`
   color: ${theme.colors.textPrimary};
 
   width: 100%;
+  max-height: ${({ $hasMaxHeight }) => $hasMaxHeight && '560px'};
   overflow: ${({ $isCentered }) => $isCentered && 'hidden'};
   pointer-events: auto;
 

--- a/src/component-library/Modal/Modal.tsx
+++ b/src/component-library/Modal/Modal.tsx
@@ -15,6 +15,7 @@ import { ModalContext } from './ModalContext';
 type Props = {
   children: ReactNode;
   align?: 'top' | 'center';
+  hasMaxHeight?: boolean;
 };
 
 type InheritAttrs = Omit<AriaDialogProps & AriaOverlayProps, keyof Props>;
@@ -22,7 +23,7 @@ type InheritAttrs = Omit<AriaDialogProps & AriaOverlayProps, keyof Props>;
 type ModalProps = Props & InheritAttrs;
 
 const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ children, isDismissable = true, align = 'center', ...props }, ref): JSX.Element | null => {
+  ({ children, isDismissable = true, align = 'center', hasMaxHeight, ...props }, ref): JSX.Element | null => {
     const dialogRef = useDOMRef(ref);
     const { isOpen, onClose } = props;
     const { shouldRender, transitionTrigger } = useMountTransition(!!isOpen, theme.transition.duration.duration100);
@@ -52,7 +53,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
               {...modalProps}
             >
               <ModalContext.Provider value={{ titleProps, bodyProps: { overflow: isCentered ? 'auto' : undefined } }}>
-                <StyledDialog $isCentered={isCentered} {...dialogProps}>
+                <StyledDialog $isCentered={isCentered} $hasMaxHeight={hasMaxHeight} {...dialogProps}>
                   <StyledCloseCTA size='small' variant='text' aria-label='Dismiss' onPress={onClose}>
                     <XMark />
                   </StyledCloseCTA>

--- a/src/component-library/TokenInput/TokenInput.style.tsx
+++ b/src/component-library/TokenInput/TokenInput.style.tsx
@@ -23,6 +23,8 @@ type StyledListItemSelectedLabelProps = {
 const StyledTicker = styled.span`
   font-size: ${theme.text.s};
   color: ${theme.colors.textPrimary};
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const StyledUSDAdornment = styled.span<Pick<StyledTokenInputBalanceValueProps, '$isDisabled'>>`
@@ -42,6 +44,7 @@ const StyledTokenSelect = styled(Flex)<StyledClickableProps>`
   cursor: ${({ $isClickable }) => $isClickable && 'pointer'};
   height: 3rem;
   width: auto;
+  overflow: hidden;
 `;
 
 const StyledChevronDown = styled(ChevronDown)`
@@ -75,6 +78,8 @@ const StyledTokenInputBalanceValue = styled.span<StyledTokenInputBalanceValuePro
 const StyledListItemLabel = styled(Span)<StyledListItemSelectedLabelProps>`
   color: ${({ $isSelected }) =>
     $isSelected ? theme.tokenInput.list.item.selected.text : theme.tokenInput.list.item.default.text};
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 const StyledList = styled(List)`
@@ -86,11 +91,16 @@ const StyledListHeader = styled(Flex)`
   padding: ${theme.modal.body.paddingY} ${theme.modal.body.paddingX};
 `;
 
+const StyledListTokenWrapper = styled(Flex)`
+  overflow: hidden;
+`;
+
 export {
   StyledChevronDown,
   StyledList,
   StyledListHeader,
   StyledListItemLabel,
+  StyledListTokenWrapper,
   StyledTicker,
   StyledTokenInputBalanceLabel,
   StyledTokenInputBalanceValue,

--- a/src/component-library/TokenInput/TokenList.tsx
+++ b/src/component-library/TokenInput/TokenList.tsx
@@ -4,7 +4,7 @@ import { ListItem, ListProps } from '../List';
 import { Span } from '../Text';
 import { TokenStack } from '../TokenStack';
 import { TokenTicker } from './TokenInput';
-import { StyledList, StyledListItemLabel } from './TokenInput.style';
+import { StyledList, StyledListItemLabel, StyledListTokenWrapper } from './TokenInput.style';
 
 type TokenData = {
   ticker: TokenTicker;
@@ -53,15 +53,15 @@ const TokenList = ({ items, selectedTicker, onSelectionChange, ...props }: Token
             justifyContent='space-between'
             gap='spacing4'
           >
-            <Flex alignItems='center' gap='spacing2'>
+            <StyledListTokenWrapper alignItems='center' gap='spacing2' flex='1'>
               {typeof item.ticker === 'string' ? (
                 <CoinIcon ticker={item.ticker} />
               ) : (
                 <TokenStack tickers={item.ticker.icons} />
               )}
               <StyledListItemLabel $isSelected={isSelected}>{tickerText}</StyledListItemLabel>
-            </Flex>
-            <Flex direction='column' alignItems='flex-end' gap='spacing2'>
+            </StyledListTokenWrapper>
+            <Flex direction='column' alignItems='flex-end' gap='spacing2' flex='0'>
               <StyledListItemLabel $isSelected={isSelected}>{item.balance}</StyledListItemLabel>
               <Span size='s' color='tertiary'>
                 {item.balanceUSD}

--- a/src/component-library/TokenInput/TokenListModal.tsx
+++ b/src/component-library/TokenInput/TokenListModal.tsx
@@ -14,7 +14,7 @@ type InheritAttrs = Omit<ModalProps, keyof Props | 'children'>;
 type TokenListModalProps = Props & InheritAttrs;
 
 const TokenListModal = ({ selectedTicker, tokens, onSelectionChange, ...props }: TokenListModalProps): JSX.Element => (
-  <Modal {...props}>
+  <Modal hasMaxHeight {...props}>
     <ModalHeader size='lg' weight='medium' color='secondary'>
       Select Token
     </ModalHeader>

--- a/src/component-library/theme/theme.ts
+++ b/src/component-library/theme/theme.ts
@@ -420,6 +420,10 @@ const theme = {
       lg: 'var(--spacing-8)',
       xl: 'var(--spacing-10)',
       xl2: 'var(--spacing-12)'
+    },
+    fallback: {
+      color: 'var(--colors-neutral-white)',
+      stroke: 'var(--colors-neutral-black)'
     }
   },
   list: {


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

1. Add fallback icon to `CoinIcon`
![image](https://user-images.githubusercontent.com/43269067/214890610-34a1259f-e5a6-462b-b6d1-bc979bab68af.png)
2. Add `hasMaxHeight` to `Modal`
3. Handle text overflow scenarios on TokenInput select adornment and also list. 

## Current behaviour (updates)

1. No fallback icon
2. Modal occupies whole screen
3. Many text overflows
 
## New behaviour

All scenarios are covered

## Reproducible testing steps:

AMM