### PR TITLE
fix(loans): use correct data for computation of incentive rewards APY in tables

### DIFF
--- a/src/components/LoanPositionsTable/ApyCell.tsx
+++ b/src/components/LoanPositionsTable/ApyCell.tsx
@@ -14,7 +14,8 @@ type ApyCellProps = {
   currency: CurrencyExt;
   earnedInterest?: MonetaryAmount<CurrencyExt>;
   accumulatedDebt?: MonetaryAmount<CurrencyExt>;
-  rewards: MonetaryAmount<CurrencyExt> | null;
+  rewardsPerYear: MonetaryAmount<CurrencyExt> | null;
+  accruedRewards: MonetaryAmount<CurrencyExt> | null;
   prices?: Prices;
   isBorrow?: boolean;
   onClick?: () => void;
@@ -23,14 +24,15 @@ type ApyCellProps = {
 const ApyCell = ({
   apy,
   currency,
-  rewards,
+  rewardsPerYear,
+  accruedRewards,
   accumulatedDebt,
   earnedInterest,
   prices,
   isBorrow = false,
   onClick
 }: ApyCellProps): JSX.Element => {
-  const rewardsApy = getSubsidyRewardApy(currency, rewards, prices);
+  const rewardsApy = getSubsidyRewardApy(currency, rewardsPerYear, prices);
 
   const totalApy = isBorrow ? apy.sub(rewardsApy || 0) : apy.add(rewardsApy || 0);
   const totalApyLabel = isBorrow ? `-${getApyLabel(totalApy)}` : getApyLabel(totalApy);
@@ -52,7 +54,7 @@ const ApyCell = ({
         apy={apy}
         currency={currency}
         prices={prices}
-        rewards={rewards}
+        rewards={accruedRewards}
         rewardsApy={rewardsApy}
         isBorrow={isBorrow}
         accumulatedDebt={accumulatedDebt}

--- a/src/components/LoanPositionsTable/LoanPositionsTable.tsx
+++ b/src/components/LoanPositionsTable/LoanPositionsTable.tsx
@@ -86,13 +86,18 @@ const LoanPositionsTable = ({
         const { currency } = amountProp;
         const asset = <AssetCell ticker={currency.ticker} />;
 
-        const { borrowApy, lendApy } = assets[currency.ticker];
+        const { borrowApy, lendApy, lendReward, borrowReward } = assets[currency.ticker];
 
         const apyCellProps = isLending
-          ? { apy: lendApy, rewards: subsidyRewards ? subsidyRewards.perMarket[currency.ticker].lend : null }
+          ? {
+              apy: lendApy,
+              rewardsPerYear: lendReward,
+              accruedRewards: subsidyRewards ? subsidyRewards.perMarket[currency.ticker].lend : null
+            }
           : {
               apy: borrowApy,
-              rewards: subsidyRewards ? subsidyRewards.perMarket[currency.ticker].borrow : null,
+              rewardsPerYear: borrowReward,
+              accruedRewards: subsidyRewards ? subsidyRewards.perMarket[currency.ticker].borrow : null,
               accumulatedDebt: (position as BorrowPosition).accumulatedDebt,
               isBorrow: true
             };

--- a/src/pages/Loans/LoansOverview/components/BorrowAssetsTable/BorrowAssetsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/BorrowAssetsTable/BorrowAssetsTable.tsx
@@ -52,15 +52,16 @@ const BorrowAssetsTable = ({ assets, onRowAction, ...props }: BorrowAssetsTableP
 
   const rows: BorrowAssetsTableRow[] = useMemo(
     () =>
-      Object.values(assets).map(({ borrowApy, currency, availableCapacity, totalBorrows }) => {
+      Object.values(assets).map(({ borrowApy, currency, availableCapacity, totalBorrows, borrowReward }) => {
         const asset = <StyledAssetCell ticker={currency.ticker} />;
-        const reward = subsidyRewards ? subsidyRewards.perMarket[currency.ticker].borrow : null;
+        const accruedRewards = subsidyRewards ? subsidyRewards.perMarket[currency.ticker].borrow : null;
 
         const apy = (
           <ApyCell
             apy={borrowApy}
             currency={currency}
-            rewards={reward}
+            rewardsPerYear={borrowReward}
+            accruedRewards={accruedRewards}
             prices={prices}
             isBorrow
             // TODO: temporary until we find why row click is being ignored

--- a/src/pages/Loans/LoansOverview/components/LendAssetsTable/LendAssetsTable.tsx
+++ b/src/pages/Loans/LoansOverview/components/LendAssetsTable/LendAssetsTable.tsx
@@ -52,15 +52,16 @@ const LendAssetsTable = ({ assets, onRowAction, ...props }: LendAssetsTableProps
 
   const rows: LendAssetsTableRow[] = useMemo(
     () =>
-      Object.values(assets).map(({ lendApy, currency, totalLiquidity }) => {
+      Object.values(assets).map(({ lendApy, currency, totalLiquidity, lendReward }) => {
         const asset = <AssetCell ticker={currency.ticker} />;
-        const reward = subsidyRewards ? subsidyRewards.perMarket[currency.ticker].lend : null;
+        const accruedRewards = subsidyRewards ? subsidyRewards.perMarket[currency.ticker].lend : null;
 
         const apy = (
           <ApyCell
             apy={lendApy}
             currency={currency}
-            rewards={reward}
+            rewardsPerYear={lendReward}
+            accruedRewards={accruedRewards}
             prices={prices}
             // TODO: temporary until we find why row click is being ignored
             onClick={() => onRowAction?.(currency.ticker as Key)}


### PR DESCRIPTION
# Interbtc UI Pull Request Template

Fix lending incentive reward APY computation in tables.  With the latest upgrade, the accrued rewards computation was fixed, but that introduced new bug in APY computation. Now both are fixed by using correct data source for computation. New property was added to `ApyCell` component to make it explicit what `reward` data is being passed so no more similar errors are made again. 
## Current behaviour (updates)
![image](https://github.com/interlay/interbtc-ui/assets/47864599/cdeaf6c9-f39a-46c0-b803-1ee08e3357e0)

## New behaviour
APY computation in tables is fixed.
![image](https://github.com/interlay/interbtc-ui/assets/47864599/c1fd8444-481d-44fb-8e0e-af2b85948f70)


## Reproducible testing steps:

> Please list all testing steps required for the reviewer to test this specific issue. Consider regressions and edge cases.
