### PR TITLE
fix(Loans): loan form ui and repay

### DIFF
--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.style.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.style.tsx
@@ -16,10 +16,20 @@ const StyledDd = styled(Dd)<StyledDdProps>`
   display: flex;
   gap: ${theme.spacing.spacing2};
   align-items: center;
+  overflow: hidden;
 `;
 
 const StyledDl = styled(Dl)`
   font-size: ${theme.text.s};
 `;
 
-export { StyledDd, StyledDl };
+const StyledSpan = styled.span`
+  white-space: nowrap;
+
+  &:last-of-type {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+`;
+
+export { StyledDd, StyledDl, StyledSpan };

--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
@@ -12,7 +12,8 @@ import { Prices } from '@/utils/hooks/api/use-get-prices';
 import { useGetLTV } from '../../hooks/use-get-ltv';
 import { isBorrowAsset } from '../../utils/is-loan-asset';
 import { LTVMeter } from '../LTVMeter.tsx';
-import { StyledDd, StyledDl } from './BorrowLimit.style';
+import { StyledDd, StyledDl, StyledSpan } from './BorrowLimit.style';
+import { RemainingDebt } from './RemainingDebt';
 
 type BorrowLimitProps = {
   loanAction: LoanAction;
@@ -20,6 +21,7 @@ type BorrowLimitProps = {
   actionAmount: MonetaryAmount<CurrencyExt>;
   prices: Prices | undefined;
   shouldDisplayLiquidationAlert?: boolean;
+  remainingDebt?: MonetaryAmount<CurrencyExt>;
 };
 
 const BorrowLimit = ({
@@ -27,6 +29,7 @@ const BorrowLimit = ({
   asset,
   actionAmount,
   prices,
+  remainingDebt,
   shouldDisplayLiquidationAlert
 }: BorrowLimitProps): JSX.Element | null => {
   const { t } = useTranslation();
@@ -61,16 +64,19 @@ const BorrowLimit = ({
           most {displayMonetaryAmount(asset.availableCapacity)} {asset.currency.ticker}.
         </Alert>
       )}
+      {remainingDebt && (
+        <RemainingDebt actionAmount={actionAmount} remainingDebt={remainingDebt} status={newLTV.status} />
+      )}
       <DlGroup justifyContent='space-between'>
         <Dt>Borrow Limit</Dt>
         <StyledDd $status={newLTV.status}>
           {currentBorrowLimit && (
             <>
-              <span>{currentBorrowLimitLabel}</span>
-              <span>--&gt;</span>
+              <StyledSpan>{currentBorrowLimitLabel}</StyledSpan>
+              <StyledSpan>--&gt;</StyledSpan>
             </>
           )}
-          <span>{newBorrowLimitLabel}</span>
+          <StyledSpan>{newBorrowLimitLabel}</StyledSpan>
         </StyledDd>
       </DlGroup>
       <DlGroup justifyContent='space-between'>
@@ -78,11 +84,11 @@ const BorrowLimit = ({
         <StyledDd $status={newLTV.status}>
           {currentLTV && (
             <>
-              <span>{currentLTVLabel}</span>
-              <span>--&gt;</span>
+              <StyledSpan>{currentLTVLabel}</StyledSpan>
+              <StyledSpan>--&gt;</StyledSpan>
             </>
           )}
-          <span>{newLTVLabel}</span>
+          <StyledSpan>{newLTVLabel}</StyledSpan>
         </StyledDd>
       </DlGroup>
       <LTVMeter value={newLTV.value} ranges={newLTV.ranges} />

--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/RemainingDebt.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/RemainingDebt.tsx
@@ -1,0 +1,34 @@
+import { CurrencyExt } from '@interlay/interbtc-api';
+import { MonetaryAmount } from '@interlay/monetary-js';
+
+import { DlGroup, Dt, Status } from '@/component-library';
+
+import { StyledDd, StyledSpan } from './BorrowLimit.style';
+
+type RemainingDebtProps = {
+  status: Status;
+  remainingDebt: MonetaryAmount<CurrencyExt>;
+  actionAmount: MonetaryAmount<CurrencyExt>;
+};
+
+const RemainingDebt = ({ status, actionAmount, remainingDebt }: RemainingDebtProps): JSX.Element | null => {
+  const newRemainingDebt = actionAmount.gt(remainingDebt) ? 0 : remainingDebt?.sub(actionAmount).toHuman();
+
+  return (
+    <DlGroup wrap justifyContent='space-between'>
+      <Dt>Remaining debt</Dt>
+      <StyledDd $status={status}>
+        <StyledSpan>
+          {remainingDebt.toHuman()} {remainingDebt.currency.ticker}
+        </StyledSpan>
+        <StyledSpan>--&gt;</StyledSpan>
+        <StyledSpan>
+          {newRemainingDebt} {remainingDebt.currency.ticker}
+        </StyledSpan>
+      </StyledDd>
+    </DlGroup>
+  );
+};
+
+export { RemainingDebt };
+export type { RemainingDebtProps };

--- a/src/pages/Loans/LoansOverview/components/LoanActionInfo/LoanActionInfo.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanActionInfo/LoanActionInfo.tsx
@@ -16,29 +16,21 @@ type LoanActionInfoProps = {
   prices?: Prices;
 };
 
-const LoanActionInfo = ({ variant, asset, prices }: LoanActionInfoProps): JSX.Element => {
-  const isBorrow = variant === 'borrow';
-  const apy = isBorrow ? asset?.borrowApy : asset?.lendApy;
-  const rewards = isBorrow ? asset?.borrowReward : asset?.lendReward;
-
-  return (
-    <StyledDl direction='column' gap='spacing2'>
-      {asset && apy && (
-        <LoanGroup isBorrow={isBorrow} currency={asset.currency} apy={apy} rewards={rewards} prices={prices} />
-      )}
-      <DlGroup justifyContent='space-between'>
-        <Dt>Fees</Dt>
-        <Dd>
-          {displayMonetaryAmount(TRANSACTION_FEE_AMOUNT)} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
-          {displayMonetaryAmountInUSDFormat(
-            TRANSACTION_FEE_AMOUNT,
-            getTokenPrice(prices, TRANSACTION_FEE_AMOUNT.currency.ticker)?.usd
-          )}
-          )
-        </Dd>
-      </DlGroup>
-    </StyledDl>
-  );
-};
+const LoanActionInfo = ({ variant, asset, prices }: LoanActionInfoProps): JSX.Element => (
+  <StyledDl direction='column' gap='spacing2'>
+    {(variant === 'borrow' || variant === 'lend') && <LoanGroup variant={variant} asset={asset} prices={prices} />}
+    <DlGroup justifyContent='space-between'>
+      <Dt>Fees</Dt>
+      <Dd>
+        {displayMonetaryAmount(TRANSACTION_FEE_AMOUNT)} {TRANSACTION_FEE_AMOUNT.currency.ticker} (
+        {displayMonetaryAmountInUSDFormat(
+          TRANSACTION_FEE_AMOUNT,
+          getTokenPrice(prices, TRANSACTION_FEE_AMOUNT.currency.ticker)?.usd
+        )}
+        )
+      </Dd>
+    </DlGroup>
+  </StyledDl>
+);
 export { LoanActionInfo };
 export type { LoanActionInfoProps };

--- a/src/pages/Loans/LoansOverview/components/LoanActionInfo/LoanGroup.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanActionInfo/LoanGroup.tsx
@@ -1,34 +1,42 @@
-import { CurrencyExt } from '@interlay/interbtc-api';
-import { MonetaryAmount } from '@interlay/monetary-js';
-import Big from 'big.js';
+import { LoanAsset } from '@interlay/interbtc-api';
 
 import { Dd, DlGroup, Dt } from '@/component-library';
+import { LoanAction } from '@/types/loans';
 import { Prices } from '@/utils/hooks/api/use-get-prices';
 
 import { getApyLabel } from '../../utils/apy';
 import { RewardsGroup } from './RewardsGroup';
 
 type LoanGroupProps = {
-  apy: Big;
-  currency: CurrencyExt;
-  isBorrow: boolean;
-  rewards?: MonetaryAmount<CurrencyExt> | null;
+  variant?: Extract<LoanAction, 'borrow' | 'lend'>;
+  asset?: LoanAsset;
   prices?: Prices;
 };
 
-const LoanGroup = ({ isBorrow, apy, currency, rewards, prices }: LoanGroupProps): JSX.Element => (
-  <>
-    <DlGroup justifyContent='space-between'>
-      <Dt>
-        {isBorrow ? 'Borrow' : 'Lend'} APY {currency.ticker}
-      </Dt>
-      <Dd>{getApyLabel(apy)}</Dd>
-    </DlGroup>
-    {!!rewards && (
-      <RewardsGroup apy={apy} isBorrow={isBorrow} rewards={rewards} assetCurrency={currency} prices={prices} />
-    )}
-  </>
-);
+const LoanGroup = ({ variant, asset, prices }: LoanGroupProps): JSX.Element | null => {
+  const isBorrow = variant === 'borrow';
+  const apy = isBorrow ? asset?.borrowApy : asset?.lendApy;
+
+  if (!apy || !asset) {
+    return null;
+  }
+
+  const rewards = isBorrow ? asset?.borrowReward : asset?.lendReward;
+
+  return (
+    <>
+      <DlGroup justifyContent='space-between'>
+        <Dt>
+          {isBorrow ? 'Borrow' : 'Lend'} APY {asset.currency.ticker}
+        </Dt>
+        <Dd>{getApyLabel(apy)}</Dd>
+      </DlGroup>
+      {!!rewards && (
+        <RewardsGroup apy={apy} isBorrow={isBorrow} rewards={rewards} assetCurrency={asset.currency} prices={prices} />
+      )}
+    </>
+  );
+};
 
 export { LoanGroup };
 export type { LoanGroupProps };

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -62,7 +62,7 @@ const getData = (t: TFunction, variant: LoanAction) =>
     repay: {
       content: {
         title: t('loans.repay'),
-        label: t('loans.borrowing'),
+        label: 'Balance',
         fieldAriaLabel: t('forms.field_amount', { field: t('loans.repay').toLowerCase() })
       }
     }
@@ -85,7 +85,11 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
     data: { hasCollateral }
   } = useGetAccountPositions();
   const prices = useGetPrices();
-  const { governanceBalance, assetAmount, assetPrice, transactionFee } = useLoanFormData(variant, asset, position);
+  const { governanceBalance, assetAmount, assetPrice, transactionFee, balance } = useLoanFormData(
+    variant,
+    asset,
+    position
+  );
 
   // withdraw has `withdraw` and `withdrawAll`
   // repay has `repay` and `repayAll`
@@ -175,8 +179,8 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
             placeholder='0.00'
             ticker={asset.currency.ticker}
             aria-label={content.fieldAriaLabel}
-            balance={assetAmount.max.value.toString()}
-            humanBalance={assetAmount.max.value.toHuman()}
+            balance={balance.toString()}
+            humanBalance={balance.toHuman()}
             balanceLabel={content.label}
             valueUSD={convertMonetaryAmountToValueInUSD(monetaryAmount, assetPrice) ?? 0}
             onClickBalance={handleClickBalance}
@@ -189,6 +193,7 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
               asset={asset}
               actionAmount={monetaryAmount}
               prices={prices}
+              remainingDebt={variant === 'repay' ? assetAmount.max.value : undefined}
             />
           )}
         </Flex>

--- a/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-loan-form-data.tsx
@@ -74,6 +74,7 @@ type UseLoanFormData = {
   governanceBalance: MonetaryAmount<CurrencyExt>;
   transactionFee: MonetaryAmount<CurrencyExt>;
   assetPrice: number;
+  balance: MonetaryAmount<CurrencyExt>;
   assetAmount: {
     available: MonetaryAmount<CurrencyExt>;
     min: MonetaryAmount<CurrencyExt>;
@@ -118,6 +119,7 @@ const useLoanFormData = (
     governanceBalance,
     transactionFee,
     assetPrice,
+    balance: loanAction === 'repay' ? (assetBalance.gt(maxAmount) ? maxAmount : assetBalance) : maxAmount,
     assetAmount: {
       available: assetBalance,
       min: minAmount,


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

1. Change repay form to show on input label the amount the user has in his wallet that can be used to repay
2. Added a row in that form for the remaining debt
3. Removed unwanted APY showing on Withdraw and Repay form

![image](https://user-images.githubusercontent.com/43269067/223412715-6bd1250d-8113-460c-bc41-d07cbfc13112.png)

## Current behaviour (updates)

Was using remaining debt as user balance

## New behaviour

Now uses available balance correctly

## Reproducible testing steps:

1. Go to lending page
2. Open lend collateral positions and borrow positions
3. Try repaying loan after some blocks