### PR TITLE
Fix/negative apy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interbtc-ui",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interbtc-ui",
-  "version": "2.30.1",
+  "version": "2.30.0",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",

--- a/src/components/LoanApyTooltip/BreakdownGroup.tsx
+++ b/src/components/LoanApyTooltip/BreakdownGroup.tsx
@@ -14,7 +14,7 @@ type BreakdownGroupProps = {
 };
 
 const BreakdownGroup = ({ apy, rewardsApy, ticker, rewardsTicker, isBorrow }: BreakdownGroupProps): JSX.Element => {
-  const apyLabel = getApyLabel(apy);
+  const apyLabel = isBorrow ? `-${getApyLabel(apy)}` : getApyLabel(apy);
 
   return (
     <DlGroup direction='column' alignItems='flex-start' gap='spacing1'>

--- a/src/components/LoanPositionsTable/ApyCell.tsx
+++ b/src/components/LoanPositionsTable/ApyCell.tsx
@@ -33,7 +33,7 @@ const ApyCell = ({
   const rewardsApy = getSubsidyRewardApy(currency, rewards, prices);
 
   const totalApy = isBorrow ? apy.sub(rewardsApy || 0) : apy.add(rewardsApy || 0);
-  const totalApyLabel = getApyLabel(totalApy);
+  const totalApyLabel = isBorrow ? `-${getApyLabel(totalApy)}` : getApyLabel(totalApy);
 
   const earnedAsset = accumulatedDebt || earnedInterest;
 


### PR DESCRIPTION
## Description

Add a "-" symbol for the borrow APY [OG issue](https://github.com/interlay/interbtc-ui/issues/1122)

## New behaviour
Adding a "-" makes it more clear to the user that borrow APY accumulates cost and will need to be paid back.


## Reproducible steps:

Go to Lending tab -> focus on borrow APY table -> there should be a negative in front of all the borrow APY values