### PR TITLE
[hotfix] Add limit to vault account ID query

### DIFF
--- a/src/services/queries/vaults-by-accountId-query.ts
+++ b/src/services/queries/vaults-by-accountId-query.ts
@@ -1,6 +1,6 @@
 const vaultsByAccountIdQuery = (accountId: string): string => `
 {
-    vaults(where: {accountId_eq: "${accountId}"}) {
+    vaults(where: {accountId_eq: "${accountId}"}, limit: 1) {
       id
     }
   }


### PR DESCRIPTION
Vault accounts are all showing in read only mode. This patches the problem, but we still need to investigate why this is happening on Kintsugi but not Interlay.