### PR TITLE
fix: Pools and Loans cells formatting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import '@/component-library/theme/theme.interlay.css';
 import '@/component-library/theme/theme.kintsugi.css';
 
 import { OverlayProvider } from '@react-aria/overlays';
+import Big from 'big.js';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { HelmetProvider } from 'react-helmet-async';
@@ -19,6 +20,11 @@ import { Subscriptions } from '@/utils/hooks/api/tokens/use-balances-subscriptio
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { store } from './store';
+
+// TODO: export this to a config
+Big.DP = 100;
+Big.NE = -39;
+Big.PE = 39;
 
 const DeveloperConsole = React.lazy(
   () => import(/* webpackChunkName: 'developer-console' */ '@/lib/substrate/components/DeveloperConsole')

--- a/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
+++ b/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useMutation } from 'react-query';
 import { toast } from 'react-toastify';
 
-import { displayMonetaryAmount, displayMonetaryAmountInUSDFormat } from '@/common/utils/utils';
+import { displayMonetaryAmountInUSDFormat } from '@/common/utils/utils';
 import { Dd, DlGroup, Dt, Flex, TokenInput } from '@/component-library';
 import { AuthCTA } from '@/components';
 import { TRANSACTION_FEE_AMOUNT } from '@/config/relay-chains';
@@ -150,7 +150,7 @@ const DepositForm = ({ pool, slippageModalRef, onDeposit }: DepositFormProps): J
                 {t('fees')}
               </Dt>
               <Dd size='xs'>
