### PR TITLE
hotfix: XCM polkadot/kintsugi max transferable balance

### DIFF
--- a/src/pages/SendAndReceive/SendAndReceiveForms/components/BridgeForm/BridgeForm.tsx
+++ b/src/pages/SendAndReceive/SendAndReceiveForms/components/BridgeForm/BridgeForm.tsx
@@ -66,7 +66,7 @@ const BridgeForm = (): JSX.Element => {
       minAmount: currentToken
         ? newMonetaryAmount(currentToken.minTransferAmount, getCurrencyFromTicker(currentToken.value), true)
         : undefined,
-      maxAmount: maxTransferable || undefined
+      maxAmount: maxTransferable
     }
   };
 


### PR DESCRIPTION
See:
https://github.com/interlay/interbtc-ui/issues/1644
https://discord.com/channels/745259537707040778/1210509457902018600

This will be fixed in the bridge next week at which point this code change will be reverted.