### PR TITLE
fix: correct wallet balance

### DIFF
--- a/src/pages/Wallet/WalletOverview/components/WalletInsights/WalletInsights.tsx
+++ b/src/pages/Wallet/WalletOverview/components/WalletInsights/WalletInsights.tsx
@@ -39,8 +39,7 @@ const WalletInsights = ({ balances }: WalletInsightsProps): JSX.Element => {
     );
 
   const totalBalance = rawBalance
-    ?.add(accountLendingStatistics?.supplyAmountUSD || 0)
-    .sub(accountLendingStatistics?.borrowAmountUSD || 0)
+    ?.sub(accountLendingStatistics?.borrowAmountUSD || 0)
     .add(accountPools?.accountLiquidityUSD || 0);
 
   const totalBalanceLabel = totalBalance ? formatUSD(totalBalance.toNumber(), { compact: true }) : '-';


### PR DESCRIPTION
Closes #1316 

Discussed with Dom and Sander—we've removed the code which added the lend positions as lend positions are already included in balance.reserved, which is taken into account when calculating the raw balance (i.e. we were counting lend positions twice).

There are still minor discrepancies when manually adding the figures together, but these are low dollar amounts and caused by rounding and/or exchange rate fluctuations.

In this account, available assets + lend positions - borrow positions + liquidity pools + staked = 46176.67 which is very close to the total balance. (Note that SKSM and USDT have small amounts available, with the dollar amount rounded to 0; these will be included in the total balance as shown in the insights box. Other dollar amounts will also be rounded.)

<img width="1452" alt="Screenshot 2023-06-23 at 11 53 24" src="https://github.com/interlay/interbtc-ui/assets/40243778/b01c4a58-343b-4048-9922-a2858b7e3132">
<img width="1446" alt="Screenshot 2023-06-23 at 11 53 34" src="https://github.com/interlay/interbtc-ui/assets/40243778/ba3a5db8-70dc-4347-b7cd-73cd190ad4b9">
<img width="1459" alt="Screenshot 2023-06-23 at 11 53 44" src="https://github.com/interlay/interbtc-ui/assets/40243778/26f5ce97-ff7d-4745-8e67-966be6d5ba6e">