### PR TITLE
fix: reset sign terms mutation on account change

### DIFF
--- a/src/utils/hooks/use-sign-message.ts
+++ b/src/utils/hooks/use-sign-message.ts
@@ -1,5 +1,5 @@
 import { PressEvent } from '@react-types/shared';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient, UseQueryResult } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
@@ -117,6 +117,14 @@ const useSignMessage = (): UseSignMessageResult => {
       toast.success('Your signature was submitted successfully.');
     }
   });
+
+  // Reset mutation on account change
+  useEffect(() => {
+    if (signMessageMutation.isLoading && selectedAccount?.address) {
+      signMessageMutation.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAccount?.address]);
 
   const handleSignMessage = (account?: KeyringPair) => {
     // should not sign message if there is already a stored signature


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Reset sign terms mutation on account change

## Current behaviour (updates)

Account A mutation would show up on Account B

## New behaviour

Mutation is reset on wallet change

## Reproducible testing steps:

- with 2 accounts without signatures, start a signature on one but dont confirm on the wallet. Switch to the other account and you should be able to see the accept & sign button enabled.
