### PR TITLE
fix(Pools): use reserve amount for lp token

### DIFF
--- a/src/pages/AMM/Pools/components/WithdrawForm/WithdrawForm.tsx
+++ b/src/pages/AMM/Pools/components/WithdrawForm/WithdrawForm.tsx
@@ -58,7 +58,7 @@ const WithdrawForm = ({ pool, slippageModalRef, onWithdraw }: WithdrawFormProps)
   const accountId = useAccountId();
   const { t } = useTranslation();
   const prices = useGetPrices();
-  const { getAvailableBalance, getBalance } = useGetBalances();
+  const { getBalance } = useGetBalances();
 
   const withdrawMutation = useMutation<void, Error, DepositData>(mutateWithdraw, {
     onSuccess: () => {
@@ -73,7 +73,7 @@ const WithdrawForm = ({ pool, slippageModalRef, onWithdraw }: WithdrawFormProps)
   const { lpToken } = pool;
 
   const governanceBalance = getBalance(GOVERNANCE_TOKEN.ticker)?.free || newMonetaryAmount(0, GOVERNANCE_TOKEN);
-  const balance = getAvailableBalance(lpToken.ticker);
+  const balance = getBalance(lpToken.ticker)?.reserved;
 
   const zeroAssetAmount = newMonetaryAmount(0, lpToken);
   const schemaParams: PoolWithdrawSchemaParams = {


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Lp tokens are being used for farming automatically, so now to access the amount, we should use `reserved` field instead of `free`.

## Current behaviour (updates)

Could not access Lp tokens amount

## New behaviour

Can access lp tokens amount 

## Reproducible testing steps:

AMM