### PR TITLE
fix: conditional check for amount

### DIFF
--- a/src/pages/Dashboard/sub-pages/Vaults/LockedCollateralCard/index.tsx
+++ b/src/pages/Dashboard/sub-pages/Vaults/LockedCollateralCard/index.tsx
@@ -47,7 +47,7 @@ const LockedCollateralCard = ({
     if (cumulativeVolumes === undefined) {
       throw new Error('Something went wrong!');
     }
-    const totalLockedCollateralTokenAmount = cumulativeVolumes.slice(-1)[0].amount;
+    const totalLockedCollateralTokenAmount = cumulativeVolumes.slice(1)[0]?.amount;
 
     let chartLineColor;
     if (process.env.REACT_APP_RELAY_CHAIN_NAME === POLKADOT) {


### PR DESCRIPTION
Vault dashboard was failing to handle no locked qUSDT. This adds a conditional check so the UI doesn't trip up.