### PR TITLE
fix: correct apy calculation

### DIFF
--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -323,9 +323,10 @@ const Staking = (): JSX.Element => {
     if (!stakedAmountAndEndBlock) return;
 
     const lockTimeValue = Number(lockTime);
-    setBlockLockTimeExtension(
-      stakedAmountAndEndBlock.endBlock + currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue)
-    );
+    const extensionTime =
+      stakedAmountAndEndBlock.endBlock + currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue);
+
+    setBlockLockTimeExtension(extensionTime);
   }, [currentBlockNumber, lockTime, stakedAmountAndEndBlock]);
 
   React.useEffect(() => {

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -320,10 +320,13 @@ const Staking = (): JSX.Element => {
   React.useEffect(() => {
     if (!lockTime) return;
     if (!currentBlockNumber) return;
+    if (!stakedAmountAndEndBlock) return;
 
     const lockTimeValue = Number(lockTime);
-    setBlockLockTimeExtension(currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue));
-  }, [currentBlockNumber, lockTime]);
+    setBlockLockTimeExtension(
+      stakedAmountAndEndBlock.endBlock + currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue)
+    );
+  }, [currentBlockNumber, lockTime, stakedAmountAndEndBlock]);
 
   React.useEffect(() => {
     reset({


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Fix APY calculation when extending lock time

## Current behaviour (updates)

APY is calculated using `currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue)`

## New behaviour

APY should be calculates using `stakedAmountAndEndBlock.endBlock + currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue)`

## Reproducible testing steps:

Check that APY calculation is correct