### PR TITLE
fix(TokenInput): rounding and decimals

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -85,14 +85,29 @@ const formatNumber = (
     minimumFractionDigits?: number;
     maximumFractionDigits?: number;
     compact?: boolean;
+    rounding?: boolean;
   }
 ): string => {
+  let formatted = amount;
+  let { compact, maximumFractionDigits, minimumFractionDigits, rounding = true } = options || {};
+
+  // Intl.NumberFormat rounds number by default. The alternative is to cut
+  // programmatically the number decimals before being formatted
+  if (!rounding && maximumFractionDigits) {
+    const decimal = new Big(10).pow(maximumFractionDigits);
+    formatted = new Big(Math.floor(decimal.mul(amount).toNumber())).div(decimal).toNumber();
+
+    // set to max digits to avoid rounding
+    maximumFractionDigits = 20;
+  }
+
   const { format } = new Intl.NumberFormat(undefined, {
-    ...options,
-    notation: options?.compact ? getFormatUSDNotation(amount) : undefined
+    minimumFractionDigits,
+    maximumFractionDigits,
+    notation: compact ? getFormatUSDNotation(formatted) : undefined
   });
 
-  return format(amount);
+  return format(formatted);
 };
 
 const formatPercentage = (

--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -13,8 +13,8 @@ import { TokenInputLabel } from './TokenInputLabel';
 import { TokenData } from './TokenList';
 import { TokenSelect } from './TokenSelect';
 
-function convertExponentialToNormal(exponentialNumber: number) {
-  const normalNumber = parseFloat(exponentialNumber.toString()).toFixed(20);
+function convertExponentialToNormal(exponentialNumber: number, decimals = 20) {
+  const normalNumber = parseFloat(exponentialNumber.toString()).toFixed(decimals);
   return normalNumber.replace(/0+$/, '').replace(/\.$/, '');
 }
 
@@ -98,7 +98,15 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
     const handleClickBalance = () => {
       if (!balance) return;
 
-      triggerChangeEvent(inputRef, convertExponentialToNormal(balance));
+      const isExponential = balance.toString().includes('e');
+
+      if (isExponential) {
+        const amount = convertExponentialToNormal(balance, decimals);
+        triggerChangeEvent(inputRef, amount.toString());
+      } else {
+        triggerChangeEvent(inputRef, balance);
+      }
+
       onClickBalance?.(balance);
     };
 

--- a/src/component-library/TokenInput/TokenInputBalance.tsx
+++ b/src/component-library/TokenInput/TokenInputBalance.tsx
@@ -1,7 +1,7 @@
 import { useFocusRing } from '@react-aria/focus';
 import { usePress } from '@react-aria/interactions';
 import { mergeProps } from '@react-aria/utils';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 
 import { formatNumber } from '@/common/utils/utils';
 
@@ -41,9 +41,13 @@ const TokenInputBalance = ({
         ...mergeProps(pressProps, focusProps)
       };
 
-  const balanceLabel = ticker
-    ? formatNumber(value, { minimumFractionDigits: 0, maximumFractionDigits: decimals || 20 })
-    : 0;
+  const balanceLabel = useMemo(
+    () =>
+      ticker
+        ? formatNumber(value, { minimumFractionDigits: 0, maximumFractionDigits: decimals || 20, rounding: false })
+        : 0,
+    [decimals, ticker, value]
+  );
 
   return (
     <StyledTokenInputBalanceWrapper className={className}>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

There are a serie of round and decimals issues.

Exponential numbers error - Here, applying balance is creating rounding issues. This started when `convertExponentialToNormal` was added to handle exponential numbers.
![image](https://user-images.githubusercontent.com/43269067/217322038-269d355b-f775-4e81-9787-9ab710200959.png)

Balance mismatch - when applying balance, it does not match the value
![image](https://user-images.githubusercontent.com/43269067/217322190-bea11bce-a742-49e1-ab91-c22fe2877426.png)

## Current behaviour (updates)

Applying balance has issues

## New behaviour

Applying balance does not has issues with rounding or handling exponential numbers

## Reproducible testing steps:

AMM