### PR TITLE
fix: use currentBlockNumber when there is no existing stake

### DIFF
--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -322,11 +322,11 @@ const Staking = (): JSX.Element => {
   React.useEffect(() => {
     if (!lockTime) return;
     if (!currentBlockNumber) return;
-    if (!stakedAmountAndEndBlock) return;
 
     const lockTimeValue = Number(lockTime);
+
     const extensionTime =
-      stakedAmountAndEndBlock.endBlock || currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue);
+      (stakedAmountAndEndBlock?.endBlock || currentBlockNumber) + convertWeeksToBlockNumbers(lockTimeValue);
 
     setBlockLockTimeExtension(extensionTime);
   }, [currentBlockNumber, lockTime, stakedAmountAndEndBlock]);

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -324,7 +324,6 @@ const Staking = (): JSX.Element => {
     if (!currentBlockNumber) return;
 
     const lockTimeValue = Number(lockTime);
-
     const extensionTime =
       (stakedAmountAndEndBlock?.endBlock || currentBlockNumber) + convertWeeksToBlockNumbers(lockTimeValue);
 

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -325,7 +325,8 @@ const Staking = (): JSX.Element => {
     if (!stakedAmountAndEndBlock) return;
 
     const lockTimeValue = Number(lockTime);
-    const extensionTime = stakedAmountAndEndBlock.endBlock + convertWeeksToBlockNumbers(lockTimeValue);
+    const extensionTime =
+      stakedAmountAndEndBlock.endBlock || currentBlockNumber + convertWeeksToBlockNumbers(lockTimeValue);
 
     setBlockLockTimeExtension(extensionTime);
   }, [currentBlockNumber, lockTime, stakedAmountAndEndBlock]);


### PR DESCRIPTION
Calculate apy and rewards when staking with no existing stake