### PR TITLE
[transfer/bridge] open correct tab

### DIFF
--- a/src/pages/Transfer/TransferForms/TransferForms.tsx
+++ b/src/pages/Transfer/TransferForms/TransferForms.tsx
@@ -19,7 +19,7 @@ const TransferForms = (): JSX.Element => {
                   <TransferForm />
                 </StyledFormWrapper>
               </TabsItem>
-              <TabsItem title='Bridge' key='bridge'>
+              <TabsItem title='Bridge' key='crossChainTransfer'>
                 <StyledFormWrapper>
                   <CrossChainTransferForm />
                 </StyledFormWrapper>

--- a/src/pages/Wallet/WalletOverview/components/AvailableAssetsTable/ActionsCell.tsx
+++ b/src/pages/Wallet/WalletOverview/components/AvailableAssetsTable/ActionsCell.tsx
@@ -108,7 +108,7 @@ const ActionsCell = ({
             to={{
               pathname: PAGES.TRANSFER,
               search: queryString.stringify({
-                [QUERY_PARAMETERS.TAB]: 'crossChainTransfer'
+                [QUERY_PARAMETERS.TAB]: 'bridge'
               })
             }}
           >

--- a/src/pages/Wallet/WalletOverview/components/AvailableAssetsTable/ActionsCell.tsx
+++ b/src/pages/Wallet/WalletOverview/components/AvailableAssetsTable/ActionsCell.tsx
@@ -108,7 +108,7 @@ const ActionsCell = ({
             to={{
               pathname: PAGES.TRANSFER,
               search: queryString.stringify({
-                [QUERY_PARAMETERS.TAB]: 'bridge'
+                [QUERY_PARAMETERS.TAB]: 'crossChainTransfer'
               })
             }}
           >


### PR DESCRIPTION
Correct query parameter. I've reverted to having 'crossChainTransfer' as the URL, as there may be inbound links (the previous version of the xcm tab could be accessed directly at http://app.interlay.io/transfer/?tab=crossChainTransfer). We'll update this when we handle #1354.

Closes #1365 