### PR TITLE
fix(Loans): loan form

### DIFF
--- a/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowLimit/BorrowLimit.tsx
@@ -10,7 +10,6 @@ import { getTokenPrice } from '@/utils/helpers/prices';
 import { Prices } from '@/utils/hooks/api/use-get-prices';
 
 import { useGetLTV } from '../../hooks/use-get-ltv';
-import { isBorrowAsset } from '../../utils/is-loan-asset';
 import { LTVMeter } from '../LTVMeter.tsx';
 import { StyledDd, StyledDl, StyledSpan } from './BorrowLimit.style';
 import { RemainingDebt } from './RemainingDebt';
@@ -44,7 +43,12 @@ const BorrowLimit = ({
     return null;
   }
 
-  const hasLiquidationAlert = shouldDisplayLiquidationAlert && isBorrowAsset(loanAction) && newLTV.status === 'error';
+  // Only show on borrow and withdraw because these could
+  // have negative impact on the loan
+  const hasLiquidationAlert =
+    (loanAction === 'borrow' || loanAction === 'withdraw') &&
+    shouldDisplayLiquidationAlert &&
+    newLTV.status === 'error';
 
   const currentLTVLabel = formatPercentage(currentLTV.value);
   const newLTVLabel = formatPercentage(newLTV.value);

--- a/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanForm/LoanForm.tsx
@@ -187,7 +187,8 @@ const LoanForm = ({ asset, variant, position, onChangeLoan }: LoanFormProps): JS
           />
           {showBorrowLimit && (
             <BorrowLimit
-              shouldDisplayLiquidationAlert
+              // Only shows the alert if the user interacted with the form
+              shouldDisplayLiquidationAlert={!!form.values[variant]}
               loanAction={variant}
               asset={asset}
               actionAmount={monetaryAmount}

--- a/src/pages/Loans/LoansOverview/utils/get-max-borrowable-amount.tsx
+++ b/src/pages/Loans/LoansOverview/utils/get-max-borrowable-amount.tsx
@@ -8,13 +8,10 @@ import { pickSmallerAmount } from '@/utils/helpers/currencies';
  * with currently provided collateral and liquidity.
  * @param {LoanAsset} asset The asset to be withdrawn.s
  * @param {LendingStats} lendingStats Object containing information about account's collateralization.
- * @return {MonetaryAmount<CurrencyExt> | undefined} maximum amount of currency that
- * user can withdraw with currently provided collateral. Returns undefined if it is loading
+ * @return {MonetaryAmount<CurrencyExt>} maximum amount of currency that
+ * user can withdraw with currently provided collateral
  */
-const getMaxBorrowableAmount = (
-  asset: LoanAsset,
-  lendingStats?: LendingStats
-): MonetaryAmount<CurrencyExt> | undefined => {
+const getMaxBorrowableAmount = (asset: LoanAsset, lendingStats?: LendingStats): MonetaryAmount<CurrencyExt> => {
   if (lendingStats === undefined) {
     return newMonetaryAmount(0, asset.currency);
   }

--- a/src/pages/Loans/LoansOverview/utils/get-max-lendable-amount.ts
+++ b/src/pages/Loans/LoansOverview/utils/get-max-lendable-amount.ts
@@ -1,25 +1,15 @@
 import { CurrencyExt, LoanAsset, newMonetaryAmount } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 
-import { pickSmallerAmount } from '@/utils/helpers/currencies';
-
-const getMaxLendableAmount = (
-  assetBalance: MonetaryAmount<CurrencyExt> | undefined,
-  asset: LoanAsset
-): MonetaryAmount<CurrencyExt> => {
-  if (assetBalance === undefined) {
-    return newMonetaryAmount(0, asset.currency);
-  }
-
+const getMaxLendableAmount = (asset: LoanAsset): MonetaryAmount<CurrencyExt> => {
   const { totalLiquidity, supplyCap, currency, totalBorrows } = asset;
   const amountInProtocol = totalLiquidity.sub(totalBorrows);
   const maximumAmountToSupply = supplyCap.sub(amountInProtocol);
-  const maximumLendableAmount = pickSmallerAmount(assetBalance, maximumAmountToSupply);
 
-  if (maximumLendableAmount.toBig().lte(0)) {
+  if (maximumAmountToSupply.toBig().lte(0)) {
     return newMonetaryAmount(0, currency);
   }
-  return maximumLendableAmount;
+  return maximumAmountToSupply;
 };
 
 export { getMaxLendableAmount };

--- a/src/pages/Loans/LoansOverview/utils/get-max-withdrawable-amount.tsx
+++ b/src/pages/Loans/LoansOverview/utils/get-max-withdrawable-amount.tsx
@@ -8,13 +8,13 @@ import { MonetaryAmount } from '@interlay/monetary-js';
  * @param {CollateralPosition} position The position to be withdrew.
  * @param {LendingStats} lendingStats Object containing information about account's collateralization.
  * @return {MonetaryAmount<CurrencyExt> | undefined} maximum amount of currency that
- * user can withdraw with currently provided collateral. Returns undefined if it is loading
+ * user can withdraw with currently provided collateral
  */
 const getMaxWithdrawableAmount = (
   asset: LoanAsset,
   position?: CollateralPosition,
   lendingStats?: LendingStats
-): MonetaryAmount<CurrencyExt> | undefined => {
+): MonetaryAmount<CurrencyExt> => {
   const { currency } = asset;
 
   if (position === undefined || lendingStats === undefined) {

--- a/src/test/pages/Loans/borrow.test.tsx
+++ b/src/test/pages/Loans/borrow.test.tsx
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom';
 
+import Big from 'big.js';
+
 import App from '@/App';
 import { WRAPPED_TOKEN } from '@/config/relay-chains';
 import {
@@ -11,6 +13,7 @@ import {
   DEFAULT_LENDING_STATS,
   mockBorrow,
   mockCalculateBorrowLimitBtcChange,
+  mockCalculateLtvAndThresholdsChange,
   mockGetBorrowPositionsOfAccount,
   mockGetLendingStats,
   mockGetLendPositionsOfAccount,
@@ -126,6 +129,24 @@ describe('Borrow Flow', () => {
 
     await waitFor(() => {
       expect(mockBorrow).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should display liquidation alert', async () => {
+    mockCalculateLtvAndThresholdsChange.mockReturnValue({
+      collateralThresholdWeightedAverage: new Big(0.5),
+      liquidationThresholdWeightedAverage: new Big(0.75),
+      ltv: new Big(0.75)
+    });
+
+    await render(<App />, { path });
+
+    const tabPanel = withinModalTabPanel(TABLES.BORROW.POSITION, 'IBTC', tab, true);
+
+    userEvent.type(tabPanel.getByRole('textbox', { name: 'borrow amount' }), DEFAULT_IBTC.AMOUNT.MEDIUM);
+
+    await waitFor(() => {
+      expect(tabPanel.getByRole('alert')).toBeInTheDocument();
     });
   });
 });

--- a/src/test/pages/Loans/index.test.tsx
+++ b/src/test/pages/Loans/index.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 
 import { newMonetaryAmount } from '@interlay/interbtc-api';
+import Big from 'big.js';
 
 import App from '@/App';
 import { GOVERNANCE_TOKEN } from '@/config/relay-chains';
@@ -8,10 +9,12 @@ import {
   DEFAULT_ASSETS,
   DEFAULT_BORROW_POSITIONS,
   DEFAULT_LEND_POSITIONS,
+  DEFAULT_LENDING_STATS,
   DEFAULT_POSITIONS,
   mockClaimAllSubsidyRewards,
   mockGetAccountSubsidyRewards,
   mockGetBorrowPositionsOfAccount,
+  mockGetLendingStats,
   mockGetLendPositionsOfAccount,
   mockGetLoanAssets
 } from '@/test/mocks/@interlay/interbtc-api/parachain/loans';
@@ -27,11 +30,13 @@ describe('Loans page', () => {
     mockGetBorrowPositionsOfAccount.mockReturnValue(DEFAULT_BORROW_POSITIONS);
     mockGetLendPositionsOfAccount.mockReturnValue(DEFAULT_LEND_POSITIONS);
     mockGetLoanAssets.mockReturnValue(DEFAULT_ASSETS);
+    mockGetLendingStats.mockReturnValue(DEFAULT_LENDING_STATS);
   });
 
   afterAll(() => {
     mockGetBorrowPositionsOfAccount.mockReturnValue(DEFAULT_BORROW_POSITIONS);
     mockGetLendPositionsOfAccount.mockReturnValue(DEFAULT_LEND_POSITIONS);
+    mockGetLendingStats.mockReturnValue(DEFAULT_LENDING_STATS);
   });
 
   describe('Tables Section', () => {
@@ -98,6 +103,38 @@ describe('Loans page', () => {
       expect(screen.getByText(/borrow balance/i)).toBeInTheDocument();
       expect(screen.getByText(/collateral balance/i)).toBeInTheDocument();
       expect(screen.getByText(/loan status/i)).toBeInTheDocument();
+    });
+
+    it('should display low risk', async () => {
+      await render(<App />, { path });
+
+      expect(screen.getByText(/low risk/i)).toBeInTheDocument();
+    });
+
+    it('should display medium risk', async () => {
+      mockGetLendingStats.mockReturnValue({
+        ...DEFAULT_LENDING_STATS,
+        collateralThresholdWeightedAverage: new Big(0.5),
+        liquidationThresholdWeightedAverage: new Big(0.75),
+        ltv: new Big(0.5)
+      });
+
+      await render(<App />, { path });
+
+      expect(screen.getByText(/medium risk/i)).toBeInTheDocument();
+    });
+
+    it('should display liquidation risk', async () => {
+      mockGetLendingStats.mockReturnValue({
+        ...DEFAULT_LENDING_STATS,
+        collateralThresholdWeightedAverage: new Big(0.5),
+        liquidationThresholdWeightedAverage: new Big(0.75),
+        ltv: new Big(0.75)
+      });
+
+      await render(<App />, { path });
+
+      expect(screen.getByText(/liquidation risk/i)).toBeInTheDocument();
     });
   });
 

--- a/src/test/pages/Loans/repay.test.tsx
+++ b/src/test/pages/Loans/repay.test.tsx
@@ -101,6 +101,7 @@ describe('Repay Flow', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
       expect(mockRepay).not.toHaveBeenCalled();
+      expect(mockRepayAll).not.toHaveBeenCalled();
     });
 
     mockTokensBalance.restore();

--- a/src/test/pages/Loans/withdraw.test.tsx
+++ b/src/test/pages/Loans/withdraw.test.tsx
@@ -93,6 +93,25 @@ describe('Withdraw Flow', () => {
     expect(mockWithdrawAll).toHaveBeenCalledWith(WRAPPED_TOKEN);
   });
 
+  it('should partially withdraw while applying max withdraw when there is low borrow limit', async () => {
+    mockGetLendingStats.mockReturnValue({ ...DEFAULT_LENDING_STATS, borrowLimitBtc: DEFAULT_IBTC.MONETARY.VERY_SMALL });
+
+    await render(<App />, { path });
+
+    const tabPanel = withinModalTabPanel(TABLES.LEND.POSITION, 'IBTC', tab, true);
+
+    userEvent.click(
+      tabPanel.getByRole('button', {
+        name: /max/i
+      })
+    );
+
+    await submitForm(tabPanel, 'withdraw');
+
+    expect(mockWithdraw).toHaveBeenCalled();
+    expect(mockWithdrawAll).not.toHaveBeenCalled();
+  });
+
   it('should not be able to withdraw due low borrow limit', async () => {
     mockGetLendingStats.mockReturnValue({ ...DEFAULT_LENDING_STATS, borrowLimitBtc: DEFAULT_IBTC.MONETARY.VERY_SMALL });
 

--- a/src/test/pages/Loans/withdraw.test.tsx
+++ b/src/test/pages/Loans/withdraw.test.tsx
@@ -108,6 +108,7 @@ describe('Withdraw Flow', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
       expect(mockWithdraw).not.toHaveBeenCalled();
+      expect(mockWithdrawAll).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

- There was a lot of code that needed refactoring.
- The problem was in the `isEqualBalance`, because I was using this to determine wether the user was repaying the full loan.  I was passing the wrong parameters. 
-  removed unwanted liquidation alert on repay form and only showed it when user had some input interaction


the problem: https://github.com/interlay/interbtc-ui/pull/1050/files#diff-1d81792feeb73f0344f796b7a435c46cf3761479ecaa8e640e1efff5dedeb35cL120

I should have not passed `assetBalance` but instead the `balance` field assigned above.
