### PR TITLE
Show full BTC address on issue modal

### DIFF
--- a/src/legacy-components/AddressWithCopyUI/index.tsx
+++ b/src/legacy-components/AddressWithCopyUI/index.tsx
@@ -5,13 +5,14 @@ import CopyToClipboardButton from '@/legacy-components/CopyToClipboardButton';
 
 interface Props extends React.ComponentPropsWithRef<'div'> {
   address: string;
+  shortenAddress?: boolean;
   className?: string;
 }
 
-const AddressWithCopyUI = ({ address, className, ...rest }: Props): JSX.Element => {
+const AddressWithCopyUI = ({ address, shortenAddress = true, className, ...rest }: Props): JSX.Element => {
   return (
     <div className={clsx('flex', 'items-center', 'space-x-1', 'font-medium', className)} {...rest}>
-      <span>{shortAddress(address)}</span>
+      <span>{shortenAddress ? shortAddress(address) : address}</span>
       <CopyToClipboardButton text={address} />
     </div>
   );

--- a/src/legacy-components/IssueUI/BTCPaymentPendingStatusUI/index.tsx
+++ b/src/legacy-components/IssueUI/BTCPaymentPendingStatusUI/index.tsx
@@ -94,7 +94,11 @@ const BTCPaymentPendingStatusUI = ({ request }: Props): JSX.Element => {
         >
           {t('issue_page.single_transaction')}
         </p>
-        <AddressWithCopyUI className={clsx('justify-center', 'p-2.5')} address={bitcoinRecipientAddress} />
+        <AddressWithCopyUI
+          shortenAddress={false}
+          className={clsx('justify-center', 'p-2.5')}
+          address={bitcoinRecipientAddress}
+        />
         {initialLeftSeconds && (
           <p className={clsx('flex', 'justify-center', 'items-center', 'space-x-1')}>
             <span


### PR DESCRIPTION
Quick fix to show full BTC address for issue modal. The component which handles this is widely used, so to avoid making lots of changes I've added a `shortenAddress` prop which defaults to true (and will maintain existing behaviour). 