### PR TITLE
rui/fix-modal-focus

### DIFF
--- a/src/component-library/Modal/Modal.stories.tsx
+++ b/src/component-library/Modal/Modal.stories.tsx
@@ -96,6 +96,7 @@ LargeContent.args = {
   isOpen: false,
   hasFooter: true,
   hasTitle: true,
+  align: 'top',
   children: (
     <>
       Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -59,6 +59,7 @@ const StyledWrapper = styled.div<StyledModalProps>`
 `;
 
 const StyledModal = styled.div<StyledModalProps>`
+  width: 100%;
   max-width: ${theme.modal.maxWidth};
   max-height: ${({ $isCentered }) => $isCentered && theme.modal.maxHeight};
   margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};

--- a/src/component-library/Modal/Modal.style.tsx
+++ b/src/component-library/Modal/Modal.style.tsx
@@ -37,29 +37,43 @@ const StyledUnderlay = styled.div<StyledUnderlayProps>`
   height: 100vh;
 
   background: ${theme.modal.underlay.bg};
-  display: flex;
-  justify-content: center;
-  align-items: ${({ $isCentered }) => ($isCentered ? 'center' : 'flex-start')};
-  overflow: ${({ $isCentered }) => !$isCentered && 'auto'};
 
   ${({ $isOpen }) => overlayCSS($isOpen)}
   transition: ${({ $isOpen }) =>
     $isOpen ? theme.modal.underlay.transition.entering : theme.modal.underlay.transition.exiting};
 `;
 
-const StyledModal = styled.div<StyledModalProps>`
-  justify-content: center;
-  display: flex;
+const StyledWrapper = styled.div<StyledModalProps>`
+  position: fixed;
+  top: 0;
+  left: 0;
   z-index: ${theme.modal.zIndex};
-  margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};
+  width: 100vw;
+  height: 100vh;
+  visibility: visible;
+
+  display: flex;
+  justify-content: center;
+  align-items: ${({ $isCentered }) => ($isCentered ? 'center' : 'flex-start')};
+  overflow: ${({ $isCentered }) => !$isCentered && 'auto'};
+`;
+
+const StyledModal = styled.div<StyledModalProps>`
   max-width: ${theme.modal.maxWidth};
   max-height: ${({ $isCentered }) => $isCentered && theme.modal.maxHeight};
-  width: 100%;
+  margin: ${({ $isCentered }) => ($isCentered ? 0 : theme.spacing.spacing16)} ${theme.spacing.spacing6};
 
   transform: ${({ $isOpen }) => ($isOpen ? 'translateY(0)' : `translateY(20px)`)};
-  visibility: inherit;
-  opacity: inherit;
+  ${({ $isOpen }) => overlayCSS(!!$isOpen)}
+  // Overrides overlayCSS properties, because react-aria Overlay
+  // contains a FocusScope that will ignore this element if it is
+  // visually hidden
+  visibility: visible;
+  // Allows scroll on the modal
+  pointer-events: auto;
   transition: ${({ $isOpen }) => ($isOpen ? theme.modal.transition.entering : theme.modal.transition.exiting)};
+
+  outline: none;
 `;
 
 const StyledDialog = styled.section<StyledDialogProps>`
@@ -71,11 +85,12 @@ const StyledDialog = styled.section<StyledDialogProps>`
   width: 100%;
   max-height: ${({ $hasMaxHeight }) => $hasMaxHeight && '560px'};
   overflow: ${({ $isCentered }) => $isCentered && 'hidden'};
-  pointer-events: auto;
 
   display: flex;
   flex-direction: column;
   position: relative;
+
+  outline: none;
 `;
 
 const StyledCloseCTA = styled(CTA)`
@@ -114,5 +129,6 @@ export {
   StyledModalDivider,
   StyledModalFooter,
   StyledModalHeader,
-  StyledUnderlay
+  StyledUnderlay,
+  StyledWrapper
 };

--- a/src/component-library/Modal/ModalWrapper.tsx
+++ b/src/component-library/Modal/ModalWrapper.tsx
@@ -3,7 +3,7 @@ import { mergeProps } from '@react-aria/utils';
 import { OverlayTriggerState } from '@react-stately/overlays';
 import { forwardRef, ReactNode, RefObject } from 'react';
 
-import { StyledModal, StyledUnderlay } from './Modal.style';
+import { StyledModal, StyledUnderlay, StyledWrapper } from './Modal.style';
 
 type Props = {
   children: ReactNode;
@@ -33,11 +33,14 @@ const ModalWrapper = forwardRef<HTMLDivElement, ModalWrapperProps>(
     const isCentered = align === 'center';
 
     return (
-      <StyledUnderlay {...underlayProps} $isOpen={!!isOpen} $isCentered={isCentered}>
-        <StyledModal ref={ref} $isOpen={isOpen} $isCentered={isCentered} {...mergeProps(modalProps, props)}>
-          {children}
-        </StyledModal>
-      </StyledUnderlay>
+      <>
+        <StyledUnderlay {...underlayProps} $isOpen={!!isOpen} $isCentered={isCentered} />
+        <StyledWrapper $isCentered={isCentered} $isOpen={!!isOpen}>
+          <StyledModal $isOpen={isOpen} ref={ref} $isCentered={isCentered} {...mergeProps(modalProps, props)}>
+            {children}
+          </StyledModal>
+        </StyledWrapper>
+      </>
     );
   }
 );

--- a/src/component-library/Overlay/Overlay.tsx
+++ b/src/component-library/Overlay/Overlay.tsx
@@ -53,18 +53,20 @@ const Overlay = ({
 
   return (
     <AriaOverlay portalContainer={container}>
-      <OpenTransition
-        in={isOpen}
-        appear
-        onExit={onExit}
-        onExiting={onExiting}
-        onExited={handleExited}
-        onEnter={onEnter}
-        onEntering={onEntering}
-        onEntered={handleEntered}
-      >
-        {children}
-      </OpenTransition>
+      <div>
+        <OpenTransition
+          in={isOpen}
+          appear
+          onExit={onExit}
+          onExiting={onExiting}
+          onExited={handleExited}
+          onEnter={onEnter}
+          onEntering={onEntering}
+          onEntered={handleEntered}
+        >
+          {children}
+        </OpenTransition>
+      </div>
     </AriaOverlay>
   );
 };


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Latest change to modal does not allow it to be closed using ESC because the focus is kept outside of the modal. This is because `react-aria` `Overlay` component has a `FocusScope` component, which is used to contain the focus inside the Overlay. This PR fixed the styles that were not allowing the `FocusScope` to find a focusable item, because when it was trying, the focusable items were visually `hidden`.


