### PR TITLE
fix: export testing-library customRender functionality

### DIFF
--- a/src/test/mocks/substrate/mocks.ts
+++ b/src/test/mocks/substrate/mocks.ts
@@ -1,6 +1,8 @@
 import { mockInterBtcApi } from '../@interlay/interbtc-api';
 import mockJsonRpc from './jsonrpc';
 
+const DEFAULT_ACCOUNT_ADDRESS = 'a3aTRC4zs1djutYS9QuZSB3XmfRgNzFfyRtbZKaoQyv67Yzcc';
+
 const DEFAULT_KEYRING_ACCOUNTS = [
   {
     key: 'header-accounts',
@@ -45,7 +47,7 @@ const DEFAULT_KEYRING = {
 
 const DEFAULT_ACCOUNTS = [
   {
-    address: 'a3aTRC4zs1djutYS9QuZSB3XmfRgNzFfyRtbZKaoQyv67Yzcc',
+    address: DEFAULT_ACCOUNT_ADDRESS,
     meta: {
       genesisHash: '',
       name: 'Wallet 1',
@@ -75,7 +77,7 @@ const DEFAULT_EXTENSIONS = [
 ];
 
 const DEFAULT_SELECTED_ACCOUNT = {
-  address: 'a3aTRC4zs1djutYS9QuZSB3XmfRgNzFfyRtbZKaoQyv67Yzcc',
+  address: DEFAULT_ACCOUNT_ADDRESS,
   addressRaw: {
     '0': 10,
     '1': 224,
@@ -166,4 +168,4 @@ const DEFAULT_SUBSTRATE = {
   extensions: DEFAULT_EXTENSIONS
 };
 
-export { DEFAULT_KEYRING, DEFAULT_SUBSTRATE };
+export { DEFAULT_ACCOUNT_ADDRESS, DEFAULT_KEYRING, DEFAULT_SUBSTRATE };

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -41,26 +41,20 @@ const ProvidersWrapper: (history: MemoryHistory) => FC<{ children?: React.ReactN
   );
 };
 
-const customRender = (ui: ReactElement, options?: CustomRenderOptions): Promise<void> => {
+const customRender = async (ui: ReactElement, options?: CustomRenderOptions): Promise<ReturnType<typeof render>> => {
   const history = createMemoryHistory();
   if (options?.path) {
     history.push(options.path);
   }
 
-  if (!options?.hasLayout) {
-    jest.mock('../parts/Layout', () => {
-      const MockedLayout: React.FC = ({ children }: any) => children;
-      MockedLayout.displayName = 'MockedLayout';
-      return MockedLayout;
-    });
-
-    console.warn('Rendering with mocked out `Layout` component');
-  }
+  let _render;
 
   // Wrapped in act so async updates are awaited.
-  return act(async () => {
-    render(ui, { wrapper: ProvidersWrapper(history), ...options });
+  await act(async () => {
+    _render = render(ui, { wrapper: ProvidersWrapper(history), ...options });
   });
+
+  return _render as any;
 };
 
 export * from '@testing-library/react';


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Our `customRender` should expose `testing-library` full functionality.

