### PR TITLE
feat(amm): add farming

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@heroicons/react": "^2.0.0",
     "@hookform/resolvers": "^2.9.7",
     "@interlay/bridge": "^0.2.1",
-    "@interlay/interbtc-api": "0.32.4",
+    "@interlay/interbtc-api": "0.32.5",
     "@material-icons/svg": "^1.0.28",
     "@polkadot/api": "9.11.1",
     "@polkadot/extension-dapp": "0.44.1",

--- a/src/pages/AMM/Pools/Pools.tsx
+++ b/src/pages/AMM/Pools/Pools.tsx
@@ -8,10 +8,11 @@ import { PoolsInsights, PoolsTables } from './components';
 
 const Pools = (): JSX.Element => {
   const accountId = useAccountId();
-  const { data: accountPools } = useGetAccountPools();
+  const { data: accountPoolsData, refetch: refetchAccountPools } = useGetAccountPools();
   const { data: pools } = useGetLiquidityPools();
 
-  const isLoadingAccountData = accountId !== undefined && accountPools === undefined;
+  const accountPositions = accountPoolsData?.positions;
+  const isLoadingAccountData = accountId !== undefined && accountPoolsData === undefined;
 
   if (pools === undefined || isLoadingAccountData) {
     return <FullLoadingSpinner />;
@@ -19,8 +20,8 @@ const Pools = (): JSX.Element => {
 
   return (
     <MainContainer>
-      <PoolsInsights pools={pools} accountPools={accountPools} />
-      <PoolsTables pools={pools} accountPools={accountPools} />
+      <PoolsInsights pools={pools} accountPoolsData={accountPoolsData} refetch={refetchAccountPools} />
+      <PoolsTables pools={pools} accountPools={accountPositions} />
     </MainContainer>
   );
 };

--- a/src/pages/AMM/Pools/components/PoolsInsights/utils.ts
+++ b/src/pages/AMM/Pools/components/PoolsInsights/utils.ts
@@ -1,0 +1,24 @@
+import { CurrencyExt, LpCurrency } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
+
+import { calculateTotalLiquidityUSD } from '@/pages/AMM/shared/utils';
+import { Prices } from '@/utils/hooks/api/use-get-prices';
+
+const calculateClaimableFarmingRewardUSD = (
+  claimableRewards: Map<LpCurrency, MonetaryAmount<CurrencyExt>[]> | undefined,
+  prices: Prices | undefined
+): number => {
+  if (claimableRewards === undefined) {
+    return 0;
+  }
+  const flattenedRewardAmounts: Array<MonetaryAmount<CurrencyExt>> = [];
+  for (const [, rewardAmounts] of claimableRewards.entries()) {
+    flattenedRewardAmounts.push(...rewardAmounts);
+  }
+
+  const totalRewardUSD = calculateTotalLiquidityUSD(flattenedRewardAmounts, prices);
+
+  return totalRewardUSD;
+};
+
+export { calculateClaimableFarmingRewardUSD };

--- a/src/pages/AMM/Pools/components/PoolsTables/PoolsTable.tsx
+++ b/src/pages/AMM/Pools/components/PoolsTables/PoolsTable.tsx
@@ -65,7 +65,7 @@ const PoolsTable = ({ variant, pools, onRowAction }: PoolsTableProps): JSX.Eleme
         const farmingApr = getFarmingApr(rewardAmountsYearly, totalSupply, totalLiquidityUSD, prices);
         // TODO: add also APR from trading volume based on squid data
         const aprAmount = farmingApr;
-        const apr = <MonetaryCell label={formatPercentage(aprAmount)} alignSelf='flex-start' />;
+        const apr = <MonetaryCell label={formatPercentage(aprAmount.toNumber())} alignSelf='flex-start' />;
 
         const totalLiquidity = <MonetaryCell label={formatUSD(totalLiquidityUSD, { compact: true })} />;
 

--- a/src/pages/AMM/Pools/components/PoolsTables/PoolsTable.tsx
+++ b/src/pages/AMM/Pools/components/PoolsTables/PoolsTable.tsx
@@ -10,6 +10,7 @@ import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
 import { PoolName } from '../PoolName';
 import { BalanceCell, PoolsBaseTable, PoolsBaseTableProps } from '../PoolsBaseTable';
 import { MonetaryCell } from '../PoolsBaseTable/MonetaryCell';
+import { getFarmingApr } from './utils';
 
 enum BorrowAssetsColumns {
   POOL_NAME = 'poolName',
@@ -54,14 +55,17 @@ const PoolsTable = ({ variant, pools, onRowAction }: PoolsTableProps): JSX.Eleme
   const rows: PoolsTableRow[] = useMemo(
     () =>
       pools.map(({ data, amount: accountLPTokenAmount }) => {
-        const { pooledCurrencies, lpToken, apr: aprAmount, totalSupply } = data;
+        const { pooledCurrencies, lpToken, rewardAmountsYearly, totalSupply } = data;
         const poolName = (
           <PoolName tickers={pooledCurrencies.map((pooledCurrencies) => pooledCurrencies.currency.ticker)} />
         );
 
-        const apr = <MonetaryCell label={formatPercentage(aprAmount.toNumber())} alignSelf='flex-start' />;
-
         const totalLiquidityUSD = calculateTotalLiquidityUSD(pooledCurrencies, prices);
+
+        const farmingApr = getFarmingApr(rewardAmountsYearly, totalSupply, totalLiquidityUSD, prices);
+        // TODO: add also APR from trading volume based on squid data
+        const aprAmount = farmingApr;
+        const apr = <MonetaryCell label={formatPercentage(aprAmount)} alignSelf='flex-start' />;
 
         const totalLiquidity = <MonetaryCell label={formatUSD(totalLiquidityUSD, { compact: true })} />;
 

--- a/src/pages/AMM/Pools/components/PoolsTables/utils.ts
+++ b/src/pages/AMM/Pools/components/PoolsTables/utils.ts
@@ -1,0 +1,25 @@
+import { CurrencyExt, LpCurrency } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
+
+import { calculateTotalLiquidityUSD } from '@/pages/AMM/shared/utils';
+import { Prices } from '@/utils/hooks/api/use-get-prices';
+
+const getFarmingApr = (
+  rewardAmountsYearly: Array<MonetaryAmount<CurrencyExt>>,
+  lpTotalSupply: MonetaryAmount<LpCurrency>,
+  totalLiquidityUSD: number,
+  prices: Prices | undefined
+): number => {
+  if (prices === undefined || lpTotalSupply.toBig().eq(0) || totalLiquidityUSD === 0) {
+    return 0;
+  }
+  const lpTokenPriceUSD = totalLiquidityUSD / lpTotalSupply.toBig().toNumber();
+
+  const totalRewardsPerTokenUSD = calculateTotalLiquidityUSD(rewardAmountsYearly, prices);
+
+  const yearlyRewardPerLPRatePercentage = (totalRewardsPerTokenUSD / lpTokenPriceUSD) * 100;
+
+  return yearlyRewardPerLPRatePercentage;
+};
+
+export { getFarmingApr };

--- a/src/pages/AMM/Pools/components/PoolsTables/utils.ts
+++ b/src/pages/AMM/Pools/components/PoolsTables/utils.ts
@@ -1,5 +1,6 @@
 import { CurrencyExt, LpCurrency } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
+import Big from 'big.js';
 
 import { calculateTotalLiquidityUSD } from '@/pages/AMM/shared/utils';
 import { Prices } from '@/utils/hooks/api/use-get-prices';
@@ -9,15 +10,15 @@ const getFarmingApr = (
   lpTotalSupply: MonetaryAmount<LpCurrency>,
   totalLiquidityUSD: number,
   prices: Prices | undefined
-): number => {
+): Big => {
   if (prices === undefined || lpTotalSupply.toBig().eq(0) || totalLiquidityUSD === 0) {
-    return 0;
+    return new Big(0);
   }
-  const lpTokenPriceUSD = totalLiquidityUSD / lpTotalSupply.toBig().toNumber();
+  const lpTokenPriceUSD = new Big(totalLiquidityUSD).div(lpTotalSupply.toBig());
 
   const totalRewardsPerTokenUSD = calculateTotalLiquidityUSD(rewardAmountsYearly, prices);
 
-  const yearlyRewardPerLPRatePercentage = (totalRewardsPerTokenUSD / lpTokenPriceUSD) * 100;
+  const yearlyRewardPerLPRatePercentage = new Big(totalRewardsPerTokenUSD).div(lpTokenPriceUSD).mul(100);
 
   return yearlyRewardPerLPRatePercentage;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,13 +2583,13 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@0.32.4":
-  version "0.32.4"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-0.32.4.tgz#a8cdd5aedacbe10a04b5ce273cab842d7a01a653"
-  integrity sha512-67c2PtoYj3ZohQTAVis0l1DpMFhN042Oed0nKHlTYBugDZNc5rg0MGmHxRK/qDMtaoIIcNJXjsMa6iVV8pmSjA==
+"@interlay/interbtc-api@0.32.5":
+  version "0.32.5"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-0.32.5.tgz#9a5aef094a86223f9e3b3bdc3183a8da86f12fee"
+  integrity sha512-9mkpO7J09onOXDJ4FIL7EbYSVilurOe1xJViiZ0sYDiEokV2iH0dJ+goDSSN1wAHw+q6bXbDrlu+Ai28joEMgA==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
-    "@interlay/interbtc-types" "0.31.4"
+    "@interlay/interbtc-types" "0.31.6"
     "@interlay/monetary-js" "0.7.0"
     "@polkadot/api" "9.11.1"
     big.js "6.1.1"
@@ -2600,10 +2600,10 @@
     isomorphic-fetch "^3.0.0"
     regtest-client "^0.2.0"
 
-"@interlay/interbtc-types@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-types/-/interbtc-types-0.31.4.tgz#fa21eb438be9e43bed0f4fd9b8eeaec04006340b"
-  integrity sha512-nWA4pfokUCKpI40gv0jwGbx0zS1RQMov+R4AyBJg0Q4q3UrPnIc9SiDfvKLEuOpX8VxAIdL8DG6YAjFwiPM39A==
+"@interlay/interbtc-types@0.31.6":
+  version "0.31.6"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-types/-/interbtc-types-0.31.6.tgz#e790887674192cc1a21af00f9062ca7ca8d78613"
+  integrity sha512-bN4AtuHgLIjuGjuvNrmKpna9fohT7PKLqvK5xglE5id/BW0eeDFHWCKJvOOEEPkNTOQ7SjUcRbEUe78IYJ0ECg==
 
 "@interlay/interbtc-types@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description
Adding farming to AMM - displaying APR, claimable rewards and adding button to claim all farming rewards. Updating lib to `0.32.5`


## Current behaviour (updates)
n/a
## New behaviour

New features added

## Reproducible testing steps:

Check if APRs are correct. Create LP position on pool that has reward activated in farming pallet. Wait for a bit and check if claimable rewards are starting to show up. Click on claim button and check that transaction is successful and rewards are added to testing account.