### PR TITLE
fix(Swap): filter out unwated tokens

### DIFF
--- a/src/pages/AMM/Swap/components/SwapForm/SwapForm.tsx
+++ b/src/pages/AMM/Swap/components/SwapForm/SwapForm.tsx
@@ -100,7 +100,7 @@ const SwapForm = ({ pair, liquidityPools, onChangePair, onSwap, ...props }: Swap
     }
   });
 
-  const { buttonProps, inputProps, outputProps } = useSwapFormData(pair, inputAmount, trade);
+  const { buttonProps, inputProps, outputProps } = useSwapFormData(pair, liquidityPools, inputAmount, trade);
 
   const handleChangeInput: ChangeEventHandler<HTMLInputElement> = (e) => {
     const value = Number(e.target.value) || undefined;

--- a/src/pages/AMM/shared/utils.ts
+++ b/src/pages/AMM/shared/utils.ts
@@ -1,4 +1,4 @@
-import { CurrencyExt, PooledCurrencies } from '@interlay/interbtc-api';
+import { CurrencyExt, LiquidityPool, PooledCurrencies } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 
 import { convertMonetaryAmountToValueInUSD } from '@/common/utils/utils';
@@ -20,4 +20,11 @@ const calculateAccountLiquidityUSD = (
   totalSupply: MonetaryAmount<CurrencyExt>
 ): number => lpTokenAmount.mul(totalLiquidityUSD).div(totalSupply.toBig()).toBig().toNumber();
 
-export { calculateAccountLiquidityUSD, calculateTotalLiquidityUSD };
+const getPooledTickers = (liquidityPools: LiquidityPool[]): Set<string> =>
+  liquidityPools.reduce((acc, pool) => {
+    pool.pooledCurrencies.forEach((curr) => acc.add(curr.currency.ticker));
+
+    return acc;
+  }, new Set<string>());
+
+export { calculateAccountLiquidityUSD, calculateTotalLiquidityUSD, getPooledTickers };


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

There were a couple of tokens that should not be listed in the swap page.

## Current behaviour (updates)

All existing on chain currencies were being displayed 

## New behaviour

Only currencies that belong to a pool will be displayed

## Reproducible testing steps:

Swap