### PR TITLE
[tokenInput] support single-item array

### DIFF
--- a/src/component-library/TokenInput/TokenInput.stories.tsx
+++ b/src/component-library/TokenInput/TokenInput.stories.tsx
@@ -84,7 +84,6 @@ SingleItemInSelectItems.args = {
   label: 'Amount',
   isDisabled: false,
   selectProps: {
-    value: 'LP KSM-KBTC-KINT',
     items: [{ balance: 200, value: 'KSM', balanceUSD: '$200' }]
   }
   // errorMessage: 'Failed'

--- a/src/component-library/TokenInput/TokenInput.stories.tsx
+++ b/src/component-library/TokenInput/TokenInput.stories.tsx
@@ -76,7 +76,21 @@ MultiToken.args = {
   // errorMessage: 'Failed'
 };
 
-export { MultiToken, WithBalance, WithCurrencySelect, WithoutBalance };
+const SingleItemInSelectItems = Template.bind({});
+SingleItemInSelectItems.args = {
+  balance: 1000.0,
+  balanceLabel: 'Balance',
+  placeholder: '0.00',
+  label: 'Amount',
+  isDisabled: false,
+  selectProps: {
+    value: 'LP KSM-KBTC-KINT',
+    items: [{ balance: 200, value: 'KSM', balanceUSD: '$200' }]
+  }
+  // errorMessage: 'Failed'
+};
+
+export { MultiToken, SingleItemInSelectItems, WithBalance, WithCurrencySelect, WithoutBalance };
 
 export default {
   title: 'Forms/TokenInput',

--- a/src/component-library/TokenInput/TokenInput.stories.tsx
+++ b/src/component-library/TokenInput/TokenInput.stories.tsx
@@ -86,7 +86,6 @@ SingleItemInSelectItems.args = {
   selectProps: {
     items: [{ balance: 200, value: 'KSM', balanceUSD: '$200' }]
   }
-  // errorMessage: 'Failed'
 };
 
 export { MultiToken, SingleItemInSelectItems, WithBalance, WithCurrencySelect, WithoutBalance };

--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -59,6 +59,9 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
 
     const selectHelperTextId = useId();
 
+    const firstItemInSelectProps =
+      selectProps?.items && Object.keys(selectProps.items).length === 1 ? Object.values(selectProps.items)[0] : null;
+
     useEffect(() => {
       if (selectProps?.value === undefined) return;
 
@@ -82,7 +85,11 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
       !errorMessage && !description && (selectProps?.errorMessage || selectProps?.description);
     const { onSelectionChange, ...restSelectProps } = selectProps || {};
 
-    const endAdornment = selectProps ? (
+    const endAdornment = ticker ? (
+      <TokenAdornment ticker={ticker} />
+    ) : firstItemInSelectProps ? (
+      <TokenAdornment ticker={firstItemInSelectProps.value} />
+    ) : selectProps ? (
       <TokenSelect
         {...restSelectProps}
         value={selectValue}
@@ -93,8 +100,6 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
         validationState={hasSelectHelperText ? 'invalid' : undefined}
         errorMessage={undefined}
       />
-    ) : ticker ? (
-      <TokenAdornment ticker={ticker} />
     ) : null;
 
     const hasLabel = !!label || balance !== undefined;

--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -59,8 +59,9 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
 
     const selectHelperTextId = useId();
 
-    const firstItemInSelectProps =
-      selectProps?.items && Object.keys(selectProps.items).length === 1 ? Object.values(selectProps.items)[0] : null;
+    const itemsArr = Array.from(selectProps?.items || []);
+    const isSelectAdornment = itemsArr.length > 1;
+    const adornmentTicker = !isSelectAdornment && selectProps?.items ? itemsArr[0].value : ticker;
 
     useEffect(() => {
       if (selectProps?.value === undefined) return;
@@ -85,11 +86,7 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
       !errorMessage && !description && (selectProps?.errorMessage || selectProps?.description);
     const { onSelectionChange, ...restSelectProps } = selectProps || {};
 
-    const endAdornment = ticker ? (
-      <TokenAdornment ticker={ticker} />
-    ) : firstItemInSelectProps ? (
-      <TokenAdornment ticker={firstItemInSelectProps.value} />
-    ) : selectProps ? (
+    const endAdornment = isSelectAdornment ? (
       <TokenSelect
         {...restSelectProps}
         value={selectValue}
@@ -100,6 +97,8 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
         validationState={hasSelectHelperText ? 'invalid' : undefined}
         errorMessage={undefined}
       />
+    ) : adornmentTicker ? (
+      <TokenAdornment ticker={adornmentTicker} />
     ) : null;
 
     const hasLabel = !!label || balance !== undefined;

--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -61,7 +61,7 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
 
     const itemsArr = Array.from(selectProps?.items || []);
     const isSelectAdornment = itemsArr.length > 1;
-    const adornmentTicker = !isSelectAdornment && selectProps?.items ? itemsArr[0].value : ticker;
+    const adornmentTicker = !isSelectAdornment && selectProps?.items ? itemsArr[0]?.value : ticker;
 
     useEffect(() => {
       if (selectProps?.value === undefined) return;


### PR DESCRIPTION
# Interbtc UI Pull Request Template

When we have a dynamic token list (as with XCM transfers) we don't want to use logic in the pages to pass through either a ticker of a list of tokens via select props. Instead, we want the token input to handle a single item array exactly as it would a ticker.

Note: we still require the ticker prop. For most of our use cases, the token list is immutable. However, the list of tokens being passed in through the XFM transfer page will change when the to and from destinations are updated.

## Description

Disable select if only a single token is passed in via `selectProps`

## Current behaviour (updates)

Select is enabled

## New behaviour

Select is disabled, with token adornment being shows instead.

## Reproducible testing steps:

Can be seen in storybook—not currently used in production