### PR TITLE
fix: remove error modal and add auth cta

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -85,29 +85,14 @@ const formatNumber = (
     minimumFractionDigits?: number;
     maximumFractionDigits?: number;
     compact?: boolean;
-    rounding?: boolean;
   }
 ): string => {
-  let formatted = amount;
-  let { compact, maximumFractionDigits, minimumFractionDigits, rounding = true } = options || {};
-
-  // Intl.NumberFormat rounds number by default. The alternative is to cut
-  // programmatically the number decimals before being formatted
-  if (!rounding && maximumFractionDigits) {
-    const decimal = new Big(10).pow(maximumFractionDigits);
-    formatted = new Big(Math.floor(decimal.mul(amount).toNumber())).div(decimal).toNumber();
-
-    // set to max digits to avoid rounding
-    maximumFractionDigits = 20;
-  }
-
   const { format } = new Intl.NumberFormat(undefined, {
-    minimumFractionDigits,
-    maximumFractionDigits,
-    notation: compact ? getFormatUSDNotation(formatted) : undefined
+    ...options,
+    notation: options?.compact ? getFormatUSDNotation(amount) : undefined
   });
 
-  return format(formatted);
+  return format(amount);
 };
 
 const formatPercentage = (

--- a/src/utils/hooks/api/loans/use-loan-mutation.tsx
+++ b/src/utils/hooks/api/loans/use-loan-mutation.tsx
@@ -27,11 +27,15 @@ const mutateLoan = ({ loanType, amount, isMaxAmount }: CreateLoanVariables) => {
   }
 };
 
-type UseLoanMutation = { onSuccess: () => void };
+type UseLoanMutation = { onSuccess: () => void; onError: (error: Error) => void };
 
-const useLoanMutation = ({ onSuccess }: UseLoanMutation): UseMutationResult<void, Error, CreateLoanVariables> => {
+const useLoanMutation = ({
+  onSuccess,
+  onError
+}: UseLoanMutation): UseMutationResult<void, Error, CreateLoanVariables> => {
   return useMutation<void, Error, CreateLoanVariables>(mutateLoan, {
-    onSuccess
+    onSuccess,
+    onError
   });
 };
 


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Error modal on loan form, when closed, closes both modals. Also added AuthCTA to LoanForm.

## Current behaviour (updates)

Error modal on loan form, when closed, closes both modals.

## New behaviour

Moved the error to a toast, just like we have in amm.

## Reproducible testing steps:

Lending