### PR TITLE
fix(TokenInput): token input decimals handling

### DIFF
--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -13,11 +13,6 @@ import { TokenInputLabel } from './TokenInputLabel';
 import { TokenData } from './TokenList';
 import { TokenSelect } from './TokenSelect';
 
-function convertExponentialToNormal(exponentialNumber: number, decimals = 20) {
-  const normalNumber = parseFloat(exponentialNumber.toString()).toFixed(decimals);
-  return normalNumber.replace(/0+$/, '').replace(/\.$/, '');
-}
-
 type SingleToken = string;
 
 type MultiToken = { text: string; icons: string[] };
@@ -37,13 +32,13 @@ const getFormatOptions = (decimals?: number): Intl.NumberFormatOptions | undefin
 type Props = {
   decimals?: number;
   valueUSD: number;
-  balance?: number;
+  balance?: string | number;
+  humanBalance?: string | number;
   balanceLabel?: ReactNode;
-  balanceDecimals?: number;
   ticker?: TokenTicker;
   defaultTicker?: TokenTicker;
   tokens?: TokenData[];
-  onClickBalance?: (balance?: number) => void;
+  onClickBalance?: (balance?: string | number) => void;
   onChangeTicker?: (ticker?: string) => void;
   selectProps?: InputHTMLAttributes<HTMLInputElement>;
 };
@@ -58,8 +53,8 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
       decimals,
       valueUSD,
       balance,
+      humanBalance,
       balanceLabel,
-      balanceDecimals,
       isDisabled,
       label,
       ticker: tickerProp,
@@ -98,15 +93,7 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
     const handleClickBalance = () => {
       if (!balance) return;
 
-      const isExponential = balance.toString().includes('e');
-
-      if (isExponential) {
-        const amount = convertExponentialToNormal(balance, decimals);
-        triggerChangeEvent(inputRef, amount.toString());
-      } else {
-        triggerChangeEvent(inputRef, balance);
-      }
-
+      triggerChangeEvent(inputRef, balance);
       onClickBalance?.(balance);
     };
 
