### PR TITLE
chore: fix test workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,11 @@
 # Workflow name
 name: 'Chromatic Deployment'
 
-# Event for the workflow
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
+  # manual trigger
+  workflow_dispatch:
 
 # List of jobs
 jobs:

--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -1,12 +1,17 @@
 name: yarn test
 
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
+  # manual trigger
+  workflow_dispatch:
 
 env:
   REACT_APP_RELAY_CHAIN_NAME: polkadot
   REACT_APP_PARACHAIN_ID: 2032
   DOCKER_RELAY_CHAIN_CURRENCY: DOT
   REACT_APP_FEATURE_FLAG_LENDING: enabled
+  REACT_APP_FEATURE_FLAG_AMM: enabled
 
 jobs:
   # MEMO: how to run a GitHub action locally


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

`on: [push, pull_request_target]`

This was making the pipeline run the test in the PR branch (`push`) and also in the `master` branch (`pull_request_target`)

The new config:
```
on:
  push:
  pull_request:
  # manual trigger
  workflow_dispatch:
```

Makes the tests run only once against the desired branch. Also added `workflow_dispatch` because it will allow us to manually trigger running tests against a certain branch (https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
