### PR TITLE
fix: use correct value for vault capacity indicator

### DIFF
--- a/src/pages/Vaults/Vault/VaultDashboard.tsx
+++ b/src/pages/Vaults/Vault/VaultDashboard.tsx
@@ -57,7 +57,7 @@ const VaultDashboard = (): JSX.Element => {
     <ProgressCircle
       aria-label='BTC remaining capacity'
       diameter='65'
-      value={(1 - Number(vault.remainingCapacity.ratio)) * 100}
+      value={100 - Number(vault.remainingCapacity.ratio)}
     />
   );
 

--- a/src/utils/hooks/api/vaults/get-vault-data.ts
+++ b/src/utils/hooks/api/vaults/get-vault-data.ts
@@ -67,12 +67,13 @@ interface VaultData {
   };
 }
 
+// note: returns percentage, so range is 0-100
 const getRemainingCapacity = (issuableTokens: Big, vaultExt: VaultExt): number => {
   if (!issuableTokens.gt(0)) return 0;
 
   const backedTokens = vaultExt.getBackedTokens().toBig();
 
-  if (!backedTokens.gt(0)) return 1;
+  if (!backedTokens.gt(0)) return 100;
 
   const totalTokens = issuableTokens.add(backedTokens);
 


### PR DESCRIPTION
The code assumed that ratio would be 0..1 while it was actually 0..100: https://github.com/interlay/interbtc-ui/blob/52ffd0dabf860650029d25bde1eeaeec2036059b/src/utils/hooks/api/vaults/get-vault-data.ts#L79

Closes https://github.com/interlay/interbtc-ui/issues/736
Closes https://github.com/interlay/interbtc-ui/issues/1439