### PR TITLE
feat: added Discord chat embed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+  <script src='https://cdn.jsdelivr.net/npm/@widgetbot/crate@3' async defer>
+    new Crate({
+      server: '745259537707040778', // Interlay | Kintsugi (Official)
+      channel: '1076512688416509992', // #🙉trollbox
+      defer: true // Only load the widget once the user opens it
+    })
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Added an embedded Discord chat using [Widgetbot](https://docs.widgetbot.io/embed/crate/tutorial/#getting-started) <script> tag in index.html. 
This functions as a live chat using our Discord server (uses trollbox public chat which has stricter MEE6 moderation rules for non-verified members).  

## Current behaviour (updates)

No embedded chat 

## New behaviour

Discord icon in the bottom right of the screen.  
When clicked, loads Discord connection and opens the "trollbox" channel (can be set to any channel). 
User can then chat with each other while using the app via our Discord server. 

See Loom video: https://www.loom.com/share/46fed094ad1a4afd825473462f1f82f1