@@ -139,9 +126,8 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
         {hasLabel && (
           <TokenInputLabel
             ticker={tickerValue}
-            balance={balance}
+            balance={humanBalance || balance}
             balanceLabel={balanceLabel}
-            balanceDecimals={balanceDecimals}
             isDisabled={isDisabled || !tickerValue}
             onClickBalance={handleClickBalance}
             {...labelProps}

--- a/src/component-library/TokenInput/TokenInputBalance.tsx
+++ b/src/component-library/TokenInput/TokenInputBalance.tsx
@@ -1,9 +1,7 @@
 import { useFocusRing } from '@react-aria/focus';
 import { usePress } from '@react-aria/interactions';
 import { mergeProps } from '@react-aria/utils';
-import { ReactNode, useMemo } from 'react';
-
-import { formatNumber } from '@/common/utils/utils';
+import { ReactNode } from 'react';
 
 import {
   StyledTokenInputBalanceLabel,
@@ -13,12 +11,11 @@ import {
 
 type TokenInputBalanceProps = {
   ticker?: string;
-  value: number;
+  value: string | number;
   onClickBalance?: () => void;
   isDisabled?: boolean;
   className?: string;
   label?: ReactNode;
-  decimals?: number;
 };
 
 const TokenInputBalance = ({
@@ -27,7 +24,6 @@ const TokenInputBalance = ({
   onClickBalance,
   className,
   isDisabled,
-  decimals,
   label = 'Balance'
 }: TokenInputBalanceProps): JSX.Element => {
   const { pressProps } = usePress({ onPress: onClickBalance, isDisabled: isDisabled });
@@ -41,20 +37,12 @@ const TokenInputBalance = ({
         ...mergeProps(pressProps, focusProps)
       };
 
-  const balanceLabel = useMemo(
-    () =>
-      ticker
-        ? formatNumber(value, { minimumFractionDigits: 0, maximumFractionDigits: decimals || 20, rounding: false })
-        : 0,
-    [decimals, ticker, value]
-  );
-
   return (
     <StyledTokenInputBalanceWrapper className={className}>
       <StyledTokenInputBalanceLabel>{label}</StyledTokenInputBalanceLabel>
       <dd>
         <StyledTokenInputBalanceValue $isDisabled={isDisabled} $isFocusVisible={isFocusVisible} {...balanceValueProps}>
-          {balanceLabel}
+          {ticker ? value : 0}
         </StyledTokenInputBalanceValue>
       </dd>
     </StyledTokenInputBalanceWrapper>

--- a/src/component-library/TokenInput/TokenInputLabel.tsx
+++ b/src/component-library/TokenInput/TokenInputLabel.tsx
@@ -6,9 +6,8 @@ import { TokenInputBalance } from './TokenInputBalance';
 
 type Props = {
   ticker?: string;
-  balance?: number;
+  balance?: string | number;
   balanceLabel?: ReactNode;
-  balanceDecimals?: number;
   isDisabled?: boolean;
   onClickBalance?: (balance?: number) => void;
 };
@@ -22,7 +21,6 @@ const TokenInputLabel = ({
   balanceLabel,
   isDisabled,
   onClickBalance,
-  balanceDecimals,
   ticker,
   children,
   ...props
@@ -39,7 +37,6 @@ const TokenInputLabel = ({
           onClickBalance={onClickBalance}
           isDisabled={isDisabled}
           label={balanceLabel}
-          decimals={balanceDecimals}
         />
       )}
     </Flex>

--- a/src/component-library/TokenInput/TokenList.tsx
+++ b/src/component-library/TokenInput/TokenList.tsx
@@ -8,7 +8,7 @@ import { StyledList, StyledListItemLabel, StyledListTokenWrapper } from './Token
 
 type TokenData = {
   ticker: TokenTicker;
-  balance: number;
+  balance: string | number;
   balanceUSD: string;
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,8 @@ import './index.css';
 import '@/component-library/theme/theme.interlay.css';
 import '@/component-library/theme/theme.kintsugi.css';
 
+import { configGlobalBig } from '@interlay/monetary-js';
 import { OverlayProvider } from '@react-aria/overlays';
-import Big from 'big.js';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { HelmetProvider } from 'react-helmet-async';
@@ -21,10 +21,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { store } from './store';
 
-// TODO: export this to a config
-Big.DP = 100;
-Big.NE = -39;
-Big.PE = 39;
+configGlobalBig();
 
 const DeveloperConsole = React.lazy(
   () => import(/* webpackChunkName: 'developer-console' */ '@/lib/substrate/components/DeveloperConsole')

--- a/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
+++ b/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
@@ -116,10 +116,12 @@ const DepositForm = ({ pool, slippageModalRef, onDeposit }: DepositFormProps): J
           <Flex direction='column' gap='spacing2'>
             {pooledCurrencies.map((amount, index) => {
               const {
-                currency: { ticker, humanDecimals }
+                currency: { ticker }
               } = amount;
 
               const isLastItem = index === pooledCurrencies.length - 1;
+
+              const balance = getAvailableBalance(ticker);
 
               return (
                 <Flex key={ticker} direction='column' gap='spacing8'>
@@ -129,8 +131,8 @@ const DepositForm = ({ pool, slippageModalRef, onDeposit }: DepositFormProps): J
                     aria-label={t('forms.field_amount', {
                       field: `${ticker} ${t('deposit').toLowerCase()}`
                     })}
-                    balance={getAvailableBalance(ticker)?.toBig().toNumber() || 0}
-                    balanceDecimals={humanDecimals}
+                    balance={balance?.toString() || 0}
+                    humanBalance={balance?.toHuman() || 0}
                     valueUSD={new Big(values[ticker] || 0).mul(getTokenPrice(prices, ticker)?.usd || 0).toNumber()}
                     value={values[ticker]}
                     name={ticker}

--- a/src/pages/AMM/Pools/components/WithdrawForm/WithdrawForm.tsx
+++ b/src/pages/AMM/Pools/components/WithdrawForm/WithdrawForm.tsx
@@ -140,8 +140,8 @@ const WithdrawForm = ({ pool, slippageModalRef, onWithdraw }: WithdrawFormProps)
               aria-label={t('forms.field_amount', {
                 field: t('withdraw').toLowerCase()
               })}
-              balance={balance?.toBig().toNumber() || 0}
-              balanceDecimals={lpToken.humanDecimals}
+              balance={balance?.toString() || 0}
+              humanBalance={balance?.toHuman() || 0}
               valueUSD={pooledAmountsUSD}
               errorMessage={getErrorMessage(errors[FormFields.WITHDRAW_AMOUNT])}
               {...register(FormFields.WITHDRAW_AMOUNT)}

--- a/src/pages/AMM/Swap/hooks/use-swap-form-data.tsx
+++ b/src/pages/AMM/Swap/hooks/use-swap-form-data.tsx
@@ -52,8 +52,8 @@ const useButtonProps = (
 };
 
 type UseSwapFormData = {
-  inputProps: { balance: number; valueUSD: number; tokens: TokenInputProps['tokens'] };
-  outputProps: { balance: number; valueUSD: number; tokens: TokenInputProps['tokens']; value?: number };
+  inputProps: Pick<TokenInputProps, 'balance' | 'humanBalance' | 'valueUSD' | 'tokens'>;
+  outputProps: Pick<TokenInputProps, 'balance' | 'humanBalance' | 'valueUSD' | 'value' | 'tokens'>;
   buttonProps: { children: ReactNode; disabled: boolean };
 };
 
@@ -71,8 +71,9 @@ const useSwapFormData = (pair: SwapPair, inputAmount?: number, trade?: Trade | n
         const balanceUSD = balance
           ? convertMonetaryAmountToValueInUSD(balance, getTokenPrice(prices, currency.ticker)?.usd)
           : 0;
+
         return {
-          balance: Number(balance?.toBig().toFixed(balance.currency.humanDecimals)) || 0,
+          balance: balance?.toHuman() || 0,
           balanceUSD: formatUSD(balanceUSD || 0, { compact: true }),
           ticker: currency.ticker
         };
@@ -80,10 +81,14 @@ const useSwapFormData = (pair: SwapPair, inputAmount?: number, trade?: Trade | n
     [currencies, getAvailableBalance, prices]
   );
 
+  const inputBalance = pair.input && getAvailableBalance(pair.input.ticker);
+  const outputBalance = pair.output && getAvailableBalance(pair.output.ticker);
+
   return {
     inputProps: {
       tokens,
-      balance: pair.input ? getAvailableBalance(pair.input.ticker)?.toBig().toNumber() || 0 : 0,
+      balance: inputBalance?.toString() || 0,
+      humanBalance: inputBalance?.toHuman() || 0,
       valueUSD:
         inputAmount && pair.input
           ? convertMonetaryAmountToValueInUSD(
@@ -94,7 +99,8 @@ const useSwapFormData = (pair: SwapPair, inputAmount?: number, trade?: Trade | n
     },
     outputProps: {
       tokens,
-      balance: pair.output ? getAvailableBalance(pair.output.ticker)?.toBig().toNumber() || 0 : 0,
+      balance: outputBalance?.toString() || 0,
+      humanBalance: outputBalance?.toHuman() || 0,
       value: trade?.outputAmount.toBig().toNumber(),
       valueUSD:
         trade?.outputAmount && pair.output

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -185,9 +185,9 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
               ticker={asset.currency.ticker}
               errorMessage={getErrorMessage(errors[formField])}
               aria-label={content.fieldAriaLabel}
-              balance={assetAmount.max.toBig().toNumber()}
+              balance={assetAmount.max.toString()}
+              humanBalance={assetAmount.max.toHuman()}
               balanceLabel={content.label}
-              balanceDecimals={asset.currency.humanDecimals}
               valueUSD={convertMonetaryAmountToValueInUSD(monetaryAmount, assetPrice) ?? 0}
               onClickBalance={handleClickBalance}
               {...register(formField, { onChange: handleChange })}

--- a/src/pages/Vaults/VaultsOverview/components/CreateVaultWizard/DespositCollateralStep.tsx
+++ b/src/pages/Vaults/VaultsOverview/components/CreateVaultWizard/DespositCollateralStep.tsx
@@ -88,9 +88,9 @@ const DepositCollateralStep = ({
               placeholder='0.00'
               ticker={collateral.currency.ticker}
               valueUSD={convertMonetaryAmountToValueInUSD(inputCollateralAmount, collateral.price.usd) ?? 0}
-              balance={collateral.balance.raw.toBig().toNumber()}
+              balance={collateral.balance.raw.toString()}
+              humanBalance={collateral.balance.raw.toHuman()}
               errorMessage={getErrorMessage(errors[DEPOSIT_COLLATERAL_AMOUNT])}
-              balanceDecimals={collateral.currency.humanDecimals}
               {...register(DEPOSIT_COLLATERAL_AMOUNT)}
             />
             <StyledDl>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

We have been facing quite a lot of issues with big decimals turning into exponential numbers. This PR aims to remove any kind of formatting happening in the `TokenInput`, since a better approach was found: config `Big` to output strings without exponentials. To safely handle this the following changes were made:

1. `balance` - from being just `number` -> `string | number`: turning amounts into numbers will make them exponential, so we now allow both types.
2. `humanBalance` - new prop which will be used to display balance in a shorter version. The difference is that `humanBalance` is just for display and `balance` is to be used programmatically.
3.  Remove old temporary code that was handling decimals issues.
4. Made changes across every form using `TokenInput` to include these latest changes

## Current behaviour (updates)

Formatting was being handled by `TokenInput`

## New behaviour

`TokenInput` does not handle formatting.

## Reproducible testing steps:

- Vault Onboarding
- AMM
- Lending