### PR TITLE
fix(Swap): error message and clean-up state after swap

### DIFF
--- a/src/pages/AMM/Swap/components/SwapForm/SwapForm.tsx
+++ b/src/pages/AMM/Swap/components/SwapForm/SwapForm.tsx
@@ -93,6 +93,8 @@ const SwapForm = ({ pair, liquidityPools, onChangePair, onSwap, ...props }: Swap
   const swapMutation = useMutation<void, Error, SwapData>(mutateSwap, {
     onSuccess: () => {
       toast.success('Swap successful');
+      setTrade(undefined);
+      setInputAmount(undefined);
       onSwap();
     },
     onError: (err) => {
@@ -100,7 +102,13 @@ const SwapForm = ({ pair, liquidityPools, onChangePair, onSwap, ...props }: Swap
     }
   });
 
-  const { buttonProps, inputProps, outputProps } = useSwapFormData(pair, liquidityPools, inputAmount, trade);
+  const { buttonProps, inputProps, outputProps } = useSwapFormData(
+    pair,
+    liquidityPools,
+    swapMutation.isLoading,
+    inputAmount,
+    trade
+  );
 
   const handleChangeInput: ChangeEventHandler<HTMLInputElement> = (e) => {
     const value = Number(e.target.value) || undefined;

--- a/src/pages/AMM/Swap/hooks/use-swap-form-data.tsx
+++ b/src/pages/AMM/Swap/hooks/use-swap-form-data.tsx
@@ -18,7 +18,8 @@ import { getPooledTickers } from '../../shared/utils';
 const useButtonProps = (
   pair: SwapPair,
   inputAmount?: number,
-  trade?: Trade | null
+  trade?: Trade | null,
+  isSwaping?: boolean
 ): { children: ReactNode; disabled: boolean } => {
   const { getAvailableBalance } = useGetBalances();
   const { t } = useTranslation();
@@ -34,7 +35,7 @@ const useButtonProps = (
     return { children: t('amm.enter_token_amount', { token: pair.input.ticker }), disabled: true };
   }
 
-  if (new Big(inputAmount).gt(getAvailableBalance(pair.input.ticker || '')?.toBig() || 0)) {
+  if (!isSwaping && new Big(inputAmount).gt(getAvailableBalance(pair.input.ticker || '')?.toBig() || 0)) {
     return { children: t('amm.insufficient_token_balance', { token: pair.input.ticker }), disabled: true };
   }
 
@@ -62,13 +63,14 @@ type UseSwapFormData = {
 const useSwapFormData = (
   pair: SwapPair,
   liquidityPools: LiquidityPool[],
+  isSwaping: boolean,
   inputAmount?: number,
   trade?: Trade | null
 ): UseSwapFormData => {
   const { bridgeLoaded } = useSelector((state: StoreType) => state.general);
   const { getAvailableBalance } = useGetBalances();
   const prices = useGetPrices();
-  const buttonProps = useButtonProps(pair, inputAmount, trade);
+  const buttonProps = useButtonProps(pair, inputAmount, trade, isSwaping);
   const { data: currencies } = useGetCurrencies(bridgeLoaded);
 
   const pooledTickers = useMemo(() => getPooledTickers(liquidityPools), [liquidityPools]);


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

When swapping max balance, there was a "Insufficient Balance" showing while the transaction was still being submitted (introduced to the block).

## New behaviour

Shows Swap and loading indicator. After successful submission, form is cleaned up.

## Reproducible testing steps:

Swap with max balance and observer button text

NOTICE: wait on NumberInput revamp to run a test
