### PR TITLE
fix: add event.stopPropagation to handleCopyToClipboard

### DIFF
--- a/src/utils/hooks/use-copy-to-clipboard.tsx
+++ b/src/utils/hooks/use-copy-to-clipboard.tsx
@@ -9,7 +9,7 @@ interface CopyToClipboardUIProps {
 const useCopyToClipboard = (
   text: string
 ): {
-  handleCopyToClipboard: () => void;
+  handleCopyToClipboard: (event: React.PointerEvent<HTMLButtonElement>) => void;
   CopyToClipboardUI: React.ElementType;
 } => {
   const [state, copyToClipboard] = useLibCopyToClipboard();
@@ -19,11 +19,15 @@ const useCopyToClipboard = (
     setShowCopied(false);
   }, 1000);
 
-  const handleCopyToClipboard = React.useCallback(() => {
-    copyToClipboard(text);
-    setShowCopied(true);
-    reset();
-  }, [copyToClipboard, reset, text]);
+  const handleCopyToClipboard = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      copyToClipboard(text);
+      setShowCopied(true);
+      reset();
+    },
+    [copyToClipboard, reset, text]
+  );
 
   const CopyToClipboardUI = React.useMemo(() => {
     // eslint-disable-next-line react/display-name


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Fixes #864 

## Current behaviour (updates)

The copy action is not possible because it takes you to the vaults page once you click it.

## New behaviour

The address is copied, and navigating does not happen if you click the copy icon.

## Reproducible testing steps:

- Go to `/dashboard/vaults`.
- Click on an address copy icon at the vaults table.
- The address is copied, and navigation does not happen but if you click outside of the icon, it takes you to the vault page instead of having that address copied.
