### PR TITLE
Fix: show transferable balance for selected currency

### DIFF
--- a/src/legacy-components/Tokens/TokenSelector/index.tsx
+++ b/src/legacy-components/Tokens/TokenSelector/index.tsx
@@ -45,7 +45,7 @@ const TokenSelector = ({ variant, tokenOptions, currentToken, onChange, showBala
                     <SelectText>
                       {showBalances && (
                         <span>
-                          {formatNumber(Number(currentToken.balance), {
+                          {formatNumber(Number(currentToken.transferableBalance), {
                             minimumFractionDigits: 0,
                             maximumFractionDigits: 8
                           })}


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

In the top right token selector, the selected token shows the total balance, not the transferable balance. The correct value is shown in the drop down.

Previous behaviour:
<img width="248" alt="Screenshot 2023-03-27 at 08 51 05" src="https://user-images.githubusercontent.com/40243778/227876140-ccb484a6-6ee5-4d05-96f3-501286763991.png">

Fixed behaviour:
<img width="230" alt="Screenshot 2023-03-27 at 08 52 28" src="https://user-images.githubusercontent.com/40243778/227876399-e651c3fe-062c-4514-819b-146082dbdb37.png">

## Reproducible testing steps:

Check that the values match.