### PR TITLE
fix(Pools): hide validation error after submit

### DIFF
--- a/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
+++ b/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
@@ -135,7 +135,8 @@ const DepositForm = ({ pool, slippageModalRef, onDeposit }: DepositFormProps): J
                     value={values[ticker]}
                     name={ticker}
                     onChange={handleChange}
-                    errorMessage={errors[ticker]}
+                    // TODO: when adding formik, use isLoanding to disabled validation
+                    errorMessage={depositMutation.isLoading ? undefined : errors[ticker]}
                   />
                   {!isLastItem && <DepositDivider />}
                 </Flex>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Field validation was showing after form submit on depositing liquidity

## Current behaviour (updates)

Showing error after form submission 

## New behaviour
Hiding error after form submission 

## Reproducible testing steps:

Pools AMM