### PR TITLE
fix(TokenInput): adorment ticker

### DIFF
--- a/src/component-library/TokenInput/TokenInput.tsx
+++ b/src/component-library/TokenInput/TokenInput.tsx
@@ -63,7 +63,7 @@ const TokenInput = forwardRef<HTMLInputElement, TokenInputProps>(
 
     const itemsArr = Array.from(selectProps?.items || []);
     const isSelectAdornment = itemsArr.length > 1;
-    const adornmentTicker = !isSelectAdornment && selectProps?.items ? itemsArr[0]?.value : ticker;
+    const adornmentTicker = !isSelectAdornment && selectProps?.items ? itemsArr[0]?.value : tickerProp;
 
     useEffect(() => {
       if (selectProps?.value === undefined) return;


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Passing wrong value to the non-select adornemnt.

## Current behaviour (updates)

TokenAdornment does not handle Lp tokens tickers

## New behaviour

Now handles

## Reproducible testing steps:

Go to withdraw form on pools page.