### PR TITLE
fix(TokenInput): apply balance decimal issue

### DIFF
--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -13,6 +13,11 @@ import { TokenInputLabel } from './TokenInputLabel';
 import { TokenData } from './TokenList';
 import { TokenSelect } from './TokenSelect';
 
+function convertExponentialToNormal(exponentialNumber: number) {
+  const normalNumber = parseFloat(exponentialNumber.toString()).toFixed(20);
+  return normalNumber.replace(/0+$/, '').replace(/\.$/, '');
+}
+
 type SingleToken = string;
 
 type MultiToken = { text: string; icons: string[] };
@@ -91,7 +96,9 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
     }, [selectProps?.value]);
 
     const handleClickBalance = () => {
-      triggerChangeEvent(inputRef, balance);
+      if (!balance) return;
+
+      triggerChangeEvent(inputRef, convertExponentialToNormal(balance));
       onClickBalance?.(balance);
     };
 


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Javascript do not handle very well decimals.

![image](https://user-images.githubusercontent.com/43269067/217202196-6a6f478d-8c83-4da2-9043-8cb9d4a9838f.png)

In this situation, when I apply max balance, it applies an exponential value, which is not validated correctly.

This PR aims to avoid applying exponential and just the full number.

## Current behaviour (updates)

Applies exponential 

## New behaviour

Applies normal number


