### PR TITLE
api: add fallback to coingecko for missing assets on dia

### DIFF
--- a/api/market_data.py
+++ b/api/market_data.py
@@ -35,10 +35,9 @@ def add_header(response):
 def coingecko(args):
     headers_dict = {
         "content-type": "application/json",
-        "accept": "application/json",
-        "x-cg-pro-api-key": api_key,
+        "accept": "application/json"
     }
-    url = "https://pro-api.coingecko.com/api/v3/simple/price"
+    url = "https://api.coingecko.com/api/v3/simple/price"
     resp = requests.get(url, params=args, headers=headers_dict)
     data = resp.json()
     return data
@@ -64,7 +63,11 @@ def dia(asset):
         }
       }
     except KeyError:
-      return { asset: None }
+      try:
+        return coingecko({"ids": [asset], "vs_currencies": ["usd"]})
+      except Exception as e:
+        print("Coingecko error", e)
+        return { asset: None }
 
 
 @app.route("/marketdata/price", methods=["GET"])


### PR DESCRIPTION
If an asset is not defined on https://www.diadata.org/ then we fallback to retrieving its price from coingecko.