### PR TITLE
fix: compare input configs with method not operator

### DIFF
--- a/src/utils/hooks/api/xcm/use-xcm-bridge.ts
+++ b/src/utils/hooks/api/xcm/use-xcm-bridge.ts
@@ -111,7 +111,7 @@ const useXCMBridge = (): UseXCMBridge => {
           const minInputToBig = Big(inputConfig.minInput.toString());
 
           // Never show less than zero
-          const transferableBalance = inputConfig.maxInput < inputConfig.minInput ? 0 : maxInputToBig;
+          const transferableBalance = inputConfig.maxInput.isLessThan(inputConfig.minInput) ? 0 : maxInputToBig;
           const currency = XCMBridge.findAdapter(from).getToken(token, from);
 
           const nativeToken = originAdapter.getNativeToken();


### PR DESCRIPTION
Bug fix—this appeared to work because our fees were fractions, but input config values can't be reliably compared with operators (i.e. this never worked properly, but it appeared to because of very low fee values)