### PR TITLE
fix(loans): use ltv in percentage denomination to resolve loan status

### DIFF
--- a/src/pages/Loans/LoansOverview/hooks/use-get-ltv.tsx
+++ b/src/pages/Loans/LoansOverview/hooks/use-get-ltv.tsx
@@ -55,14 +55,16 @@ const getData = (
     };
   }
 
+  const ltvPercentage = ltv.mul(100);
+
   const thresholds = {
     collateral: collateralThresholdWeightedAverage.mul(100),
     liquidation: liquidationThresholdWeightedAverage.mul(100)
   };
 
   return {
-    value: ltv.toNumber() * 100,
-    status: getStatus(ltv, thresholds),
+    value: ltvPercentage.toNumber(),
+    status: getStatus(ltvPercentage, thresholds),
     ranges: getRanges(thresholds)
   };
 };


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Fix loan status resolution by using LTV in percentage denomination.

## Current behaviour (updates)
![image](https://user-images.githubusercontent.com/47864599/224954599-34453af0-6526-4b8d-a891-4a58aba08c1a.png)

## New behaviour
![image](https://user-images.githubusercontent.com/47864599/224954627-ce344e17-7773-411f-ab77-f465b29d60d1.png)

> Please describe the behaviour or changes this PR adds

## Reproducible testing steps:

> Please list all testing steps required for the reviewer to test this specific issue. Consider regressions and edge cases.
