### PR TITLE
refactor: use current block when calculating lock time extension

### DIFF
--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -319,10 +319,11 @@ const Staking = (): JSX.Element => {
 
   React.useEffect(() => {
     if (!lockTime) return;
+    if (!currentBlockNumber) return;
 
     const lockTimeValue = Number(lockTime);
-    setBlockLockTimeExtension(convertWeeksToBlockNumbers(lockTimeValue));
-  }, [lockTime]);
+    setBlockLockTimeExtension(currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue));
+  }, [currentBlockNumber, lockTime]);
 
   React.useEffect(() => {
     reset({


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Lock time extension was being calculated incorrectly, and generating an incorrect APY value 

## Reproducible testing steps:

Check staking UI values