### PR TITLE
refactor: reset selected account on account change

### DIFF
--- a/src/pages/Transfer/CrossChainTransferForm/CrossChainTransferForm.tsx
+++ b/src/pages/Transfer/CrossChainTransferForm/CrossChainTransferForm.tsx
@@ -212,6 +212,14 @@ const CrossChainTransferForm = (): JSX.Element => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountId, destinationChains]);
 
+  // TODO: When we refactor account select this should be handled there so
+  // that it's consitent across the application
+  useEffect(() => {
+    if (!accountId) return;
+    form.setFieldValue(CROSS_CHAIN_TRANSFER_TO_ACCOUNT_FIELD, accountId?.toString());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountId]);
+
   if (!originatingChains || !destinationChains || !transferableTokens.length) {
     return (
       <Flex justifyContent='center'>


### PR DESCRIPTION
This is a temporary fix—at the moment the account selector is only used on the XCM form. When it's refactored to use the updated select component and to allow manual input, this should be handled in the component for consistency across the application.

This changes the behaviour so that if a used changes account using the account selector in the top bar, the selected XCM account is changed to that account. At the moment it remains set to the previously selected account.