### PR TITLE
hotffix kintusgi: add percentage conversion

### DIFF
--- a/src/components/LoanApyTooltip/BreakdownGroup.tsx
+++ b/src/components/LoanApyTooltip/BreakdownGroup.tsx
@@ -29,7 +29,7 @@ const BreakdownGroup = ({ apy, rewardsApy, ticker, rewardsTicker, isBorrow }: Br
           </StyledApyTooltipGroup>
           {!!rewardsApy && (
             <StyledApyTooltipGroup gap='spacing1' wrap>
-              <Dd color='tertiary'>Rewards APY {rewardsTicker}:</Dd>
+              <Dd color='tertiary'>Rewards APR {rewardsTicker}:</Dd>
               <Dt color='primary'>{getApyLabel(rewardsApy)}</Dt>
             </StyledApyTooltipGroup>
           )}

--- a/src/pages/Loans/LoansOverview/components/LoanActionInfo/RewardsGroup.tsx
+++ b/src/pages/Loans/LoansOverview/components/LoanActionInfo/RewardsGroup.tsx
@@ -26,7 +26,7 @@ const RewardsGroup = ({ isBorrow, apy, assetCurrency, rewards, prices }: Rewards
   return (
     <>
       <DlGroup justifyContent='space-between'>
-        <Dt>Rewards APY {rewards.currency.ticker}</Dt>
+        <Dt>Rewards APR {rewards.currency.ticker}</Dt>
         <Dd>{getApyLabel(subsidyRewardApy)}</Dd>
       </DlGroup>
       <DlGroup justifyContent='space-between'>

--- a/src/utils/helpers/loans.ts
+++ b/src/utils/helpers/loans.ts
@@ -41,7 +41,7 @@ const getSubsidyRewardApy = (
   }
 
   const exchangeRate = rewardCurrencyPriceUSD / positionCurrencyPriceUSD;
-  const apy = reward.toBig().mul(exchangeRate);
+  const apy = reward.toBig().mul(exchangeRate).mul(100);
 
   return apy;
 };


### PR DESCRIPTION
# Interbtc UI Pull Request Template
Incentive rewards APR was not converted to percentage when displayed. Now fixed and APY changed to APR for incentive rewards.

## New behaviour
![image](https://github.com/interlay/interbtc-ui/assets/47864599/5458fff8-616b-4610-a3be-5c9195f7be97)

> Please describe the behaviour or changes this PR adds

## Reproducible testing steps:

> Please list all testing steps required for the reviewer to test this specific issue. Consider regressions and edge cases.
