### PR TITLE
Tom/fix/staking rewards edge case

### DIFF
--- a/src/config/relay-chains.tsx
+++ b/src/config/relay-chains.tsx
@@ -149,7 +149,7 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     CROWDLOAN_LINK = INTERLAY_CROWDLOAN_LINK;
     OPEN_GRAPH_IMAGE_FILE_NAME = 'interlay-meta-image.jpg';
     STAKE_LOCK_TIME = {
-      MIN: 0,
+      MIN: 1,
       MAX: 192
     };
     // TODO: temporary
@@ -191,7 +191,7 @@ switch (process.env.REACT_APP_RELAY_CHAIN_NAME) {
     CROWDLOAN_LINK = KINTSUGI_CROWDLOAN_LINK;
     OPEN_GRAPH_IMAGE_FILE_NAME = 'kintsugi-meta-image.jpg';
     STAKE_LOCK_TIME = {
-      MIN: 0,
+      MIN: 1,
       MAX: 96
     };
     // TODO: temporary

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -199,8 +199,8 @@ const Staking = (): JSX.Element => {
   const {
     isLoading: estimatedRewardAmountAndAPYLoading,
     data: estimatedRewardAmountAndAPY,
-    error: estimatedRewardAmountAndAPYError
-    // refetch: estimatedRewardAmountAndAPYRefetch
+    error: estimatedRewardAmountAndAPYError,
+    refetch: estimatedRewardAmountAndAPYRefetch
   } = useQuery<EstimatedRewardAmountAndAPY, Error>(
     [
       GENERIC_FETCHER,
@@ -310,6 +310,13 @@ const Staking = (): JSX.Element => {
       }
     }
   );
+
+  React.useEffect(() => {
+    if (!isValid) return;
+    if (!estimatedRewardAmountAndAPYRefetch) return;
+
+    estimatedRewardAmountAndAPYRefetch();
+  }, [isValid, estimatedRewardAmountAndAPYRefetch]);
 
   React.useEffect(() => {
     if (!lockTime) return;

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -582,7 +582,7 @@ const Staking = (): JSX.Element => {
 
   const renderNewVoteGovernanceTokenGainedLabel = () => {
     const newTotalStakeAmount = getNewTotalStake();
-    if (voteGovernanceTokenBalance === undefined || newTotalStakeAmount === undefined) {
+    if (voteGovernanceTokenBalance === undefined || newTotalStakeAmount === undefined || !isValid) {
       return '-';
     }
 

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -316,7 +316,7 @@ const Staking = (): JSX.Element => {
     if (!estimatedRewardAmountAndAPYRefetch) return;
 
     estimatedRewardAmountAndAPYRefetch();
-  }, [isValid, estimatedRewardAmountAndAPYRefetch]);
+  }, [isValid, monetaryLockingAmount, blockLockTimeExtension, estimatedRewardAmountAndAPYRefetch]);
 
   React.useEffect(() => {
     if (!lockTime) return;

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -124,7 +124,7 @@ const Staking = (): JSX.Element => {
     handleSubmit,
     watch,
     reset,
-    formState: { errors, isDirty, isValid },
+    formState: { errors, isValid },
     trigger,
     setValue
   } = useForm<StakingFormData>({
@@ -197,11 +197,10 @@ const Staking = (): JSX.Element => {
   // Estimated governance token Rewards & APY
   const monetaryLockingAmount = newMonetaryAmount(lockingAmount, GOVERNANCE_TOKEN, true);
   const {
-    isIdle: estimatedRewardAmountAndAPYIdle,
     isLoading: estimatedRewardAmountAndAPYLoading,
     data: estimatedRewardAmountAndAPY,
-    error: estimatedRewardAmountAndAPYError,
-    refetch: estimatedRewardAmountAndAPYRefetch
+    error: estimatedRewardAmountAndAPYError
+    // refetch: estimatedRewardAmountAndAPYRefetch
   } = useQuery<EstimatedRewardAmountAndAPY, Error>(
     [
       GENERIC_FETCHER,
@@ -218,13 +217,6 @@ const Staking = (): JSX.Element => {
     }
   );
   useErrorHandler(estimatedRewardAmountAndAPYError);
-
-  // MEMO: This is being set outside of a useEffect because of
-  // an race condition. This is a underlying issue with the
-  // component and can't be easily fixed.
-  if (isValid || !isDirty) {
-    estimatedRewardAmountAndAPYRefetch();
-  }
 
   const {
     isIdle: stakedAmountAndEndBlockIdle,
@@ -633,15 +625,15 @@ const Staking = (): JSX.Element => {
 
   const renderEstimatedAPYLabel = () => {
     if (
-      estimatedRewardAmountAndAPYIdle ||
       estimatedRewardAmountAndAPYLoading ||
+      !projectedRewardAmountAndAPY ||
       errors[LOCK_TIME] ||
       errors[LOCKING_AMOUNT]
     ) {
       return '-';
     }
     if (estimatedRewardAmountAndAPY === undefined) {
-      throw new Error('Something went wrong!');
+      return formatPercentage(projectedRewardAmountAndAPY.apy.toNumber());
     }
 
     return formatPercentage(estimatedRewardAmountAndAPY.apy.toNumber());
@@ -649,15 +641,15 @@ const Staking = (): JSX.Element => {
 
   const renderEstimatedRewardAmountLabel = () => {
     if (
-      estimatedRewardAmountAndAPYIdle ||
       estimatedRewardAmountAndAPYLoading ||
+      !projectedRewardAmountAndAPY ||
       errors[LOCK_TIME] ||
       errors[LOCKING_AMOUNT]
     ) {
       return '-';
     }
     if (estimatedRewardAmountAndAPY === undefined) {
-      throw new Error('Something went wrong!');
+      return `${displayMonetaryAmount(projectedRewardAmountAndAPY.amount)} ${GOVERNANCE_TOKEN_SYMBOL}`;
     }
 
     return `${displayMonetaryAmount(estimatedRewardAmountAndAPY.amount)} ${GOVERNANCE_TOKEN_SYMBOL}`;
@@ -714,7 +706,6 @@ const Staking = (): JSX.Element => {
     claimableRewardAmountLoading ||
     projectedRewardAmountAndAPYIdle ||
     projectedRewardAmountAndAPYLoading ||
-    estimatedRewardAmountAndAPYIdle ||
     estimatedRewardAmountAndAPYLoading ||
     stakedAmountAndEndBlockIdle ||
     stakedAmountAndEndBlockLoading;

--- a/src/pages/Staking/index.tsx
+++ b/src/pages/Staking/index.tsx
@@ -594,7 +594,7 @@ const Staking = (): JSX.Element => {
   };
 
   const getNewTotalStake = () => {
-    if (remainingBlockNumbersToUnstake === undefined || stakedAmount === undefined) {
+    if (remainingBlockNumbersToUnstake === undefined || stakedAmount === undefined || !isValid) {
       return undefined;
     }
 


### PR DESCRIPTION
Better way of handling reward estimate—if we use the initial value (projectedRewards) on the first render, then the second request (estimatedRewards) behaves as expected.