### PR TITLE
feat(Pools): add custom input amounts mode

### DIFF
--- a/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
+++ b/src/pages/AMM/Pools/components/DepositForm/DepositForm.tsx
@@ -30,6 +30,9 @@ import { DepositDivider } from './DepositDivider';
 import { StyledDl } from './DepositForm.styles';
 import { DepositOutputAssets } from './DepositOutputAssets';
 
+const isCustomAmountsMode = (form: ReturnType<typeof useForm>) =>
+  form.dirty && Object.values(form.touched).filter(Boolean).length > 0;
+
 type DepositData = {
   amounts: PooledCurrencies;
   pool: LiquidityPool;
@@ -105,6 +108,8 @@ const DepositForm = ({ pool, slippageModalRef, onDeposit }: DepositFormProps): J
   });
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (isCustomAmountsMode(form)) return;
+
     if (!e.target.value || isNaN(Number(e.target.value))) {
       return form.setValues(defaultValues);
     }

--- a/src/test/pages/Pools.test.tsx
+++ b/src/test/pages/Pools.test.tsx
@@ -181,4 +181,50 @@ describe('Pools Page', () => {
 
     mockGetClaimableFarmingRewards.mockReturnValue(DEFAULT_CLAIMABLE_REWARDS);
   });
+
+  it('should be able to enter customisable input amounts mode', async () => {
+    jest
+      .spyOn(DEFAULT_LIQUIDITY_POOL_1, 'getLiquidityDepositInputAmounts')
+      .mockReturnValue(DEFAULT_POOLED_CURRENCIES_1);
+
+    const [DEFAULT_CURRENCY_1, DEFAULT_CURRENCY_2] = DEFAULT_POOLED_CURRENCIES_1;
+
+    await render(<App />, { path });
+
+    const tabPanel = withinModalTabPanel(TABLES.AVAILABLE_POOLS, DEFAULT_LP_TOKEN_1.ticker, TABS.DEPOSIT);
+
+    await userEvent.type(
+      tabPanel.getByRole('textbox', {
+        name: new RegExp(`${DEFAULT_CURRENCY_1.currency.ticker} deposit amount`, 'i')
+      }),
+      DEFAULT_CURRENCY_1.toString(),
+      { delay: 1 }
+    );
+
+    expect(DEFAULT_LIQUIDITY_POOL_1.getLiquidityDepositInputAmounts).toHaveBeenCalledWith(DEFAULT_CURRENCY_1);
+
+    await waitFor(() => {
+      expect(
+        tabPanel.getByRole('textbox', {
+          name: new RegExp(`${DEFAULT_CURRENCY_2.currency.ticker} deposit amount`, 'i')
+        })
+      ).toHaveValue(DEFAULT_CURRENCY_2.toString());
+    });
+
+    await userEvent.type(
+      tabPanel.getByRole('textbox', {
+        name: new RegExp(`${DEFAULT_CURRENCY_2.currency.ticker} deposit amount`, 'i')
+      }),
+      '10',
+      { delay: 1 }
+    );
+
+    await waitFor(() => {
+      expect(
+        tabPanel.getByRole('textbox', {
+          name: new RegExp(`${DEFAULT_CURRENCY_1.currency.ticker} deposit amount`, 'i')
+        })
+      ).toHaveValue(DEFAULT_CURRENCY_1.toString());
+    });
+  });
 });


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Adds custom input amounts mode for Pools

## Current behaviour (updates)

Each input is set with pool ratio

## New behaviour

When the user touches a second input, he enter custom input amounts mode

## Reproducible testing steps:

1. Go to pools page
2. Open a pool
3. Input amount on first input
4. See that second gets affected
5. Input Amount on second input
6. See that first input **is not** affected
