### PR TITLE
fix: sort notifications

### DIFF
--- a/src/components/NotificationsPopover/NotificationsList.tsx
+++ b/src/components/NotificationsPopover/NotificationsList.tsx
@@ -20,7 +20,7 @@ const NotificationsList = ({ items }: NotificationsListProps): JSX.Element => {
     );
   }
 
-  const latestTransactions = items.slice(-5);
+  const latestTransactions = items.slice(-5).sort((a, b) => b.date.getTime() - a.date.getTime());
 
   return (
     <Flex direction='column'>


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Notifications need to be sorted from newest to oldest

Before

![image](https://github.com/interlay/interbtc-ui/assets/43269067/2d192f8e-ad26-4102-9bc0-ec407f8ec788)

After

![image](https://github.com/interlay/interbtc-ui/assets/43269067/54ec6871-71ac-4c6e-8c5e-e75a972061d7)

