### PR TITLE
exclude USDC.wh from foreign assets

### DIFF
--- a/src/hooks/api/use-get-currencies.tsx
+++ b/src/hooks/api/use-get-currencies.tsx
@@ -5,6 +5,10 @@ import { useQuery, UseQueryResult } from 'react-query';
 import { CurrencySquidFormat } from '@/types/currency';
 import { NATIVE_CURRENCIES } from '@/utils/constants/currency';
 
+enum ExcludedForeignAssets {
+  USDC_WH = 'USDC.wh'
+}
+
 type UseGetCurrenciesResult = UseQueryResult<Array<CurrencyExt>> & {
   getCurrencyFromTicker: (ticker: string) => CurrencyExt;
   getForeignCurrencyFromId: (id: number) => CurrencyExt;
@@ -18,7 +22,12 @@ const getCurrencies = async (): Promise<Array<CurrencyExt>> => {
     window.bridge.loans.getLendTokens(),
     window.bridge.amm.getLpTokens()
   ]);
-  return [...NATIVE_CURRENCIES, ...foreignCurrencies, ...lendCurrencies, ...lpTokens];
+
+  const filteredForeignCurrencies = foreignCurrencies.filter(
+    (currency) => !Object.values(ExcludedForeignAssets).includes(currency.ticker as ExcludedForeignAssets)
+  );
+
+  return [...NATIVE_CURRENCIES, ...filteredForeignCurrencies, ...lendCurrencies, ...lpTokens];
 };
 
 // Returns all currencies, both native and foreign and helping utils to get CurrencyExt object.


### PR DESCRIPTION
Have spoken to Philipp and he's asked us to exclude this from the dAPP (and not just the wallet page) so we're excluding the asset when fetching the currencies rather than when fetching the balances.