### PR TITLE
market data api fix

### DIFF
--- a/api/market_data.js
+++ b/api/market_data.js
@@ -132,7 +132,7 @@ const coingecko = async (args) => {
     return cached
   }
 
-  const url = 'https://api.coingecko.com/api/v3/simple/price?' + new URLSearchParams(args)
+  const url = 'https://api.coingecko.com/api/v3/simple/price?' + new URLSearchParams({ids: args.ids, vs_currencies: "usd"} )
   const response = await fetch(url, { headers: { "accept": "application/json" } })
   const data = await response.json()
   if (!response.ok) {


### PR DESCRIPTION
This pull request makes a small change to the API call in the `coingecko` function to ensure it always requests prices in USD, regardless of the input arguments.

* The `coingecko` function in `api/market_data.js` now constructs the request URL using only the `ids` from the input arguments and sets `vs_currencies` to `"usd"` explicitly, ensuring consistent currency results.