### PR TITLE
fix(loans): display correct incentive rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^2.0.0",
     "@interlay/bridge": "^0.2.4",
-    "@interlay/interbtc-api": "2.1.1",
+    "@interlay/interbtc-api": "2.2.1",
     "@interlay/monetary-js": "0.7.2",
     "@polkadot/api": "9.14.2",
     "@polkadot/extension-dapp": "0.44.1",

--- a/src/components/LoanPositionsTable/LoanPositionsTable.tsx
+++ b/src/components/LoanPositionsTable/LoanPositionsTable.tsx
@@ -7,6 +7,7 @@ import { convertMonetaryAmountToValueInUSD } from '@/common/utils/utils';
 import { Switch } from '@/component-library';
 import { LoanType } from '@/types/loans';
 import { getTokenPrice } from '@/utils/helpers/prices';
+import { useGetAccountSubsidyRewards } from '@/utils/hooks/api/loans/use-get-account-subsidy-rewards';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
 
 import { AssetCell, BalanceCell, Table, TableProps } from '../DataGrid';
@@ -52,6 +53,7 @@ const LoanPositionsTable = ({
   const titleId = useId();
   const { t } = useTranslation();
   const prices = useGetPrices();
+  const { data: subsidyRewards } = useGetAccountSubsidyRewards();
 
   const isLending = variant === 'lend';
   const showCollateral = !!onPressCollateralSwitch && isLending;
@@ -84,13 +86,13 @@ const LoanPositionsTable = ({
         const { currency } = amountProp;
         const asset = <AssetCell ticker={currency.ticker} />;
 
-        const { borrowApy, borrowReward, lendApy, lendReward } = assets[currency.ticker];
+        const { borrowApy, lendApy } = assets[currency.ticker];
 
         const apyCellProps = isLending
-          ? { apy: lendApy, rewards: lendReward }
+          ? { apy: lendApy, rewards: subsidyRewards ? subsidyRewards.perMarket[currency.ticker].lend : null }
           : {
               apy: borrowApy,
-              rewards: borrowReward,
+              rewards: subsidyRewards ? subsidyRewards.perMarket[currency.ticker].borrow : null,
               accumulatedDebt: (position as BorrowPosition).accumulatedDebt,
               isBorrow: true
             };
@@ -133,7 +135,7 @@ const LoanPositionsTable = ({
           collateral
         };
       }),
-    [assets, isLending, onPressCollateralSwitch, onRowAction, positions, prices, showCollateral]
+    [assets, isLending, onPressCollateralSwitch, onRowAction, positions, prices, showCollateral, subsidyRewards]
   );
 
   return (

--- a/src/pages/Loans/LoansOverview/components/BorrowAssetsTable/BorrowAssetsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowAssetsTable/BorrowAssetsTable.tsx
@@ -8,6 +8,7 @@ import { Cell, Table, TableProps } from '@/components';
 import { ApyCell } from '@/components/LoanPositionsTable/ApyCell';
 import { LoanTablePlaceholder } from '@/components/LoanPositionsTable/LoanTablePlaceholder';
 import { getTokenPrice } from '@/utils/helpers/prices';
+import { useGetAccountSubsidyRewards } from '@/utils/hooks/api/loans/use-get-account-subsidy-rewards';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
 
 import { StyledAssetCell } from './BorrowAssetsTable.style';
@@ -47,17 +48,19 @@ const BorrowAssetsTable = ({ assets, onRowAction, ...props }: BorrowAssetsTableP
   const titleId = useId();
   const { t } = useTranslation();
   const prices = useGetPrices();
+  const { data: subsidyRewards } = useGetAccountSubsidyRewards();
 
   const rows: BorrowAssetsTableRow[] = useMemo(
     () =>
-      Object.values(assets).map(({ borrowApy, currency, availableCapacity, borrowReward, totalBorrows }) => {
+      Object.values(assets).map(({ borrowApy, currency, availableCapacity, totalBorrows }) => {
         const asset = <StyledAssetCell ticker={currency.ticker} />;
+        const reward = subsidyRewards ? subsidyRewards.perMarket[currency.ticker].borrow : null;
 
         const apy = (
           <ApyCell
             apy={borrowApy}
             currency={currency}
-            rewards={borrowReward}
+            rewards={reward}
             prices={prices}
             isBorrow
             // TODO: temporary until we find why row click is being ignored
@@ -85,7 +88,7 @@ const BorrowAssetsTable = ({ assets, onRowAction, ...props }: BorrowAssetsTableP
           totalBorrowed
         };
       }),
-    [assets, prices, onRowAction]
+    [assets, prices, onRowAction, subsidyRewards]
   );
 
   return (

--- a/src/pages/Loans/LoansOverview/components/LendAssetsTable/LendAssetsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/LendAssetsTable/LendAssetsTable.tsx
@@ -8,6 +8,7 @@ import { AssetCell, BalanceCell, Cell, Table, TableProps } from '@/components';
 import { ApyCell } from '@/components/LoanPositionsTable/ApyCell';
 import { LoanTablePlaceholder } from '@/components/LoanPositionsTable/LoanTablePlaceholder';
 import { getTokenPrice } from '@/utils/helpers/prices';
+import { useGetAccountSubsidyRewards } from '@/utils/hooks/api/loans/use-get-account-subsidy-rewards';
 import { useGetBalances } from '@/utils/hooks/api/tokens/use-get-balances';
 import { useGetPrices } from '@/utils/hooks/api/use-get-prices';
 
@@ -47,17 +48,19 @@ const LendAssetsTable = ({ assets, onRowAction, ...props }: LendAssetsTableProps
   const { t } = useTranslation();
   const prices = useGetPrices();
   const { data: balances } = useGetBalances();
+  const { data: subsidyRewards } = useGetAccountSubsidyRewards();
 
   const rows: LendAssetsTableRow[] = useMemo(
     () =>
-      Object.values(assets).map(({ lendApy, lendReward, currency, totalLiquidity }) => {
+      Object.values(assets).map(({ lendApy, currency, totalLiquidity }) => {
         const asset = <AssetCell ticker={currency.ticker} />;
+        const reward = subsidyRewards ? subsidyRewards.perMarket[currency.ticker].lend : null;
 
         const apy = (
           <ApyCell
             apy={lendApy}
             currency={currency}
-            rewards={lendReward}
+            rewards={reward}
             prices={prices}
             // TODO: temporary until we find why row click is being ignored
             onClick={() => onRowAction?.(currency.ticker as Key)}
@@ -83,7 +86,7 @@ const LendAssetsTable = ({ assets, onRowAction, ...props }: LendAssetsTableProps
           totalSupply
         };
       }),
-    [assets, balances, onRowAction, prices]
+    [assets, balances, onRowAction, prices, subsidyRewards]
   );
 
   return (

--- a/src/pages/Loans/LoansOverview/components/LoansInsights/LoansInsights.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoansInsights/LoansInsights.tsx
@@ -42,11 +42,11 @@ const LoansInsights = ({ statistics }: LoansInsightsProps): JSX.Element => {
   const netPercentage = formatPercentage(netAPY?.toNumber() || 0);
   const netPercentageLabel = `${netAPY?.gt(0) ? '+' : ''}${netPercentage}`;
 
-  const subsidyRewardsAmount = formatNumber(subsidyRewards?.toBig().toNumber() || 0, {
-    maximumFractionDigits: subsidyRewards?.currency.humanDecimals || 5
+  const subsidyRewardsAmount = formatNumber(subsidyRewards?.total.toBig().toNumber() || 0, {
+    maximumFractionDigits: subsidyRewards?.total.currency.humanDecimals || 5
   });
-  const subsidyRewardsAmountLabel = `${subsidyRewardsAmount} ${subsidyRewards?.currency.ticker || ''}`;
-  const hasSubsidyRewards = !!subsidyRewards && !subsidyRewards?.isZero();
+  const subsidyRewardsAmountLabel = `${subsidyRewardsAmount} ${subsidyRewards?.total.currency.ticker || ''}`;
+  const hasSubsidyRewards = !!subsidyRewards && !subsidyRewards?.total.isZero();
 
   return (
     <>

--- a/src/test/mocks/@interlay/interbtc-api/parachain/loans.ts
+++ b/src/test/mocks/@interlay/interbtc-api/parachain/loans.ts
@@ -126,7 +126,14 @@ const DEFAULT_ASSETS: TickerToData<LoanAsset> = {
 const mockGetLendPositionsOfAccount = jest.fn().mockReturnValue(DEFAULT_LEND_POSITIONS);
 const mockGetBorrowPositionsOfAccount = jest.fn().mockReturnValue(DEFAULT_BORROW_POSITIONS);
 const mockGetLoanAssets = jest.fn().mockReturnValue(DEFAULT_ASSETS);
-const mockGetAccountSubsidyRewards = jest.fn().mockReturnValue(DEFAULT_INTR.MONETARY.MEDIUM);
+const mockGetAccountSubsidyRewards = jest.fn().mockReturnValue({
+  total: DEFAULT_INTR.MONETARY.MEDIUM,
+  perMarket: {
+    INTR: null,
+    IBTC: null,
+    DOT: null
+  }
+});
 
 const mockLend = jest.fn();
 const mockWithdraw = jest.fn();

--- a/src/utils/hooks/api/loans/use-get-account-lending-statistics.tsx
+++ b/src/utils/hooks/api/loans/use-get-account-lending-statistics.tsx
@@ -122,7 +122,14 @@ const useGetAccountLendingStatistics = (): UseGetAccountLendingStatistics => {
       return undefined;
     }
 
-    return getAccountPositionsStats(loanAssets, lendPositions, borrowPositions, subsidyRewards, prices, lendingStats);
+    return getAccountPositionsStats(
+      loanAssets,
+      lendPositions,
+      borrowPositions,
+      subsidyRewards.total,
+      prices,
+      lendingStats
+    );
   }, [lendPositions, borrowPositions, prices, subsidyRewards, loanAssets, lendingStats]);
 
   return {

--- a/src/utils/hooks/api/loans/use-get-account-subsidy-rewards.tsx
+++ b/src/utils/hooks/api/loans/use-get-account-subsidy-rewards.tsx
@@ -1,4 +1,4 @@
-import { CurrencyExt } from '@interlay/interbtc-api';
+import { AccruedRewards, CurrencyExt } from '@interlay/interbtc-api';
 import { MonetaryAmount } from '@interlay/monetary-js';
 import { AccountId } from '@polkadot/types/interfaces';
 import { useErrorHandler } from 'react-error-boundary';
@@ -9,7 +9,7 @@ import { BLOCKTIME_REFETCH_INTERVAL } from '@/utils/constants/api';
 import useAccountId from '../../use-account-id';
 
 interface AccountAccruedRewards {
-  data: MonetaryAmount<CurrencyExt> | undefined;
+  data: AccruedRewards | undefined;
   refetch: () => void;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,10 +2073,10 @@
   dependencies:
     axios "^0.21.1"
 
-"@interlay/interbtc-api@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-2.1.1.tgz#cdbd4fab03b83b32a32936bfa3f7eaf5f55859f7"
-  integrity sha512-6cNPwgExJHQJhtxgAa3Igmswyfujz8e+EVxyj9IQHs1KtJydYZQpa0qQC/QnOiQqRXw4DVNZkmKLEfXodDLBdQ==
+"@interlay/interbtc-api@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@interlay/interbtc-api/-/interbtc-api-2.2.1.tgz#7babde28fdcc47ebd986405184602b95f61f4c29"
+  integrity sha512-0QY4sqB2SLrnIPVutvYFNtMdZ3BNO0VjvTYNizd63OUJlqfsgujpkp4dWzIO+DMC5kzkcEo80r2NloyJer7p2A==
   dependencies:
     "@interlay/esplora-btc-api" "0.4.0"
     "@interlay/interbtc-types" "1.12.0"


### PR DESCRIPTION
# Interbtc UI Pull Request Template
#description
Display correct incentive rewards, lib update to `2.2.1`.

## Current behaviour (updates)

 Dapp was displaying incorrect amount that is used to compute average APY.

## New behaviour

Total reward amount is computed more precisely and reward per market is fixed.

## Reproducible testing steps:

1. Lend or borrow asset with active rewards
2. Check that rewards are changing on block-by-block basis 
3. Check particular rewards in asset tooltip
4. Check that claimed reward amount corresponds to displayed amount.