-                {displayMonetaryAmount(TRANSACTION_FEE_AMOUNT)} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
+                {TRANSACTION_FEE_AMOUNT.toHuman()} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
                 {displayMonetaryAmountInUSDFormat(
                   TRANSACTION_FEE_AMOUNT,
                   getTokenPrice(prices, TRANSACTION_FEE_AMOUNT.currency.ticker)?.usd

--- a/src/pages/AMM/Pools/components/PoolsBaseTable/BalanceCell.tsx
+++ b/src/pages/AMM/Pools/components/PoolsBaseTable/BalanceCell.tsx
@@ -1,7 +1,7 @@
 import { CurrencyExt } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 
-import { formatNumber, formatUSD } from '@/common/utils/utils';
+import { formatUSD } from '@/common/utils/utils';
 import { AlignItems } from '@/component-library';
 
 import { MonetaryCell } from './MonetaryCell';
@@ -12,16 +12,14 @@ type BalanceCellProps = {
   alignItems?: AlignItems;
 };
 
-const BalanceCell = ({ amount, amountUSD, alignItems }: BalanceCellProps): JSX.Element => {
-  const assetBalance = formatNumber(amount.toBig().toNumber(), {
-    // TODO: figure how many decimals to show
-    maximumFractionDigits: amount.currency.humanDecimals || 8
-  });
-
-  return (
-    <MonetaryCell alignItems={alignItems} label={assetBalance} sublabel={formatUSD(amountUSD)} labelColor='secondary' />
-  );
-};
+const BalanceCell = ({ amount, amountUSD, alignItems }: BalanceCellProps): JSX.Element => (
+  <MonetaryCell
+    alignItems={alignItems}
+    label={amount.toString()}
+    sublabel={formatUSD(amountUSD, { compact: true })}
+    labelColor='secondary'
+  />
+);
 
 export { BalanceCell };
 export type { BalanceCellProps };

--- a/src/pages/AMM/Pools/components/WithdrawForm/WithdrawForm.tsx
+++ b/src/pages/AMM/Pools/components/WithdrawForm/WithdrawForm.tsx
@@ -10,11 +10,7 @@ import { useMutation } from 'react-query';
 import { toast } from 'react-toastify';
 import * as z from 'zod';
 
-import {
-  convertMonetaryAmountToValueInUSD,
-  displayMonetaryAmount,
-  displayMonetaryAmountInUSDFormat
-} from '@/common/utils/utils';
+import { convertMonetaryAmountToValueInUSD, displayMonetaryAmountInUSDFormat } from '@/common/utils/utils';
 import { Dd, DlGroup, Dt, Flex, TokenInput } from '@/component-library';
 import { AuthCTA } from '@/components';
 import { GOVERNANCE_TOKEN, TRANSACTION_FEE_AMOUNT } from '@/config/relay-chains';
@@ -158,7 +154,7 @@ const WithdrawForm = ({ pool, slippageModalRef, onWithdraw }: WithdrawFormProps)
                 Fees
               </Dt>
               <Dd size='xs'>
-                {displayMonetaryAmount(TRANSACTION_FEE_AMOUNT)} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
+                {TRANSACTION_FEE_AMOUNT.toHuman()} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
                 {displayMonetaryAmountInUSDFormat(
                   TRANSACTION_FEE_AMOUNT,
                   getTokenPrice(prices, TRANSACTION_FEE_AMOUNT.currency.ticker)?.usd

--- a/src/pages/AMM/Swap/components/SwapInfo/SwapInfo.tsx
+++ b/src/pages/AMM/Swap/components/SwapInfo/SwapInfo.tsx
@@ -1,11 +1,6 @@
 import { Trade } from '@interlay/interbtc-api';
 
-import {
-  displayMonetaryAmount,
-  displayMonetaryAmountInUSDFormat,
-  formatNumber,
-  formatPercentage
-} from '@/common/utils/utils';
+import { displayMonetaryAmountInUSDFormat, formatPercentage } from '@/common/utils/utils';
 import { Accordion, AccordionItem, Dd, Dl, DlGroup, Dt } from '@/component-library';
 import { TRANSACTION_FEE_AMOUNT } from '@/config/relay-chains';
 import { getTokenPrice } from '@/utils/helpers/prices';
@@ -23,9 +18,7 @@ const SwapInfo = ({ trade, slippage }: SwapInfoProps): JSX.Element | null => {
 
   const { inputAmount, outputAmount, executionPrice, priceImpact } = trade;
 
-  const title = `1 ${inputAmount.currency.ticker} = ${formatNumber(executionPrice.toBig().toNumber())} ${
-    outputAmount.currency.ticker
-  }`;
+  const title = `1 ${inputAmount.currency.ticker} = ${executionPrice.toHuman()} ${outputAmount.currency.ticker}`;
 
   const minimumReceived = outputAmount.sub(outputAmount.mul(slippage).div(100));
 
@@ -39,7 +32,7 @@ const SwapInfo = ({ trade, slippage }: SwapInfoProps): JSX.Element | null => {
                 Expected Output
               </Dt>
               <Dd size='s'>
-                {displayMonetaryAmount(outputAmount)} {outputAmount.currency.ticker}
+                {outputAmount.toHuman()} {outputAmount.currency.ticker}
               </Dd>
             </DlGroup>
             <DlGroup justifyContent='space-between'>
@@ -47,7 +40,7 @@ const SwapInfo = ({ trade, slippage }: SwapInfoProps): JSX.Element | null => {
                 Minimum Received
               </Dt>
               <Dd size='s'>
-                {displayMonetaryAmount(minimumReceived)} {outputAmount.currency.ticker}
+                {minimumReceived.toHuman()} {outputAmount.currency.ticker}
               </Dd>
             </DlGroup>
             <DlGroup justifyContent='space-between'>
@@ -62,7 +55,7 @@ const SwapInfo = ({ trade, slippage }: SwapInfoProps): JSX.Element | null => {
                 Fees
               </Dt>
               <Dd size='s'>
-                {displayMonetaryAmount(TRANSACTION_FEE_AMOUNT)} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
+                {TRANSACTION_FEE_AMOUNT.toHuman()} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
                 {displayMonetaryAmountInUSDFormat(
                   TRANSACTION_FEE_AMOUNT,
                   getTokenPrice(prices, TRANSACTION_FEE_AMOUNT.currency.ticker)?.usd

--- a/src/pages/Loans/LoansOverview/components/LoansBaseTable/BalanceCell.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoansBaseTable/BalanceCell.tsx
@@ -1,7 +1,7 @@
 import { CurrencyExt } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 
-import { displayMonetaryAmountInUSDFormat, formatNumber } from '@/common/utils/utils';
+import { displayMonetaryAmountInUSDFormat } from '@/common/utils/utils';
 import { AlignItems } from '@/component-library';
 import { getTokenPrice } from '@/utils/helpers/prices';
 import { Prices } from '@/utils/hooks/api/use-get-prices';
@@ -16,12 +16,9 @@ type BalanceCellProps = {
 
 const BalanceCell = ({ amount, prices, alignItems }: BalanceCellProps): JSX.Element => {
   const assetBalanceUSD = displayMonetaryAmountInUSDFormat(amount, getTokenPrice(prices, amount.currency.ticker)?.usd);
-  const assetBalance = formatNumber(amount.toBig().toNumber(), {
-    maximumFractionDigits: amount.currency.humanDecimals
-  });
 
   return (
-    <MonetaryCell alignItems={alignItems} label={assetBalance} sublabel={assetBalanceUSD} labelColor='secondary' />
+    <MonetaryCell alignItems={alignItems} label={amount.toHuman()} sublabel={assetBalanceUSD} labelColor='secondary' />
   );
 };
 


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Config `Big` to handle better big decimals (copied `monetary` config).
Fixed places where rounding was too aggressive.

![image](https://user-images.githubusercontent.com/43269067/217504340-a682826a-2865-486a-9f33-b6af98f899ec.png)
 
Liquidity should not be 0