### PR TITLE
hotfix: testnet banner

### DIFF
--- a/src/legacy-components/TestnetBanner/index.tsx
+++ b/src/legacy-components/TestnetBanner/index.tsx
@@ -3,10 +3,9 @@ import clsx from 'clsx';
 import WarningBanner from '../WarningBanner';
 
 const TestnetBanner = (): JSX.Element => (
-  <WarningBanner className={clsx('mx-auto', 'md:max-w-2xl')} severity='info'>
+  <WarningBanner className={clsx('mx-auto', 'md:max-w-2xl')} severity='alert'>
     <p>
-      Thanks for trying out the testnet! The testnet might be reset at any point to make sure we can get the latest
-      version of our software to you.
+      We are currently facing an issue with block production on the testnet. We are working to restore block production. Until then, the testnet cannot be used. Follow the latest updates in our <a href='https://discord.com/invite/KgCYK3MKSf' target='_blank' rel='noreferrer'>Discord</a>.
     </p>
   </WarningBanner>
 );


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Changes the current testnet banner to notify users that testnet is currently offline and points them to our discord.

## Reproducible testing steps:

Got to any testnet page and see the updated banner.