### PR TITLE
wip: try setting node options in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@polkadot/util-crypto": "^10.2.4"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider craco start",
     "start-regtest": "cross-env REACT_APP_BITCOIN_NETWORK=regtest yarn start",
     "start-testnet": "cross-env REACT_APP_BITCOIN_NETWORK=testnet yarn start",
     "generate:defs": "ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package sample-polkadotjs-typegen/interfaces --input ./src/interfaces",
@@ -168,7 +168,7 @@
     "type-check": "tsc",
     "format": "yarn prettier --write src",
     "setup": "yarn generate:defs && yarn generate:meta",
-    "build": "REACT_APP_VERSION=$npm_package_version craco build",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider REACT_APP_VERSION=$npm_package_version craco build",
     "build-with-webpack-bundle-analysis": "yarn build --stats && webpack-bundle-analyzer build/bundle-stats.json -m static -r build/bundle-stats.html -O",
     "lint-and-type-check": "yarn lint && yarn type-check",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Set NODE_OPTIONS to enable legacy SSL support. This is required to build with Node 18. Have tested on Interlay testnet and it works fine, so I've updated the settings for all four environments. This PR will need to be merged before any others, otherwise builds will fail.

Closes #1546 