### PR TITLE
feat: zero slippage option

### DIFF
--- a/src/components/SlippageManager/SlippageManager.tsx
+++ b/src/components/SlippageManager/SlippageManager.tsx
@@ -42,6 +42,9 @@ const SlippageManager = forwardRef<HTMLDivElement, SlippageManagerProps>(
               onSelectionChange={handleSelectionChange}
               defaultSelectedKeys={[value.toString()]}
             >
+              <ListItem textValue='0' key='0'>
+                0%
+              </ListItem>
               <ListItem textValue='0.1' key='0.1'>
                 0.1%
               </ListItem>


### PR DESCRIPTION
Adds a zero % slippage option. Note that the decision to add this has not been signed off  by anyone. I just added it because I personally needed this feature, I'm using the preview for now. I tested and it seems to work fine. The default value is still 0.1%