### PR TITLE
feat: take supply and borrow caps into account

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@heroicons/react": "^2.0.0",
     "@hookform/resolvers": "^2.9.7",
     "@interlay/bridge": "^0.2.1",
-    "@interlay/interbtc-api": "0.32.8",
+    "@interlay/interbtc-api": "0.32.9",
     "@material-icons/svg": "^1.0.28",
     "@polkadot/api": "9.11.1",
     "@polkadot/extension-dapp": "0.44.1",

--- a/src/lib/form-validation/loans/lend.ts
+++ b/src/lib/form-validation/loans/lend.ts
@@ -7,11 +7,11 @@ import balance from '../common/balance';
 import field from '../common/field';
 import { AvailableBalanceSchemaParams, CommonSchemaParams, MaxAmountSchemaParams } from '../types';
 
-type LoanLendSchemaParams = CommonSchemaParams & AvailableBalanceSchemaParams;
+type LoanLendSchemaParams = CommonSchemaParams & AvailableBalanceSchemaParams & MaxAmountSchemaParams;
 
 const lend = (t: TFunction, params: LoanLendSchemaParams): z.ZodEffects<z.ZodString, string, string> =>
   z.string().superRefine((value, ctx) => {
-    const { governanceBalance, transactionFee, availableBalance, minAmount } = params;
+    const { governanceBalance, transactionFee, availableBalance, minAmount, maxAmount } = params;
 
     if (!field.required.validate({ value })) {
       const issueArg = field.required.issue(t, { fieldName: t('loans.lend').toLowerCase(), fieldType: 'number' });
@@ -34,6 +34,14 @@ const lend = (t: TFunction, params: LoanLendSchemaParams): z.ZodEffects<z.ZodStr
 
     if (!balance.currency.validate({ availableBalance: availableBalance, inputAmount })) {
       return ctx.addIssue(balance.currency.issue(t));
+    }
+
+    if (!field.max.validate({ inputAmount: inputAmount.toBig(), maxAmount: maxAmount.toBig() })) {
+      const issueArg = field.max.issue(t, {
+        action: t('loans.lend').toLowerCase(),
+        amount: maxAmount.toString()
+      });
+      return ctx.addIssue(issueArg);
     }
   });
 

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -60,7 +60,7 @@ const getData = (t: TFunction, variant: LoanAction, params: LoanSchemaParams) =>
     lend: {
       content: {
         title: t('loans.lend'),
-        label: 'Maximum amount',
+        label: 'Available',
         fieldAriaLabel: t('forms.field_amount', { field: t('loans.lend').toLowerCase() })
       },
       schema: z.object({

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -60,7 +60,7 @@ const getData = (t: TFunction, variant: LoanAction, params: LoanSchemaParams) =>
     lend: {
       content: {
         title: t('loans.lend'),
-        label: 'Balance',
+        label: 'Maximum amount',
         fieldAriaLabel: t('forms.field_amount', { field: t('loans.lend').toLowerCase() })
       },
       schema: z.object({

--- a/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
@@ -10,6 +10,7 @@ import { useGetBalances } from '@/utils/hooks/api/tokens/use-get-balances';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
 
 import { getMaxBorrowableAmount } from '../utils/get-max-borrowable-amount';
+import { getMaxLendableAmount } from '../utils/get-max-lendable-amount';
 import { getMaxWithdrawableAmount } from '../utils/get-max-withdrawable-amount';
 
 type GetMaxAmountParams = {
@@ -42,8 +43,15 @@ const getMaxAmount = ({
         totalBorrowedAmountUSD,
         totalCollateralAmountUSD
       );
-    case 'lend':
-      return assetBalance;
+    case 'lend': {
+      if (assetBalance === undefined) {
+        return newMonetaryAmount(0, asset.currency);
+      }
+      const r = getMaxLendableAmount(assetBalance, asset);
+      console.log(r?.toString());
+      return r;
+    }
+
     case 'repay':
       return position?.amount.add((position as BorrowPosition).accumulatedDebt || 0);
   }

--- a/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
@@ -43,15 +43,8 @@ const getMaxAmount = ({
         totalBorrowedAmountUSD,
         totalCollateralAmountUSD
       );
-    case 'lend': {
-      if (assetBalance === undefined) {
-        return newMonetaryAmount(0, asset.currency);
-      }
-      const r = getMaxLendableAmount(assetBalance, asset);
-      console.log(r?.toString());
-      return r;
-    }
-
+    case 'lend':
+      return getMaxLendableAmount(assetBalance, asset);
     case 'repay':
       return position?.amount.add((position as BorrowPosition).accumulatedDebt || 0);
   }

--- a/src/pages/Loans/LoansOverview/utils/get-max-borrowable-amount.tsx
+++ b/src/pages/Loans/LoansOverview/utils/get-max-borrowable-amount.tsx
@@ -31,11 +31,8 @@ const getMaxBorrowableAmount = (
 
   const maxBorrowableAmountByCollateral =
     new MonetaryAmount(currency, maxBorrowableCurrencyAmount) || new MonetaryAmount(currency, 0);
-
-  const maxBorrowableAmount = pickSmallerAmount(
-    pickSmallerAmount(availableCapacity, borrowCap.sub(totalBorrows)),
-    maxBorrowableAmountByCollateral
-  );
+  const protocolLimitAmount = pickSmallerAmount(availableCapacity, borrowCap.sub(totalBorrows));
+  const maxBorrowableAmount = pickSmallerAmount(protocolLimitAmount, maxBorrowableAmountByCollateral);
 
   if (maxBorrowableAmount.toBig().lte(0)) {
     return newMonetaryAmount(0, currency);

--- a/src/pages/Loans/LoansOverview/utils/get-max-lendable-amount.ts
+++ b/src/pages/Loans/LoansOverview/utils/get-max-lendable-amount.ts
@@ -1,0 +1,21 @@
+import { CurrencyExt, LoanAsset, newMonetaryAmount } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
+
+import { pickSmallerAmount } from '@/utils/helpers/currencies';
+
+const getMaxLendableAmount = (
+  assetBalance: MonetaryAmount<CurrencyExt>,
+  asset: LoanAsset
+): MonetaryAmount<CurrencyExt> => {
+  const { totalLiquidity, supplyCap, currency, totalBorrows } = asset;
+  const amountInProtocol = totalLiquidity.sub(totalBorrows);
+  const maximumAmountToSupply = supplyCap.sub(amountInProtocol);
+  const maximumLendableAmount = pickSmallerAmount(assetBalance, maximumAmountToSupply);
+
+  if (maximumLendableAmount.toBig().lte(0)) {
+    return newMonetaryAmount(0, currency);
+  }
+  return maximumLendableAmount;
+};
+
+export { getMaxLendableAmount };

--- a/src/pages/Loans/LoansOverview/utils/get-max-lendable-amount.ts
+++ b/src/pages/Loans/LoansOverview/utils/get-max-lendable-amount.ts
@@ -4,9 +4,13 @@ import { MonetaryAmount } from '@interlay/monetary-js';
 import { pickSmallerAmount } from '@/utils/helpers/currencies';
 
 const getMaxLendableAmount = (
-  assetBalance: MonetaryAmount<CurrencyExt>,
+  assetBalance: MonetaryAmount<CurrencyExt> | undefined,
   asset: LoanAsset
 ): MonetaryAmount<CurrencyExt> => {
+  if (assetBalance === undefined) {
+    return newMonetaryAmount(0, asset.currency);
+  }
+
   const { totalLiquidity, supplyCap, currency, totalBorrows } = asset;
   const amountInProtocol = totalLiquidity.sub(totalBorrows);
   const maximumAmountToSupply = supplyCap.sub(amountInProtocol);

--- a/src/utils/helpers/currencies.ts
+++ b/src/utils/helpers/currencies.ts
@@ -1,4 +1,5 @@
 import { CurrencyExt } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
 
 // Squid query by currency ticker for native assets and by id for foreign assets.
 // We need to differentiate because those are handled differently on squid side.
@@ -6,4 +7,14 @@ import { CurrencyExt } from '@interlay/interbtc-api';
 const getCurrencyEqualityCondition = (currency: CurrencyExt): string =>
   'foreignAsset' in currency ? `asset_eq: ${currency.foreignAsset.id}` : `token_eq: ${currency.ticker}`;
 
-export { getCurrencyEqualityCondition };
+const pickSmallerAmount = (
+  amount0: MonetaryAmount<CurrencyExt>,
+  amount1: MonetaryAmount<CurrencyExt>
+): MonetaryAmount<CurrencyExt> => {
+  if (amount0.lte(amount1)) {
+    return amount0;
+  }
+  return amount1;
+};
+
+export { getCurrencyEqualityCondition, pickSmallerAmount };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,10 +2583,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@0.32.8":
-  version "0.32.8"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-0.32.8.tgz#99b9b64806d0c167783f9a97a3779ae7471f310d"
-  integrity sha512-XGTJL+DgP46Kn3SGozqfbq4G7ggQV4XiNl9/DJTM/b+20YdU6byZ9uJwLZtGz53Ch5+fKOzOcljAJYS/OaiKkw==
+"@interlay/interbtc-api@0.32.9":
+  version "0.32.9"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-0.32.9.tgz#e276e8b74f6d1785f84a76b9c8287928164e2baa"
+  integrity sha512-sCxFAdLxIsnimDaVSRsxMbnZ/zFeM4I3r8093xtRcW1valvCM9D/GIUqRmf1N5UfpfdIswsg+9ndxI6Am6LYFQ==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "0.31.6"


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Adding supply and borrow caps into loans calculations.

## Current behaviour (updates)

Caps were not taken into account before which caused some errors.

## New behaviour

Loan form is validated using caps and maximum computation methods are adjusted.

## Reproducible testing steps:

Go to loans page. Find a pair that is close to supply or borrow cap and check that Loan form is displaying and validating correct amount.

