### PR TITLE
[staking] Handle RPC error

### DIFF
--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -219,6 +219,9 @@ const Staking = (): JSX.Element => {
   );
   useErrorHandler(estimatedRewardAmountAndAPYError);
 
+  // MEMO: This is being set outside of a useEffect because of
+  // an race condition. This is a underlying issue with the
+  // component and can't be easily fixed.
   if (isValid || !isDirty) {
     estimatedRewardAmountAndAPYRefetch();
   }

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -124,7 +124,7 @@ const Staking = (): JSX.Element => {
     handleSubmit,
     watch,
     reset,
-    formState: { errors },
+    formState: { errors, isDirty, isValid },
     trigger,
     setValue
   } = useForm<StakingFormData>({
@@ -200,7 +200,8 @@ const Staking = (): JSX.Element => {
     isIdle: estimatedRewardAmountAndAPYIdle,
     isLoading: estimatedRewardAmountAndAPYLoading,
     data: estimatedRewardAmountAndAPY,
-    error: estimatedRewardAmountAndAPYError
+    error: estimatedRewardAmountAndAPYError,
+    refetch: estimatedRewardAmountAndAPYRefetch
   } = useQuery<EstimatedRewardAmountAndAPY, Error>(
     [
       GENERIC_FETCHER,
@@ -212,10 +213,15 @@ const Staking = (): JSX.Element => {
     ],
     genericFetcher<EstimatedRewardAmountAndAPY>(),
     {
-      enabled: !!bridgeLoaded
+      enabled: false,
+      retry: false
     }
   );
   useErrorHandler(estimatedRewardAmountAndAPYError);
+
+  if (isValid || !isDirty) {
+    estimatedRewardAmountAndAPYRefetch();
+  }
 
   const {
     isIdle: stakedAmountAndEndBlockIdle,
@@ -851,7 +857,7 @@ const Staking = (): JSX.Element => {
               fullWidth
               size='large'
               type='submit'
-              disabled={initializing || unlockFirst}
+              disabled={initializing || unlockFirst || !isValid}
               loading={initialStakeMutation.isLoading || moreStakeMutation.isLoading}
             >
               {submitButtonLabel}{' '}


### PR DESCRIPTION
This PR prevents the estimated staking rewards from being fetched when the form is in error. It's not an ideal fix—the refetch function is being called from the component body. Unfortunately there is a race condition when using `useEffect` which mean that the RPC call was being made before it could be disabled. This is an underlying issue with the component design, and not easily resolvable.