### PR TITLE
[app] Use route instead of redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { useErrorHandler, withErrorBoundary } from 'react-error-boundary';
 import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 
 import { isVaultClientLoaded } from '@/common/actions/general.actions';
 import { StoreType } from '@/common/types/util.types';
@@ -95,7 +95,6 @@ const App = (): JSX.Element => {
                 <Route path={PAGES.VAULT}>
                   <Vaults />
                 </Route>
-
                 <Route path={PAGES.DASHBOARD}>
                   <Dashboard />
                 </Route>
@@ -120,7 +119,7 @@ const App = (): JSX.Element => {
                 <Route path={PAGES.POOLS}>
                   <Pools />
                 </Route>
-                <Route path={PAGES.WALLET}>
+                <Route path={[PAGES.HOME, PAGES.WALLET]}>
                   <Wallet />
                 </Route>
                 {isStrategiesEnabled && (
@@ -141,7 +140,6 @@ const App = (): JSX.Element => {
                 <Route path={PAGES.ACTIONS}>
                   <Actions />
                 </Route>
-                <Redirect exact from={PAGES.HOME} to={PAGES.WALLET} />
                 <Route path='*'>
                   <NoMatch />
                 </Route>


### PR DESCRIPTION
Redirect seems to be flaky—sometimes resolves to the wallet page, sometimes not. We haven't changed this for a while, so not sure what's caused it to become an issue now (unless it was an existing issue we hadn't picked up).

Alternative way of handling this is to use an array in the Route path, rather than a redirect; this seems to be working consistently.