### PR TITLE
fix(Pools): remove ratio customization

### DIFF
--- a/src/test/pages/Pools.test.tsx
+++ b/src/test/pages/Pools.test.tsx
@@ -206,52 +206,6 @@ describe('Pools Page', () => {
     getClaimableFarmingRewards.mockReturnValue(CLAIMABLE_REWARDS);
   });
 
-  it('should be able to enter customisable input amounts mode', async () => {
-    jest
-      .spyOn(LIQUIDITY_POOLS.ONE, 'getLiquidityDepositInputAmounts')
-      .mockReturnValue(LIQUIDITY_POOLS.ONE.pooledCurrencies);
-
-    const [DEFAULT_CURRENCY_1, DEFAULT_CURRENCY_2] = LIQUIDITY_POOLS.ONE.pooledCurrencies;
-
-    await render(<App />, { path });
-
-    const tabPanel = await withinModalTabPanel(TABLES.AVAILABLE_POOLS, LP_TOKEN_A.ticker, TABS.DEPOSIT);
-
-    await userEvent.type(
-      tabPanel.getByRole('textbox', {
-        name: new RegExp(`${DEFAULT_CURRENCY_1.currency.ticker} deposit amount`, 'i')
-      }),
-      DEFAULT_CURRENCY_1.toString(),
-      { delay: 1 }
-    );
-
-    expect(LIQUIDITY_POOLS.ONE.getLiquidityDepositInputAmounts).toHaveBeenCalledWith(DEFAULT_CURRENCY_1);
-
-    await waitFor(() => {
-      expect(
-        tabPanel.getByRole('textbox', {
-          name: new RegExp(`${DEFAULT_CURRENCY_2.currency.ticker} deposit amount`, 'i')
-        })
-      ).toHaveValue(DEFAULT_CURRENCY_2.toString());
-    });
-
-    await userEvent.type(
-      tabPanel.getByRole('textbox', {
-        name: new RegExp(`${DEFAULT_CURRENCY_2.currency.ticker} deposit amount`, 'i')
-      }),
-      '10',
-      { delay: 1 }
-    );
-
-    await waitFor(() => {
-      expect(
-        tabPanel.getByRole('textbox', {
-          name: new RegExp(`${DEFAULT_CURRENCY_1.currency.ticker} deposit amount`, 'i')
-        })
-      ).toHaveValue(DEFAULT_CURRENCY_1.toString());
-    });
-  });
-
   it('should render illiquid pool and deposit with custom ratio', async () => {
     jest
       .spyOn(LIQUIDITY_POOLS.EMPTY, 'getLiquidityDepositInputAmounts')


### PR DESCRIPTION
# Interbtc UI Pull Request Template

## Description

Custom ration on inputs was leading a lot of users to failing transactions

## Current behaviour (updates)

Changing input A and then customising the input B leads leads to custom ratio 

## New behaviour

Pool ratio is always applied

## Reproducible testing steps:

> go to pools
> open deposit modal
> Change input A
> change input B
> See that input A is changed to current ratio